### PR TITLE
Remap links to github

### DIFF
--- a/.gitlab/issue_templates/Add New Singer Connector.md
+++ b/.gitlab/issue_templates/Add New Singer Connector.md
@@ -15,12 +15,12 @@ Reference "How to Submit a Singer Connector to MeltanoHub" [YouTube video](https
 - [ ] Create a Merge Request to `main` from the new branch in your fork and select the template "Add a New Singer Connector".
 - [ ] Tag `@tayloramurphy` or `@pnadolny13` to flag it for review. Or post to the hub channel on Meltano slack.
 
-## Detailed Steps (GitLab Web Editor)
+## Detailed Steps (Git Web Editor)
 
-- Click Web IDE on the [MeltanoHub repo](https://gitlab.com/meltano/hub)
+- Click Web IDE on the [MeltanoHub repo](https://github.com/meltano/hub)
 - You'll be prompted to create a fork since you dont have access to edit directly. This automatically create a fork in your project and land you in the web editor.
-- Add your yaml config file in `/_data/taps/` by clicking "New File". You can use the sample below to get started.
-- Upload your png image in `/assets/logos/<taps or targets>` by clicking "Upload File".
+- Add your yaml config file in `/_data/meltano/extractors` by clicking "New File". You can use the sample below to get started.
+- Upload your png image in `/assets/logos/<extractors or loaders>` by clicking "Upload File".
 - Click the commit, write a write a message, then commit again (keep "Create new branch" and "Start a new merge request selected")
 - Choose the "Add new Singer Connector" template in the merge request
 - Tag `@tayloramurphy` or `@pnadolny13`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Let's build together! Please see our [Contributor Guide](https://docs.meltano.co
 for more information on contributing to Meltano.
 
 We believe that everyone can contribute and we welcome all contributions. 
-If you're not sure what to work on, here are some [ideas to get you started](https://gitlab.com/groups/meltano/-/issues?label_name%5B%5D=Accepting%20Merge%20Requests).
+If you're not sure what to work on, here are some [ideas to get you started](https://github.com/meltano/meltano/issues?q=is%3Aissue+is%3Aopen+label%3A%22accepting+merge+requests%22+).
 
 Chat with us in [#contributing](https://meltano.slack.com/archives/C013Z450LCD) on [Slack](https://meltano.com/slack).
 

--- a/_data/meltano/files/airflow/meltano.yml
+++ b/_data/meltano/files/airflow/meltano.yml
@@ -1,7 +1,7 @@
 name: airflow
 namespace: airflow
-repo: https://gitlab.com/meltano/files-airflow
-pip_url: git+https://gitlab.com/meltano/files-airflow.git
+repo: https://github.com/meltano/files-airflow
+pip_url: git+https://github.com/meltano/files-airflow.git
 variant: meltano
 update:
   orchestrate/dags/meltano.py: true

--- a/_data/meltano/files/dbt-snowflake/meltano.yml
+++ b/_data/meltano/files/dbt-snowflake/meltano.yml
@@ -1,6 +1,6 @@
 name: dbt-snowflake
 namespace: dbt_snowflake
-repo: https://gitlab.com/meltano/files-dbt-snowflake
-pip_url: git+https://gitlab.com/meltano/files-dbt-snowflake
+repo: https://github.com/meltano/files-dbt-snowflake
+pip_url: git+https://github.com/meltano/files-dbt-snowflake
 variant: meltano
 logo_url: /assets/logos/files/dbt-snowflake.png

--- a/_data/meltano/files/dbt/meltano.yml
+++ b/_data/meltano/files/dbt/meltano.yml
@@ -1,6 +1,6 @@
 name: dbt
 namespace: dbt
-repo: https://gitlab.com/meltano/files-dbt
-pip_url: git+https://gitlab.com/meltano/files-dbt.git@config-version-2
+repo: https://github.com/meltano/files-dbt
+pip_url: git+https://github.com/meltano/files-dbt.git@config-version-2
 variant: meltano
 logo_url: /assets/logos/files/dbt.png

--- a/_data/meltano/files/docker-compose/meltano.yml
+++ b/_data/meltano/files/docker-compose/meltano.yml
@@ -1,6 +1,6 @@
 name: docker-compose
 namespace: docker_compose
-repo: https://gitlab.com/meltano/files-docker-compose
-pip_url: git+https://gitlab.com/meltano/files-docker-compose.git
+repo: https://github.com/meltano/files-docker-compose
+pip_url: git+https://github.com/meltano/files-docker-compose.git
 variant: meltano
 logo_url: /assets/logos/files/docker-compose.png

--- a/_data/meltano/files/docker/meltano.yml
+++ b/_data/meltano/files/docker/meltano.yml
@@ -1,6 +1,6 @@
 name: docker
 namespace: docker
-repo: https://gitlab.com/meltano/files-docker
-pip_url: git+https://gitlab.com/meltano/files-docker.git
+repo: https://github.com/meltano/files-docker
+pip_url: git+https://github.com/meltano/files-docker.git
 variant: meltano
 logo_url: /assets/logos/files/docker.png

--- a/_data/meltano/files/gitlab-ci/meltano.yml
+++ b/_data/meltano/files/gitlab-ci/meltano.yml
@@ -1,6 +1,6 @@
 name: gitlab-ci
 namespace: gitlab_ci
-repo: https://gitlab.com/meltano/files-gitlab-ci
-pip_url: git+https://gitlab.com/meltano/files-gitlab-ci.git
+repo: https://github.com/meltano/files-gitlab-ci
+pip_url: git+https://github.com/meltano/files-gitlab-ci.git
 variant: meltano
 logo_url: /assets/logos/files/gitlab-ci.png

--- a/_data/meltano/files/great_expectations/meltano.yml
+++ b/_data/meltano/files/great_expectations/meltano.yml
@@ -1,6 +1,6 @@
 name: great_expectations
 namespace: great_expectations
-repo: https://gitlab.com/meltano/files-great-expectations
-pip_url: git+https://gitlab.com/meltano/files-great-expectations
+repo: https://github.com/meltano/files-great-expectations
+pip_url: git+https://github.com/meltano/files-great-expectations
 variant: meltano
 logo_url: /assets/logos/files/great_expectations.png

--- a/_layouts/meltano_plugin.html
+++ b/_layouts/meltano_plugin.html
@@ -413,7 +413,7 @@ plugin_name=plugin.name %} {% endfor %} {% endif %}
 <p>
   This page is generated from a
   <a
-    href="https://gitlab.com/meltano/hub/-/tree/main/_data/meltano/{{plugin_type}}s/{{ plugin.name }}.yml"
+    href="https://github.com/meltano/hub/blob/develop/_data/meltano/{{plugin_type}}s/{{ plugin.name }}/{{ plugin.variant }}.yml"
     >YAML file</a
   >
   that you can contribute changes to!

--- a/_layouts/plugins.html
+++ b/_layouts/plugins.html
@@ -56,7 +56,7 @@ header: singer
   <p>
     If a {{singular_type}} for your {{human_type}} doesn't exist yet, you can
     create one yourself using the
-    <a href="https://sdk.meltano.com" target="_blank">SDK</a> and then <a href="https://gitlab.com/meltano/hub/-/issues/new?issuable_template=Add%20New%20Singer%20Connector" target="_blank">click here</a> to submit
+    <a href="https://sdk.meltano.com" target="_blank">SDK</a> and then <a href="https://github.com/meltano/hub/issues/new" target="_blank">click here</a> to submit
     your {{human_type}} to be listed on the Hub. 
   </p>
 

--- a/extractors.md
+++ b/extractors.md
@@ -17,4 +17,4 @@ To learn more about extracting and [loading](/loaders/) data using Meltano, refe
 Any [Singer tap](/singer/taps/) can easily be [added to your Meltano project as a custom extractor](https://docs.meltano.com/plugin-management.html#custom-plugins).
 
 If a tap for your source doesn't exist yet, you can learn how to [create your own from scratch](https://meltano.com/tutorials/create-a-custom-extractor.html). Once you've got the new extractor working in your project, you can
-[add it to the Hub](https://gitlab.com/meltano/hub/-/tree/main/_data/taps).
+[add it to the Hub](https://github.com/meltano/hub/tree/main/_data/meltano/extractors).

--- a/extractors/google-analytics.md
+++ b/extractors/google-analytics.md
@@ -294,7 +294,7 @@ export TAP_GOOGLE_ANALYTICS_VIEW_ID=<ids>
 
 - Name: `reports`
 - [Environment variable](https://docs.meltano.com/configuration.html#configuring-settings): `TAP_GOOGLE_ANALYTICS_REPORTS`, alias: `GOOGLE_ANALYTICS_API_REPORTS`
-- Default: Bundled [`defaults/default_report_definition.json`](https://gitlab.com/meltano/tap-google-analytics/blob/master/tap_google_analytics/defaults/default_report_definition.json)
+- Default: Bundled [`defaults/default_report_definition.json`](https://github.com/MeltanoLabs/tap-google-analytics/blob/main/tap_google_analytics/defaults/default_report_definition.json)
 
 Project-relative path to JSON file with the definition of the reports to be generated.
 

--- a/files/airflow.md
+++ b/files/airflow.md
@@ -7,7 +7,7 @@ description: Airflow file bundle
 The [`airflow`](https://airflow.apache.org/) [file bundle](https://docs.meltano.com/concepts/plugins#file-bundles) installs files into your Meltano project to accelerate onboarding and integrating the plugin into your project.
 This file bundle installs a DAG generator that works together with Meltano schedules to auto generate Airflow DAGs based on Meltano configurations.
 
-- **Repository**: <https://gitlab.com/meltano/files-airflow>
+- **Repository**: <https://github.com/meltano/files-airflow>
 - **Documentation**: <https://airflow.apache.org/docs/>
 - **Maintainer**: Meltano community
 - **Maintenance status**: Active

--- a/files/dbt-snowflake.md
+++ b/files/dbt-snowflake.md
@@ -7,7 +7,7 @@ description: dbt file bundle for Snowflake
 The [`dbt-snowflake`](https://www.getdbt.com) [file bundle](https://docs.meltano.com/concepts/plugins#file-bundles) for Snowflake installs files into your Meltano project to accelerate onboarding and integrating the plugin into your project.
 This file bundle installs your dbt project directory including configuration files like `dbt_projects.yml` and `profiles.yml` with defaults in place to allow you to connect to you warehouse easily.
 
-- **Repository**: <https://gitlab.com/meltano/files-dbt-snowflake>
+- **Repository**: <https://github.com/meltano/files-dbt-snowflake>
 - **Documentation**: <https://docs.getdbt.com/>
 - **Maintainer**: Meltano community
 - **Maintenance status**: Active

--- a/files/dbt.md
+++ b/files/dbt.md
@@ -7,7 +7,7 @@ description: dbt file bundle
 The [`dbt`](https://www.getdbt.com) [file bundle](https://docs.meltano.com/concepts/plugins#file-bundles) installs files into your Meltano project to accelerate onboarding and integrating the plugin into your project.
 This file bundle installs your dbt project directory including configuration files like `dbt_projects.yml` and `profiles.yml` with defaults in place to allow you to connect to you warehouse easily.
 
-- **Repository**: <https://gitlab.com/meltano/files-dbt>
+- **Repository**: <https://github.com/meltano/files-dbt>
 - **Documentation**: <https://docs.getdbt.com/>
 - **Maintainer**: Meltano community
 - **Maintenance status**: Active

--- a/files/docker-compose.md
+++ b/files/docker-compose.md
@@ -8,7 +8,7 @@ The [`docker-compose`](https://docs.docker.com/compose/) [file bundle](https://d
 This file bundle installs docker-compose files used for spinning up your Meltano project service using docker containers.
 
 
-- **Repository**: <https://gitlab.com/meltano/files-docker-compose>
+- **Repository**: <https://github.com/meltano/files-docker-compose>
 - **Documentation**: <https://docs.docker.com/compose/>
 - **Maintainer**: Meltano community
 - **Maintenance status**: Active
@@ -32,6 +32,6 @@ If you haven't already, follow the [Getting Started guide](https://docs.meltano.
 
 ### Next steps
 
-1. Follow the advanced instructions to uncomment the services you want to run and spin them up using [`docker-compose up -d`](https://gitlab.com/meltano/files-docker-compose/-/blob/master/bundle/README.md)
+1. Follow the advanced instructions to uncomment the services you want to run and spin them up using [`docker-compose up -d`](https://github.com/meltano/files-docker-compose/blob/main/bundle/README.md)
 
 If you run into any issues, chat with us in [#troubleshooting](https://meltano.slack.com/archives/C01TCRBBJD7) on [Slack](https://meltano.com/slack).

--- a/files/docker.md
+++ b/files/docker.md
@@ -7,7 +7,7 @@ description: Docker file bundle to build a Docker image containing your Meltano 
 The [`docker`](https://docs.docker.com/) [file bundle](https://docs.meltano.com/concepts/plugins#file-bundles) installs files into your Meltano project to accelerate onboarding and integrating the plugin into your project.
 This file bundle installs a DockerFile to package your Meltano project as a Docker image.
 
-- **Repository**: <https://gitlab.com/meltano/files-docker>
+- **Repository**: <https://github.com/meltano/files-docker>
 - **Documentation**: <https://docs.docker.com/>
 - **Maintainer**: Meltano community
 - **Maintenance status**: Active
@@ -31,6 +31,6 @@ If you haven't already, follow the [Getting Started guide](https://docs.meltano.
 
 ### Next steps
 
-1. Follow the advanced instructions to uncomment the services you want to run and spin them up using [`docker-compose up -d`](https://gitlab.com/meltano/files-docker-compose/-/blob/master/bundle/README.md)
+1. Follow the advanced instructions to uncomment the services you want to run and spin them up using [`docker-compose up -d`](https://github.com/meltano/files-docker-compose/blob/main/bundle/README.md)
 
 If you run into any issues, chat with us in [#troubleshooting](https://meltano.slack.com/archives/C01TCRBBJD7) on [Slack](https://meltano.com/slack).

--- a/files/gitlab-ci.md
+++ b/files/gitlab-ci.md
@@ -7,7 +7,7 @@ description: GitLab CI file bundle with configuration to manage CICD using GitLa
 The [`gitlab-ci`](https://docs.gitlab.com/ee/ci/) [file bundle](https://docs.meltano.com/concepts/plugins#file-bundles) installs files into your Meltano project to accelerate onboarding and integrating the plugin into your project.
 This file bundle installs GitLab CI configuration files used as a starting place for your CICD pipelines.
 
-- **Repository**: <https://gitlab.com/meltano/files-gitlab-ci>
+- **Repository**: <https://github.com/meltano/files-gitlab-ci>
 - **Documentation**: <https://docs.gitlab.com/ee/ci/>
 - **Maintainer**: Meltano community
 - **Maintenance status**: Active

--- a/files/great_expectations.md
+++ b/files/great_expectations.md
@@ -4,9 +4,9 @@ layout: plugin_page
 description: Great Expectations file bundle
 ---
 
-The [`great-expectations`](https://gitlab.com/meltano/files-great-expectations) [file bundle](https://docs.meltano.com/concepts/plugins#file-bundles) installs files into your Meltano project to accelerate onboarding and integrating the plugin into your project.
+The [`great-expectations`](https://github.com/meltano/files-great-expectations) [file bundle](https://docs.meltano.com/concepts/plugins#file-bundles) installs files into your Meltano project to accelerate onboarding and integrating the plugin into your project.
 
-- **Repository**: <https://gitlab.com/meltano/files-great-expectations>
+- **Repository**: <https://github.com/meltano/files-great-expectations>
 - **Documentation**: <https://docs.greatexpectations.io/docs/>
 - **Maintainer**: Meltano community
 - **Maintenance status**: Active
@@ -30,6 +30,6 @@ If you haven't already, follow the [Getting Started guide](https://docs.meltano.
 
 ### Next steps
 
-1. Follow the [additional instructions](https://gitlab.com/meltano/files-great-expectations/-/tree/main/bundle/utilities/great_expectations) for initialization and advanced project configuration.
+1. Follow the [additional instructions](https://github.com/meltano/files-great-expectations/blob/main/bundle/utilities/great_expectations/) for initialization and advanced project configuration.
 
 If you run into any issues, chat with us in [#troubleshooting](https://meltano.slack.com/archives/C01TCRBBJD7) on [Slack](https://meltano.com/slack).

--- a/loaders.md
+++ b/loaders.md
@@ -17,4 +17,4 @@ To learn more about [extracting](/loaders/) and loading data using Meltano, refe
 Any [Singer target](/singer/targets) can easily be [added to your Meltano project as a custom loader](https://docs.meltano.com/plugin-management.html#custom-plugins).
 
 If a target for your destination doesn't exist yet, you can learn how to [create your own from scratch](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#developing-a-target). Once you've got the new loader working in your project, you can
-[add it to the Hub](https://gitlab.com/meltano/hub/-/tree/main/_data/targets).
+[add it to the Hub](https://github.com/meltano/hub/tree/main/_data/meltano/loaders).

--- a/singer/docs.md
+++ b/singer/docs.md
@@ -12,7 +12,7 @@ We're fully [embracing Singer](https://docs.meltano.com/#embracing-singer) and M
 
 ## Development
 
-MeltanoHub is under active development by Meltano. Check out the [main development epic](https://gitlab.com/groups/meltano/-/epics/83) for our roadmap or [view the issues](https://gitlab.com/meltano/hub/-/issues) to understand progress on a specific feature.
+MeltanoHub is under active development by Meltano. Check out the [main development epic](https://gitlab.com/groups/meltano/-/epics/83) for our roadmap or [view the issues](https://github.com/meltano/hub/-/issues) to understand progress on a specific feature.
 
 ## Standardized Connectors
 
@@ -40,7 +40,7 @@ The latest version of these files will always be available at these endpoints:
 
 These files will also be versioned when changes are made in a backwards-incompatible way.
 The versioned files will be available through the [API](/singer/api/v1/).
-Individual YAML files are also available through the individual connector pages or on the [repository](https://gitlab.com/meltano/hub/) building MeltanoHub.
+Individual YAML files are also available through the individual connector pages or on the [repository](https://github.com/meltano/hub/) building MeltanoHub.
 
 Our expectation is that other tools, including Meltano, will utilize the data available via the API to build their own library of Singer taps and targets.
 
@@ -95,7 +95,7 @@ Supporting this capability, where applicable, means that targets have the inform
 
 This capability is still in development, but the goal is to make it easy for connector developers to test locally without having to make a connection to the source systems.
 This might be accomplished by implementing utilities that can generate and save test data or make saving and moving real HTTP requests for tests easier.
-Join the issue conversation [here](https://gitlab.com/meltano/sdk/-/issues/30)!
+Join the issue conversation [here](https://github.com/meltano/sdk/issues/30)!
 
 ### Target Specific
 
@@ -219,11 +219,11 @@ Join the issue conversation [here](https://gitlab.com/meltano/sdk/-/issues/9)!
 
 MeltanoHub is built with every part of the Singer ecosystem and Meltano product family. This is a completely open source, end-to-end, production example of Meltano using full-featured Singer connectors.
 
-We use Meltano itself to pull data from GitHub. View the Meltano project for this effort in the [Hub repository](https://gitlab.com/meltano/hub/-/tree/main/meltano).
+We use Meltano itself to pull data from GitHub. View the Meltano project for this effort in the [Meltano Squared repository](https://github.com/meltano/squared/).
 
-Using the SDK, we built a [custom GitHub tap](/singer/taps/github-search) and a [custom Athena target](/singer/targets/target-athena).
+We're using Singer taps and targets to extract and load into a Snowflake warehouse.
 
-We're using dbt to [manage transformations](https://gitlab.com/meltano/hub/-/tree/main/meltano/transform/transforms/marts/singer) with Athena to aid in curating the data.
+We're using dbt to [manage transformations](https://github.com/meltano/squared/tree/main/data/transform/models/publish/meltano_hub) with Athena to aid in curating the data.
 
 ## Meltano Usage Metrics
 
@@ -248,7 +248,7 @@ For example, [tap-gitlab](/taps/gitlab) has multiple variants ([MeltanoLabs](htt
 
 Since Meltano makes it easy for users to [opt out](https://docs.meltano.com/settings.html#send-anonymous-usage-stats) of sending usage stats we assume that metrics are undercounted.
 
-Checkout the [Meltano Squared](https://gitlab.com/meltano/squared) repository to see how we're using Meltano to extract and aggregate these metrics.
+Checkout the [Meltano Squared](https://github.com/meltano/squared) repository to see how we're using Meltano to extract and aggregate these metrics.
 
 <u>Last Updated:</u>
 

--- a/taps.md
+++ b/taps.md
@@ -19,12 +19,12 @@ We are working to add all taps in the ecosystem to MeltanoHub.
 
 If a tap for your source doesn't exist yet, you can
 create one yourself using the
-[SDK](https://sdk.meltano.com) and then [click here](https://gitlab.com/meltano/hub/-/issues/new?issuable_template=Add%20New%20Singer%20Connector) to submit
+[SDK](https://sdk.meltano.com) and then [click here](https://github.com/meltano/hub/issues/new) to submit
 your tap to be listed on MeltanoHub. 
 
 Any [Singer tap](/singer/targets) can easily be [added to your Meltano project as a custom extractor](https://docs.meltano.com/plugin-management.html#custom-plugins).
 If a tap for your source doesn't exist yet, you can learn how to [create your own from scratch](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#developing-a-tap). Once you've got the new extractor working in your project, you can
-[add it to the Hub](https://gitlab.com/meltano/hub/-/tree/main/_data/meltano/extractors/).
+[add it to the Hub](https://github.com/meltano/hub/tree/main/_data/meltano/extractors).
 
 Don’t want to build the tap yourself? These
 [partners](https://meltano.com/partners/) can help.

--- a/targets.md
+++ b/targets.md
@@ -19,12 +19,12 @@ We are working to add all targets in the ecosystem to MeltanoHub.
 
 If a target for your destination doesn't exist yet, you can
 create one yourself using the
-[SDK](https://sdk.meltano.com) and then [click here](https://gitlab.com/meltano/hub/-/issues/new?issuable_template=Add%20New%20Singer%20Connector) to submit
+[SDK](https://sdk.meltano.com) and then [click here](https://github.com/meltano/hub/issues/new) to submit
 your target to be listed on MeltanoHub. 
 
 Any [Singer target](/singer/targets) can easily be [added to your Meltano project as a custom loader](https://docs.meltano.com/plugin-management.html#custom-plugins).
 If a target for your destination doesn't exist yet, you can learn how to [create your own from scratch](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#developing-a-target). Once you've got the new loader working in your project, you can
-[add it to the Hub](https://gitlab.com/meltano/hub/-/tree/main/_data/meltano/loaders/).
+[add it to the Hub](https://github.com/meltano/hub/tree/main/_data/meltano/loaders).
 
 Don’t want to build the target yourself? These
 [partners](https://meltano.com/partners/) can help.

--- a/transformers/dbt-snowflake.md
+++ b/transformers/dbt-snowflake.md
@@ -100,7 +100,7 @@ export DBT_SNOWFLAKE_PROFILES_DIR=<profiles_dir>
 - [Environment variable](https://docs.meltano.com/configuration.html#configuring-settings): `DBT_SNOWFLAKE_TARGET`
 - Default: `$MELTANO_LOAD__DIALECT`, which [will expand to](https://docs.meltano.com/integration.html#pipeline-environment-variables) the value of the [`dialect` extra](https://docs.meltano.com/concepts/plugins#dialect-extra) for the loader used in the pipeline, e.g. `postgres` for `target-postgres` and `snowflake` for `target-snowflake`.
 
-This is the dialect of your warehouse where data is stored. It maps to the [`target:` value](https://gitlab.com/meltano/files-dbt/-/blob/master/bundle/transform/profile/profiles.yml#L5) in the dbt [`profiles.yml` file](https://docs.getdbt.com/dbt-cli/configure-your-profile).
+This is the dialect of your warehouse where data is stored. It maps to the [`target:` value](https://github.com/meltano/files-dbt/blob/ca1d0c5395e01a00a8174323301fb94a9910b92a/bundle/transform/profile/profiles.yml#L5) in the dbt [`profiles.yml` file](https://docs.getdbt.com/dbt-cli/configure-your-profile).
 
 #### How to use
 

--- a/transformers/dbt.md
+++ b/transformers/dbt.md
@@ -100,7 +100,7 @@ export DBT_PROFILES_DIR=<profiles_dir>
 - [Environment variable](https://docs.meltano.com/configuration.html#configuring-settings): `DBT_TARGET`
 - Default: `$MELTANO_LOAD__DIALECT`, which [will expand to](https://docs.meltano.com/integration.html#pipeline-environment-variables) the value of the [`dialect` extra](https://docs.meltano.com/concepts/plugins#dialect-extra) for the loader used in the pipeline, e.g. `postgres` for `target-postgres` and `snowflake` for `target-snowflake`.
 
-This is the dialect of your warehouse where data is stored. It maps to the [`target:` value](https://gitlab.com/meltano/files-dbt/-/blob/master/bundle/transform/profile/profiles.yml#L5) in the dbt [`profiles.yml` file](https://docs.getdbt.com/dbt-cli/configure-your-profile).
+This is the dialect of your warehouse where data is stored. It maps to the [`target:` value](https://github.com/meltano/files-dbt/blob/ca1d0c5395e01a00a8174323301fb94a9910b92a/bundle/transform/profile/profiles.yml#L5) in the dbt [`profiles.yml` file](https://docs.getdbt.com/dbt-cli/configure-your-profile).
 
 #### How to use
 


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/257

The only link I couldnt update is https://github.com/meltano/hub/blob/f9f81932087804b4c7d1b4eacc95d99c16bd97cd/singer/docs.md?plain=1#L15 because we dont have Epics in GitHub as far as I know.