### PR TITLE
feature/stream-map-filtering

### DIFF
--- a/meltano/.gitignore
+++ b/meltano/.gitignore
@@ -6,3 +6,8 @@
 /venv
 /.meltano
 .env
+
+# Python internal files
+
+__pycache__
+*.pyc

--- a/meltano/meltano.yml
+++ b/meltano/meltano.yml
@@ -12,12 +12,29 @@ plugins:
     select:
     - issues.*
     - issue_comments.*
-    - "!*.comments"
-    - "!*.body"
+    - '!*.comments'
+    - '!*.body'
+  - name: tap-github-test
+    # This invocation is used for testing and should run as quickly as possible.
+    inherit_from: tap-github
+    select:
+    - repositories.*
+    - issues.*
+    - issue_comments.*
+    - '!*.comments'
+    - '!*.body'
+    config:
+      searches:
+      - name: target forks
+        query: target- fork:only language:Python singer in:readme
+      stream_maps:
+        repositories:
+          __filter__: full_name == 'dataops-tk/target-athena'
   - name: tap-github
     namespace: tap_github
     pip_url: git+https://github.com/dataops-tk/tap-github.git
-    executable: /Users/ajsteers/Source/tap-github/tap-github.sh
+    # Comment or uncomment this line to use the local checkout
+    # executable: //Users/aj/Source/tap-github/tap-github.sh
     capabilities:
     - catalog
     - discover
@@ -53,10 +70,16 @@ plugins:
     config:
       destination_path: data/
       do_timestamp_file: true
+  - name: target-athena-test
+    inherit_from: target-athena
+    config:
+      athena_database: test_localdev
+      s3_staging_dir: s3://devtest-meltano-bucket-01/test/localdev/
   - name: target-athena
     namespace: target_athena
-    pip_url: git+https://github.com/aaronsteers/target-athena.git
-    executable: /Users/ajsteers/Source/target-athena/target-athena.sh
+    pip_url: git+https://github.com/dataops-tk/target-athena.git
+    # Comment or uncomment this line to use the local checkout
+    # executable: //Users/aj/Source/target-athena/target-athena.sh
     settings:
     - name: aws_access_key_id
       kind: password
@@ -74,6 +97,7 @@ plugins:
       s3_staging_dir: s3://devtest-meltano-bucket-01/stage/ajdev/
       compression: none
       temp_dir: .output
+      add_record_metadata: True
   transformers:
   - name: dbt
     pip_url: git+https://github.com/Tomme/dbt-athena.git


### PR DESCRIPTION
Adds stream map -based filtering.
Adds `-test` implementations for the primary tap and target, to make sure runtimes are fast and tests are fully isolated from 'prod'.