### PR TITLE
[fix] Add Missing Env Var to BQ

### DIFF
--- a/_data/meltano/loaders/target-bigquery/adswerve.yml
+++ b/_data/meltano/loaders/target-bigquery/adswerve.yml
@@ -9,75 +9,77 @@ pip_url: git+https://github.com/adswerve/target-bigquery.git@0.11.3
 dialect: bigquery
 target_schema: $TARGET_BIGQUERY_DATASET_ID
 settings_group_validation:
-- - project_id
-  - dataset_id
-  - location
-  - credentials_path
+  - - project_id
+    - dataset_id
+    - location
+    - credentials_path
 settings:
-- name: project_id
-  description: BigQuery project
-  label: Project ID
-- name: dataset_id
-  value: $MELTANO_EXTRACT__LOAD_SCHEMA
-  label: Dataset ID
-  description: |
-    BigQuery dataset.
+  - name: project_id
+    description: BigQuery project
+    label: Project ID
+  - name: dataset_id
+    value: $MELTANO_EXTRACT__LOAD_SCHEMA
+    label: Dataset ID
+    description: |
+      BigQuery dataset.
 
-    The default value [will expand to](https://docs.meltano.com/guide/configuration.html#expansion-in-setting-values) the value of the [`load_schema` extra](https://docs.meltano.com/concepts/plugins#load-schema-extra) for the extractor used in the pipeline, which defaults to the extractor's namespace, e.g. `tap_gitlab` for [`tap-gitlab`](/extractors/gitlab).
-- name: location
-  description: Dataset Location. See https://cloud.google.com/bigquery/docs/locations.
-  value: US
-  label: Location
-- name: credentials_path
-  value: $MELTANO_PROJECT_ROOT/client_secrets.json
-  label: Credentials Path
-  description: |
-    Fully qualified path to `client_secrets.json` for your service account.
+      The default value [will expand to](https://docs.meltano.com/guide/configuration.html#expansion-in-setting-values) the value of the [`load_schema` extra](https://docs.meltano.com/concepts/plugins#load-schema-extra) for the extractor used in the pipeline, which defaults to the extractor's namespace, e.g. `tap_gitlab` for [`tap-gitlab`](/extractors/gitlab).
+  - name: location
+    description: Dataset Location. See https://cloud.google.com/bigquery/docs/locations.
+    value: US
+    label: Location
+  - name: credentials_path
+    value: $MELTANO_PROJECT_ROOT/client_secrets.json
+    label: Credentials Path
+    description: |
+      Fully qualified path to `client_secrets.json` for your service account.
 
-    See the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api) and <https://cloud.google.com/docs/authentication/production>.
+      See the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api) and <https://cloud.google.com/docs/authentication/production>.
 
-    By default, this file is expected to be at the root of your project directory.
-- name: validate_records
-  kind: boolean
-  value: false
-  label: Validate Records
-- name: add_metadata_columns
-  description: Add `_time_extracted` and `_time_loaded` metadata columns
-  kind: boolean
-  value: false
-  label: Add Metadata Columns
-- name: replication_method
-  description: Replication method, `append` or `truncate`
-  kind: options
-  options:
-  - label: Append
+      By default, this file is expected to be at the root of your project directory.
+    env: GOOGLE_APPLICATION_CREDENTIALS
+  - name: validate_records
+    kind: boolean
+    value: false
+    label: Validate Records
+  - name: add_metadata_columns
+    description: Add `_time_extracted` and `_time_loaded` metadata columns
+    kind: boolean
+    value: false
+    label: Add Metadata Columns
+  - name: replication_method
+    description: Replication method, `append` or `truncate`
+    kind: options
+    options:
+      - label: Append
+        value: append
+      - label: Truncate
+        value: truncate
     value: append
-  - label: Truncate
-    value: truncate
-  value: append
-  label: Replication Method
-- name: table_prefix
-  description: Add prefix to table name
-  label: Table Prefix
-- name: table_suffix
-  description: Add suffix to table name
-  label: Table Suffix
-- name: max_cache
-  description: Maximum cache size in MB
-  value: 50
-  label: Max Cache
-- name: merge_state_messages
-  kind: boolean
-  description: Whether to merge multiple state messages from the tap into the state
-    file or uses the last state message as the state file. Note that it is not recommended to set this to true when using with Meltano as the merge behavior conflicts with Meltano’s merge process.
-  label: Merge State Messages
-  value: false
-- name: table_config
-  description: A path to a file containing the definition of partitioning and clustering.
-  label: Table Config
+    label: Replication Method
+  - name: table_prefix
+    description: Add prefix to table name
+    label: Table Prefix
+  - name: table_suffix
+    description: Add suffix to table name
+    label: Table Suffix
+  - name: max_cache
+    description: Maximum cache size in MB
+    value: 50
+    label: Max Cache
+  - name: merge_state_messages
+    kind: boolean
+    description:
+      Whether to merge multiple state messages from the tap into the state
+      file or uses the last state message as the state file. Note that it is not recommended to set this to true when using with Meltano as the merge behavior conflicts with Meltano’s merge process.
+    label: Merge State Messages
+    value: false
+  - name: table_config
+    description: A path to a file containing the definition of partitioning and clustering.
+    label: Table Config
 domain_url: https://cloud.google.com/bigquery
 maintenance_status: active
 keywords:
-- database
+  - database
 prereq: |
   Then, follow the steps in the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api).

--- a/_data/meltano/loaders/target-bigquery/adswerve.yml
+++ b/_data/meltano/loaders/target-bigquery/adswerve.yml
@@ -51,10 +51,10 @@ settings:
   description: Replication method, `append` or `truncate`
   kind: options
   options:
-    - label: Append
-      value: append
-    - label: Truncate
-      value: truncate
+  - label: Append
+    value: append
+  - label: Truncate
+    value: truncate
   value: append
   label: Replication Method
 - name: table_prefix

--- a/_data/meltano/loaders/target-bigquery/adswerve.yml
+++ b/_data/meltano/loaders/target-bigquery/adswerve.yml
@@ -9,77 +9,77 @@ pip_url: git+https://github.com/adswerve/target-bigquery.git@0.11.3
 dialect: bigquery
 target_schema: $TARGET_BIGQUERY_DATASET_ID
 settings_group_validation:
-  - - project_id
-    - dataset_id
-    - location
-    - credentials_path
+- - project_id
+  - dataset_id
+  - location
+  - credentials_path
 settings:
-  - name: project_id
-    description: BigQuery project
-    label: Project ID
-  - name: dataset_id
-    value: $MELTANO_EXTRACT__LOAD_SCHEMA
-    label: Dataset ID
-    description: |
-      BigQuery dataset.
+- name: project_id
+  description: BigQuery project
+  label: Project ID
+- name: dataset_id
+  value: $MELTANO_EXTRACT__LOAD_SCHEMA
+  label: Dataset ID
+  description: |
+    BigQuery dataset.
 
-      The default value [will expand to](https://docs.meltano.com/guide/configuration.html#expansion-in-setting-values) the value of the [`load_schema` extra](https://docs.meltano.com/concepts/plugins#load-schema-extra) for the extractor used in the pipeline, which defaults to the extractor's namespace, e.g. `tap_gitlab` for [`tap-gitlab`](/extractors/gitlab).
-  - name: location
-    description: Dataset Location. See https://cloud.google.com/bigquery/docs/locations.
-    value: US
-    label: Location
-  - name: credentials_path
-    value: $MELTANO_PROJECT_ROOT/client_secrets.json
-    label: Credentials Path
-    description: |
-      Fully qualified path to `client_secrets.json` for your service account.
+    The default value [will expand to](https://docs.meltano.com/guide/configuration.html#expansion-in-setting-values) the value of the [`load_schema` extra](https://docs.meltano.com/concepts/plugins#load-schema-extra) for the extractor used in the pipeline, which defaults to the extractor's namespace, e.g. `tap_gitlab` for [`tap-gitlab`](/extractors/gitlab).
+- name: location
+  description: Dataset Location. See https://cloud.google.com/bigquery/docs/locations.
+  value: US
+  label: Location
+- name: credentials_path
+  value: $MELTANO_PROJECT_ROOT/client_secrets.json
+  label: Credentials Path
+  description: |
+    Fully qualified path to `client_secrets.json` for your service account.
 
-      See the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api) and <https://cloud.google.com/docs/authentication/production>.
+    See the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api) and <https://cloud.google.com/docs/authentication/production>.
 
-      By default, this file is expected to be at the root of your project directory.
-    env: GOOGLE_APPLICATION_CREDENTIALS
-  - name: validate_records
-    kind: boolean
-    value: false
-    label: Validate Records
-  - name: add_metadata_columns
-    description: Add `_time_extracted` and `_time_loaded` metadata columns
-    kind: boolean
-    value: false
-    label: Add Metadata Columns
-  - name: replication_method
-    description: Replication method, `append` or `truncate`
-    kind: options
-    options:
-      - label: Append
-        value: append
-      - label: Truncate
-        value: truncate
-    value: append
-    label: Replication Method
-  - name: table_prefix
-    description: Add prefix to table name
-    label: Table Prefix
-  - name: table_suffix
-    description: Add suffix to table name
-    label: Table Suffix
-  - name: max_cache
-    description: Maximum cache size in MB
-    value: 50
-    label: Max Cache
-  - name: merge_state_messages
-    kind: boolean
-    description:
-      Whether to merge multiple state messages from the tap into the state
-      file or uses the last state message as the state file. Note that it is not recommended to set this to true when using with Meltano as the merge behavior conflicts with Meltano’s merge process.
-    label: Merge State Messages
-    value: false
-  - name: table_config
-    description: A path to a file containing the definition of partitioning and clustering.
-    label: Table Config
+    By default, this file is expected to be at the root of your project directory.
+  env: GOOGLE_APPLICATION_CREDENTIALS
+- name: validate_records
+  kind: boolean
+  value: false
+  label: Validate Records
+- name: add_metadata_columns
+  description: Add `_time_extracted` and `_time_loaded` metadata columns
+  kind: boolean
+  value: false
+  label: Add Metadata Columns
+- name: replication_method
+  description: Replication method, `append` or `truncate`
+  kind: options
+  options:
+    - label: Append
+      value: append
+    - label: Truncate
+      value: truncate
+  value: append
+  label: Replication Method
+- name: table_prefix
+  description: Add prefix to table name
+  label: Table Prefix
+- name: table_suffix
+  description: Add suffix to table name
+  label: Table Suffix
+- name: max_cache
+  description: Maximum cache size in MB
+  value: 50
+  label: Max Cache
+- name: merge_state_messages
+  kind: boolean
+  description:
+    Whether to merge multiple state messages from the tap into the state
+    file or uses the last state message as the state file. Note that it is not recommended to set this to true when using with Meltano as the merge behavior conflicts with Meltano’s merge process.
+  label: Merge State Messages
+  value: false
+- name: table_config
+  description: A path to a file containing the definition of partitioning and clustering.
+  label: Table Config
 domain_url: https://cloud.google.com/bigquery
 maintenance_status: active
 keywords:
-  - database
+- database
 prereq: |
   Then, follow the steps in the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api).


### PR DESCRIPTION
Adds `env` to config for `GOOGLE_APPLICATION_CREDENTIALS` which the tap required.