### PR TITLE
upd: marketo extractor capabilities

### DIFF
--- a/_data/meltano/extractors/marketo.yml
+++ b/_data/meltano/extractors/marketo.yml
@@ -7,7 +7,10 @@ variants:
   docs: https://hub.meltano.com/extractors/marketo.html
   repo: https://github.com/singer-io/tap-marketo
   pip_url: git+https://github.com/singer-io/tap-marketo.git
-  capabilities: []
+  capabilities:
+  - properties
+  - discover
+  - state
   settings:
   - name: endpoint
     label: Endpoint


### PR DESCRIPTION
Singer-io variant capabilities were not added, resulting in the tap not functioning.

Previous PR updated it for the meltano variant instead of singer-io:  https://gitlab.com/meltano/hub/-/merge_requests/247

Capabilities can already be seen in MeltanoHub: https://hub.meltano.com/taps/marketo