### PR TITLE
Fix loader target_schema extras

### DIFF
--- a/_data/meltano/loaders/target-postgres/datamill-co.yml
+++ b/_data/meltano/loaders/target-postgres/datamill-co.yml
@@ -3,7 +3,7 @@ label: PostgreSQL
 description: PostgreSQL database loader
 namespace: target_postgres
 dialect: postgres
-target_schema: $TARGET_POSTGRES_SCHEMA
+target_schema: $TARGET_POSTGRES_POSTGRES_SCHEMA
 logo_url: /assets/logos/loaders/postgres.png
 variant: datamill-co
 docs: https://hub.meltano.com/loaders/postgres--datamill-co.html
@@ -116,8 +116,8 @@ settings:
   kind: integer
   description: |
     How often, in rows received, to count the buffered rows and bytes to
-    check if a flush is necessary. 
-    
+    check if a flush is necessary.
+
     There's a slight performance penalty to checking
     the buffered records count or bytesize, so this controls how often this is polled
     in order to mitigate the penalty. This value is usually not necessary to set as
@@ -128,8 +128,8 @@ settings:
   value: true
   description: |
     Whether the Target should emit `STATE` messages to stdout for further
-    consumption. 
-    
+    consumption.
+
     In this mode, which is on by default, STATE messages are buffered
     in memory until all the records that occurred before them are flushed according
     to the batch flushing schedule the target is configured with.
@@ -139,8 +139,8 @@ settings:
   value: true
   description: |
     Whether the Target should create column indexes on the important columns
-    used during data loading. 
-    
+    used during data loading.
+
     These indexes will make data loading slightly slower
     but the deduplication phase much faster. Defaults to on for better baseline performance.
 - name: before_run_sql
@@ -183,15 +183,15 @@ usage: |
   To resolve this, refer to the ["Dependencies" section](#dependencies) above.
 
   ### `ld`, `clang`, `lssl`, or `linker` Errors
-  
+
   If you have an error message like:
-    
+
     * `ld: library not found for -lssl`
     * `clang: error: linker command failed with exit code 1`
     * `error: command 'clang' failed with exit status 1`
 
-  These error messages indicates that there is a problem installing OpenSSL. 
-  
+  These error messages indicates that there is a problem installing OpenSSL.
+
   This [Stack Overflow answer](https://stackoverflow.com/questions/26288042/error-installing-psycopg2-library-not-found-for-lssl)
   has specific recommendations on setting the `LDFLAGS` and/or `CPPFLAGS` environment variables.
   Set those prior to running `meltano add loader target-postgres`.

--- a/_data/meltano/loaders/target-postgres/transferwise.yml
+++ b/_data/meltano/loaders/target-postgres/transferwise.yml
@@ -3,7 +3,7 @@ label: PostgreSQL
 description: PostgreSQL database loader
 namespace: target_postgres
 dialect: postgres
-target_schema: $TARGET_POSTGRES_SCHEMA
+target_schema: $TARGET_POSTGRES_DEFAULT_TARGET_SCHEMA
 logo_url: /assets/logos/loaders/postgres.png
 variant: transferwise
 docs: https://hub.meltano.com/loaders/postgres.html
@@ -147,15 +147,15 @@ usage: |
   ## Troubleshooting
 
   ### `ld`, `clang`, `lssl`, or `linker` Errors
-  
+
   If you have an error message like:
-    
+
     * `ld: library not found for -lssl`
     * `clang: error: linker command failed with exit code 1`
     * `error: command 'clang' failed with exit status 1`
 
-  These error messages indicates that there is a problem installing OpenSSL. 
-  
+  These error messages indicates that there is a problem installing OpenSSL.
+
   This [Stack Overflow answer](https://stackoverflow.com/questions/26288042/error-installing-psycopg2-library-not-found-for-lssl)
   has specific recommendations on setting the `LDFLAGS` and/or `CPPFLAGS` environment variables.
   Set those prior to running `meltano add loader target-postgres`.

--- a/_data/meltano/loaders/target-redshift/transferwise.yml
+++ b/_data/meltano/loaders/target-redshift/transferwise.yml
@@ -15,7 +15,7 @@ capabilities:
 - datatype-failsafe
 - record-flattening
 dialect: redshift
-target_schema: $TARGET_REDSHIFT_SCHEMA
+target_schema: $TARGET_REDSHIFT_DEFAULT_TARGET_SCHEMA
 settings_group_validation:
 - - host
   - port
@@ -69,7 +69,7 @@ settings:
   value: $MELTANO_EXTRACT__LOAD_SCHEMA
   description: |
     Note `$MELTANO_EXTRACT__LOAD_SCHEMA` [will expand to](https://docs.meltano.com/configuration.html#expansion-in-setting-values) the value of the [`load_schema` extra](https://docs.meltano.com/concepts/plugins#load-schema-extra) for the extractor used in the pipeline, which defaults to the extractor's namespace, e.g. `tap_gitlab` for [`tap-gitlab`](/extractors/gitlab).
-    
+
     Name of the schema where the tables will be created. If `schema_mapping`
     is not defined then every stream sent by the tap is loaded into this schema.
 - name: aws_profile
@@ -110,7 +110,7 @@ settings:
   description: |
     Parameters to use in the COPY command when loading data to Redshift.
 
-    Some basic file formatting parameters are fixed values and not recommended overriding them by custom values. 
+    Some basic file formatting parameters are fixed values and not recommended overriding them by custom values.
     They are like: `CSV GZIP DELIMITER ',' REMOVEQUOTES ESCAPE`.
 - name: batch_size_rows
   label: Batch Size Rows
@@ -147,11 +147,11 @@ settings:
   kind: object
   description: |
     Useful if you want to load multiple streams from one tap to multiple
-    Redshift schemas. 
-    
+    Redshift schemas.
+
     If the tap sends the `stream_id` in `<schema_name>-<table_name>`
-    format then this option overwrites the `default_target_schema` value. 
-    
+    format then this option overwrites the `default_target_schema` value.
+
     Note, that using `schema_mapping` you can overwrite the `default_target_schema_select_permissions`
     value to grant SELECT permissions to different groups per schemas or optionally
     you can create indices automatically for the replicated tables.
@@ -172,12 +172,12 @@ settings:
     Metadata columns add extra row level information about data ingestions,
     (i.e. when was the row read in source, when was inserted or deleted in redshift
     etc.) Metadata columns are creating automatically by adding extra columns to the
-    tables with a column prefix `_SDC_`. 
-    
+    tables with a column prefix `_SDC_`.
+
     The metadata columns are documented at https://transferwise.github.io/pipelinewise/data_structure/sdc-columns.html.
     Enabling metadata columns will flag the deleted rows by setting the _SDC_DELETED_AT
-    metadata column. 
-    
+    metadata column.
+
     Without the `add_metadata_columns` option the deleted rows from
     singer taps will not be recongisable in Redshift.
 - name: hard_delete

--- a/_data/meltano/loaders/target-snowflake/datamill-co.yml
+++ b/_data/meltano/loaders/target-snowflake/datamill-co.yml
@@ -3,7 +3,7 @@ label: Snowflake
 description: Snowflake database loader
 namespace: target_snowflake
 dialect: snowflake
-target_schema: $TARGET_SNOWFLAKE_SCHEMA
+target_schema: $TARGET_SNOWFLAKE_SNOWFLAKE_SCHEMA
 logo_url: /assets/logos/loaders/snowflake.png
 variant: datamill-co
 docs: https://hub.meltano.com/loaders/snowflake--datamill-co.html
@@ -20,7 +20,7 @@ settings:
   label: Account
   description: |
     `ACCOUNT` might require the `region` and `cloud` platform where your account is located, in the form of: `<your_account_name>.<region_id>.<cloud>` (e.g. `xy12345.east-us-2.azure`)
-    
+
     Refer to [Snowflake's documentation](https://docs.snowflake.net/manuals/user-guide/connecting.html#your-snowflake-account-name-and-url) about Accounts.
 - name: snowflake_username
   label: Username

--- a/_data/meltano/loaders/target-snowflake/transferwise.yml
+++ b/_data/meltano/loaders/target-snowflake/transferwise.yml
@@ -3,7 +3,7 @@ label: Snowflake
 description: Snowflake database loader
 namespace: target_snowflake
 dialect: snowflake
-target_schema: $TARGET_SNOWFLAKE_SCHEMA
+target_schema: $TARGET_SNOWFLAKE_DEFAULT_TARGET_SCHEMA
 logo_url: /assets/logos/loaders/snowflake.png
 variant: transferwise
 docs: https://hub.meltano.com/loaders/snowflake.html
@@ -75,7 +75,7 @@ settings:
   value_processor: upcase_string
   description: |
     Note `$MELTANO_EXTRACT__LOAD_SCHEMA` [will expand to](https://docs.meltano.com/configuration.html#expansion-in-setting-values) the value of the [`load_schema` extra](https://docs.meltano.com/concepts/plugins#load-schema-extra) for the extractor used in the pipeline, which defaults to the extractor's namespace, e.g. `tap_gitlab` for [`tap-gitlab`](/extractors/gitlab). Values are automatically converted to uppercase before they're passed on to the plugin, so `tap_gitlab` becomes `TAP_GITLAB`.
-    
+
     Name of the schema where the tables will be created, without database
     prefix. If `schema_mapping` is not defined then every stream sent by the tap is
     loaded into this schema.
@@ -139,9 +139,9 @@ settings:
   kind: object
   description: |
     Useful if you want to load multiple streams from one tap to multiple Snowflake schemas.
-    
+
     If the tap sends the `stream_id` in `<schema_name>-<table_name>` format then this option overwrites the `default_target_schema` value.
-    
+
     Note, that using `schema_mapping` you can overwrite the `default_target_schema_select_permission` value to grant SELECT permissions to different groups per schemas or optionally you can create indices automatically for the replicated tables.
 - name: disable_table_cache
   label: Disable Table Cache
@@ -222,7 +222,7 @@ settings:
   label: Query Tag
   description: |
     Optional string to tag executed queries in Snowflake. Replaces tokens
-    
+
     `schema` and `table` with the appropriate values. The tags are displayed in the
     output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions.
 - name: archive_load_files
@@ -232,9 +232,9 @@ settings:
   description: |
     When enabled, the files loaded to Snowflake will also be stored in
     `archive_load_files_s3_bucket` under the key /{archive_load_files_s3_prefix}/{schema_name}/{table_name}/.
-    
-    All archived files will have tap, schema, table and archived-by as S3 metadata keys. 
-    
+
+    All archived files will have tap, schema, table and archived-by as S3 metadata keys.
+
     When incremental replication is used, the archived files will also have
     the following S3 metadata keys - incremental-key, incremental-key-min and incremental-key-max.
 - name: archive_load_files_s3_prefix


### PR DESCRIPTION
After the removal of `env_aliases` (https://github.com/meltano/meltano/pull/5927), `TARGET_[SNOWFLAKE|POSTGRES]_SCHEMA` is only being set when the setting was actually called `schema`, which was the case with the `meltano` variant but not `transferwise` and `datamill-co`, meaning that the extra would always be `null`. This fixes that.