### PR TITLE
Limit filtering of plugins only to extractors/loaders/taps/targets

### DIFF
--- a/_includes/plugin_grid.html
+++ b/_includes/plugin_grid.html
@@ -1,8 +1,8 @@
-{% if include.search %}
+{% if include.search == "extractors" or include.search == "loaders" or include.search == "taps" or include.search == "targets"%}
 <input
   type="search"
   class="grid-search"
-  placeholder="Search all {{include.search}}..."
+  placeholder="Filter {{include.search}}..."
   disabled="disabled"
 />
 {% endif %}


### PR DESCRIPTION
This PR removes the search bar from every page except Extractors, Loaders, Taps, and Targets.