### PR TITLE
add airflow ui command

### DIFF
--- a/_data/meltano/orchestrators/airflow/apache.yml
+++ b/_data/meltano/orchestrators/airflow/apache.yml
@@ -4,6 +4,10 @@ docs: https://docs.meltano.com/guide/orchestration
 repo: https://github.com/apache/airflow
 pip_url: apache-airflow==2.1.2 --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.1.2/constraints-${MELTANO__PYTHON_VERSION}.txt
 variant: apache
+commands:
+  ui:
+    args: webserver
+    description: Start the Airflow webserver.
 settings:
 - name: core.dags_folder
   value: $MELTANO_PROJECT_ROOT/orchestrate/dags


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/252

The current implementation adds a `ui` command that just aliases webserver:

```
meltano invoke airflow:ui
# Is equivalent to the current
meltano invoke airflow webserver
```

Do we want more than this? It assumes that the user has already turned on the scheduler in the background. We could alternatively add a startup script similar to https://github.com/meltano/files-superset/blob/5a3c212933a2b76e09422ee3ab541afdf4fc6b98/bundle/analyze/superset/superset-init.sh if we wanted to start the scheduler in the background then start the webserver in the foreground but then we'd have have a way of shutting the scheduler down on exit. It wouldnt be all that hard but I wasnt sure what we were looking for.