### PR TITLE
[fix] Incorrect target name and missing env on transferwise bigquery

### DIFF
--- a/_data/meltano/loaders/target-bigquery/transferwise.yml
+++ b/_data/meltano/loaders/target-bigquery/transferwise.yml
@@ -11,7 +11,6 @@ capabilities:
 settings:
 - name: credentials_path
   value: $MELTANO_PROJECT_ROOT/client_secrets.json
-  type: string
   label: Credentials Path
   description: |
     Fully qualified path to `client_secrets.json` for your service account.

--- a/_data/meltano/loaders/target-bigquery/transferwise.yml
+++ b/_data/meltano/loaders/target-bigquery/transferwise.yml
@@ -9,6 +9,17 @@ capabilities:
   - hard-delete
   - soft-delete
 settings:
+  - name: credentials_path
+    value: $MELTANO_PROJECT_ROOT/client_secrets.json
+    type: string
+    label: Credentials Path
+    description: |
+      Fully qualified path to `client_secrets.json` for your service account.
+
+      See the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api) and <https://cloud.google.com/docs/authentication/production>.
+
+      By default, this file is expected to be at the root of your project directory.
+    env: GOOGLE_APPLICATION_CREDENTIALS
   - name: dataset_id
     description: BigQuery dataset
     label: Dataset Id

--- a/_data/meltano/loaders/target-bigquery/transferwise.yml
+++ b/_data/meltano/loaders/target-bigquery/transferwise.yml
@@ -1,118 +1,130 @@
-name: bigquery
+name: target-bigquery
 label: BigQuery
 description: For loading data into BigQuery
 namespace: target_bigquery
 logo_url: /assets/logos/loaders/bigquery.png
 variant: transferwise
 capabilities:
-- record-flattening
-- hard-delete
-- soft-delete
+  - record-flattening
+  - hard-delete
+  - soft-delete
 settings:
-- name: dataset_id
-  description: BigQuery dataset
-  label: Dataset Id
-- name: project_id
-  description: BigQuery project
-  label: Project Id
-- name: location
-  description: Region where BigQuery stores your dataset
-  value: US
-  label: Location
-- name: batch_size_rows
-  description: Maximum number of rows in each batch. At the end of each batch, the
-    rows in the batch are loaded into BigQuery.
-  label: Batch Size Rows
-  value: 100000
-  kind: integer
-- name: flush_all_streams
-  description: Flush and load every stream into BigQuery when one batch is full. Warning
-    - This may trigger transfer of data with low number of records, and may cause
-    performance problems.
-  label: Flush All Streams
-  value: false
-  kind: boolean
-- name: parallelism
-  description: The number of threads used to flush tables. 0 will create a thread
-    for each stream, up to parallelism_max. -1 will create a thread for each CPU core.
-    Any other positive number will create that number of threads, up to parallelism_max.
-  label: Parallelism
-  value: 0
-  kind: integer
-- name: max_parallelism
-  description: Max number of parallel threads to use when flushing tables.
-  value: 16
-  kind: integer
-  label: Max Parallelism
-- name: default_target_schema
-  description: Name of the schema where the tables will be created. If schema_mapping
-    is not defined then every stream sent by the tap is loaded into this schema.
-  label: Default Target Schema
-- name: default_target_schema_select_permission
-  description: Grant USAGE privilege on newly created schemas and grant SELECT privilege
-    on newly created
-  label: Default Target Schema Select Permission
-- name: schema_mapping
-  description: (Experimental) Useful if you want to load multiple streams from one
-    tap to multiple BigQuery schemas. If the tap sends the stream_id in <schema_name>-<table_name>
-    format then this option overwrites the default_target_schema value. Note, that
-    using schema_mapping you can overwrite the default_target_schema_select_permission
-    value to grant SELECT permissions to different groups per schemas or optionally
-    you can create indices automatically for the replicated tables.
-  label: Schema Mapping
-  kind: object
-- name: add_metadata_columns
-  description: Metadata columns add extra row level information about data ingestions,
-    (i.e. when was the row read in source, when was inserted or deleted in bigquery
-    etc.) Metadata columns are creating automatically by adding extra columns to the
-    tables with a column prefix _sdc_. The column names are following the stitch naming
-    conventions documented at https://www.stitchdata.com/docs/data-structure/integration-schemas#sdc-columns.
-    Enabling metadata columns will flag the deleted rows by setting the _sdc_deleted_at
-    metadata column. Without the add_metadata_columns option the deleted rows from
-    singer taps will not be recognisable in BigQuery.
-  kind: boolean
-  value: false
-  label: Add Metadata Columns
-- name: hard_delete
-  description: When hard_delete option is true then DELETE SQL commands will be performed
-    in BigQuery to delete rows in tables. It's achieved by continuously checking the
-    _sdc_deleted_at metadata column sent by the singer tap. Due to deleting rows requires
-    metadata columns, hard_delete option automatically enables the add_metadata_columns
-    option as well.
-  label: Hard Delete
-  kind: boolean
-  value: false
-- name: data_flattening_max_level
-  description: Object type RECORD items from taps can be loaded into VARIANT columns
-    as JSON (default) or we can flatten the schema by creating columns automatically.
-    When value is 0 (default) then flattening functionality is turned off.
-  label: Data Flattening Max Level
-  value: 0
-  kind: integer
-- name: primary_key_required
-  description: Log based and Incremental replications on tables with no Primary Key
-    cause duplicates when merging UPDATE events. When set to true, stop loading data
-    if no Primary Key is defined.
-  label: Primary Key Required
-  kind: boolean
-  value: true
-- name: validate_records
-  description: Validate every single record message to the corresponding JSON schema.
-    This option is disabled by default and invalid RECORD messages will fail only
-    at load time by BigQuery. Enabling this option will detect invalid records earlier
-    but could cause performance degradation.
-  kind: boolean
-  value: false
-  label: Validate Records
-- name: temp_schema
-  description: Name of the schema where the temporary tables will be created. Will
-    default to the same schema as the target tables.
-  label: Temp Schema
+  - name: dataset_id
+    description: BigQuery dataset
+    label: Dataset Id
+  - name: project_id
+    description: BigQuery project
+    label: Project Id
+  - name: location
+    description: Region where BigQuery stores your dataset
+    value: US
+    label: Location
+  - name: batch_size_rows
+    description:
+      Maximum number of rows in each batch. At the end of each batch, the
+      rows in the batch are loaded into BigQuery.
+    label: Batch Size Rows
+    value: 100000
+    kind: integer
+  - name: flush_all_streams
+    description:
+      Flush and load every stream into BigQuery when one batch is full. Warning
+      - This may trigger transfer of data with low number of records, and may cause
+      performance problems.
+    label: Flush All Streams
+    value: false
+    kind: boolean
+  - name: parallelism
+    description:
+      The number of threads used to flush tables. 0 will create a thread
+      for each stream, up to parallelism_max. -1 will create a thread for each CPU core.
+      Any other positive number will create that number of threads, up to parallelism_max.
+    label: Parallelism
+    value: 0
+    kind: integer
+  - name: max_parallelism
+    description: Max number of parallel threads to use when flushing tables.
+    value: 16
+    kind: integer
+    label: Max Parallelism
+  - name: default_target_schema
+    description:
+      Name of the schema where the tables will be created. If schema_mapping
+      is not defined then every stream sent by the tap is loaded into this schema.
+    label: Default Target Schema
+  - name: default_target_schema_select_permission
+    description:
+      Grant USAGE privilege on newly created schemas and grant SELECT privilege
+      on newly created
+    label: Default Target Schema Select Permission
+  - name: schema_mapping
+    description:
+      (Experimental) Useful if you want to load multiple streams from one
+      tap to multiple BigQuery schemas. If the tap sends the stream_id in <schema_name>-<table_name>
+      format then this option overwrites the default_target_schema value. Note, that
+      using schema_mapping you can overwrite the default_target_schema_select_permission
+      value to grant SELECT permissions to different groups per schemas or optionally
+      you can create indices automatically for the replicated tables.
+    label: Schema Mapping
+    kind: object
+  - name: add_metadata_columns
+    description:
+      Metadata columns add extra row level information about data ingestions,
+      (i.e. when was the row read in source, when was inserted or deleted in bigquery
+      etc.) Metadata columns are creating automatically by adding extra columns to the
+      tables with a column prefix _sdc_. The column names are following the stitch naming
+      conventions documented at https://www.stitchdata.com/docs/data-structure/integration-schemas#sdc-columns.
+      Enabling metadata columns will flag the deleted rows by setting the _sdc_deleted_at
+      metadata column. Without the add_metadata_columns option the deleted rows from
+      singer taps will not be recognisable in BigQuery.
+    kind: boolean
+    value: false
+    label: Add Metadata Columns
+  - name: hard_delete
+    description:
+      When hard_delete option is true then DELETE SQL commands will be performed
+      in BigQuery to delete rows in tables. It's achieved by continuously checking the
+      _sdc_deleted_at metadata column sent by the singer tap. Due to deleting rows requires
+      metadata columns, hard_delete option automatically enables the add_metadata_columns
+      option as well.
+    label: Hard Delete
+    kind: boolean
+    value: false
+  - name: data_flattening_max_level
+    description:
+      Object type RECORD items from taps can be loaded into VARIANT columns
+      as JSON (default) or we can flatten the schema by creating columns automatically.
+      When value is 0 (default) then flattening functionality is turned off.
+    label: Data Flattening Max Level
+    value: 0
+    kind: integer
+  - name: primary_key_required
+    description:
+      Log based and Incremental replications on tables with no Primary Key
+      cause duplicates when merging UPDATE events. When set to true, stop loading data
+      if no Primary Key is defined.
+    label: Primary Key Required
+    kind: boolean
+    value: true
+  - name: validate_records
+    description:
+      Validate every single record message to the corresponding JSON schema.
+      This option is disabled by default and invalid RECORD messages will fail only
+      at load time by BigQuery. Enabling this option will detect invalid records earlier
+      but could cause performance degradation.
+    kind: boolean
+    value: false
+    label: Validate Records
+  - name: temp_schema
+    description:
+      Name of the schema where the temporary tables will be created. Will
+      default to the same schema as the target tables.
+    label: Temp Schema
 settings_group_validation:
-- - dataset_id
-  - project_id
+  - - dataset_id
+    - project_id
 pip_url: pipelinewise-target-bigquery
 repo: https://github.com/transferwise/pipelinewise-target-bigquery
-domain_url:
+domain_url: https://cloud.google.com/bigquery/
 maintenance_status: active
 keywords: []

--- a/_data/meltano/loaders/target-bigquery/transferwise.yml
+++ b/_data/meltano/loaders/target-bigquery/transferwise.yml
@@ -5,137 +5,139 @@ namespace: target_bigquery
 logo_url: /assets/logos/loaders/bigquery.png
 variant: transferwise
 capabilities:
-  - record-flattening
-  - hard-delete
-  - soft-delete
+- record-flattening
+- hard-delete
+- soft-delete
 settings:
-  - name: credentials_path
-    value: $MELTANO_PROJECT_ROOT/client_secrets.json
-    type: string
-    label: Credentials Path
-    description: |
-      Fully qualified path to `client_secrets.json` for your service account.
+- name: credentials_path
+  value: $MELTANO_PROJECT_ROOT/client_secrets.json
+  type: string
+  label: Credentials Path
+  description: |
+    Fully qualified path to `client_secrets.json` for your service account.
 
-      See the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api) and <https://cloud.google.com/docs/authentication/production>.
+    See the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/adswerve/target-bigquery#step-1-activate-the-google-bigquery-api) and <https://cloud.google.com/docs/authentication/production>.
 
-      By default, this file is expected to be at the root of your project directory.
-    env: GOOGLE_APPLICATION_CREDENTIALS
-  - name: dataset_id
-    description: BigQuery dataset
-    label: Dataset Id
-  - name: project_id
-    description: BigQuery project
-    label: Project Id
-  - name: location
-    description: Region where BigQuery stores your dataset
-    value: US
-    label: Location
-  - name: batch_size_rows
-    description:
-      Maximum number of rows in each batch. At the end of each batch, the
-      rows in the batch are loaded into BigQuery.
-    label: Batch Size Rows
-    value: 100000
-    kind: integer
-  - name: flush_all_streams
-    description:
-      Flush and load every stream into BigQuery when one batch is full. Warning
-      - This may trigger transfer of data with low number of records, and may cause
-      performance problems.
-    label: Flush All Streams
-    value: false
-    kind: boolean
-  - name: parallelism
-    description:
-      The number of threads used to flush tables. 0 will create a thread
-      for each stream, up to parallelism_max. -1 will create a thread for each CPU core.
-      Any other positive number will create that number of threads, up to parallelism_max.
-    label: Parallelism
-    value: 0
-    kind: integer
-  - name: max_parallelism
-    description: Max number of parallel threads to use when flushing tables.
-    value: 16
-    kind: integer
-    label: Max Parallelism
-  - name: default_target_schema
-    description:
-      Name of the schema where the tables will be created. If schema_mapping
-      is not defined then every stream sent by the tap is loaded into this schema.
-    label: Default Target Schema
-  - name: default_target_schema_select_permission
-    description:
-      Grant USAGE privilege on newly created schemas and grant SELECT privilege
-      on newly created
-    label: Default Target Schema Select Permission
-  - name: schema_mapping
-    description:
-      (Experimental) Useful if you want to load multiple streams from one
-      tap to multiple BigQuery schemas. If the tap sends the stream_id in <schema_name>-<table_name>
-      format then this option overwrites the default_target_schema value. Note, that
-      using schema_mapping you can overwrite the default_target_schema_select_permission
-      value to grant SELECT permissions to different groups per schemas or optionally
-      you can create indices automatically for the replicated tables.
-    label: Schema Mapping
-    kind: object
-  - name: add_metadata_columns
-    description:
-      Metadata columns add extra row level information about data ingestions,
-      (i.e. when was the row read in source, when was inserted or deleted in bigquery
-      etc.) Metadata columns are creating automatically by adding extra columns to the
-      tables with a column prefix _sdc_. The column names are following the stitch naming
-      conventions documented at https://www.stitchdata.com/docs/data-structure/integration-schemas#sdc-columns.
-      Enabling metadata columns will flag the deleted rows by setting the _sdc_deleted_at
-      metadata column. Without the add_metadata_columns option the deleted rows from
-      singer taps will not be recognisable in BigQuery.
-    kind: boolean
-    value: false
-    label: Add Metadata Columns
-  - name: hard_delete
-    description:
-      When hard_delete option is true then DELETE SQL commands will be performed
-      in BigQuery to delete rows in tables. It's achieved by continuously checking the
-      _sdc_deleted_at metadata column sent by the singer tap. Due to deleting rows requires
-      metadata columns, hard_delete option automatically enables the add_metadata_columns
-      option as well.
-    label: Hard Delete
-    kind: boolean
-    value: false
-  - name: data_flattening_max_level
-    description:
-      Object type RECORD items from taps can be loaded into VARIANT columns
-      as JSON (default) or we can flatten the schema by creating columns automatically.
-      When value is 0 (default) then flattening functionality is turned off.
-    label: Data Flattening Max Level
-    value: 0
-    kind: integer
-  - name: primary_key_required
-    description:
-      Log based and Incremental replications on tables with no Primary Key
-      cause duplicates when merging UPDATE events. When set to true, stop loading data
-      if no Primary Key is defined.
-    label: Primary Key Required
-    kind: boolean
-    value: true
-  - name: validate_records
-    description:
-      Validate every single record message to the corresponding JSON schema.
-      This option is disabled by default and invalid RECORD messages will fail only
-      at load time by BigQuery. Enabling this option will detect invalid records earlier
-      but could cause performance degradation.
-    kind: boolean
-    value: false
-    label: Validate Records
-  - name: temp_schema
-    description:
-      Name of the schema where the temporary tables will be created. Will
-      default to the same schema as the target tables.
-    label: Temp Schema
+    By default, this file is expected to be at the root of your project directory.
+  env: GOOGLE_APPLICATION_CREDENTIALS
+- name: dataset_id
+  description: BigQuery dataset
+  label: Dataset Id
+- name: project_id
+  description: BigQuery project
+  label: Project Id
+- name: location
+  description: Region where BigQuery stores your dataset
+  value: US
+  label: Location
+- name: batch_size_rows
+  description:
+    Maximum number of rows in each batch. At the end of each batch, the
+    rows in the batch are loaded into BigQuery.
+  label: Batch Size Rows
+  value: 100000
+  kind: integer
+- name: flush_all_streams
+  description:
+    Flush and load every stream into BigQuery when one batch is full. Warning
+    - This may trigger transfer of data with low number of records, and may cause
+    performance problems.
+  label: Flush All Streams
+  value: false
+  kind: boolean
+- name: parallelism
+  description:
+    The number of threads used to flush tables. 0 will create a thread
+    for each stream, up to parallelism_max. -1 will create a thread for each CPU core.
+    Any other positive number will create that number of threads, up to parallelism_max.
+  label: Parallelism
+  value: 0
+  kind: integer
+- name: max_parallelism
+  description: Max number of parallel threads to use when flushing tables.
+  value: 16
+  kind: integer
+  label: Max Parallelism
+- name: default_target_schema
+  description:
+    Name of the schema where the tables will be created. If schema_mapping
+    is not defined then every stream sent by the tap is loaded into this schema.
+  label: Default Target Schema
+- name: default_target_schema_select_permission
+  description:
+    Grant USAGE privilege on newly created schemas and grant SELECT privilege
+    on newly created
+  label: Default Target Schema Select Permission
+- name: schema_mapping
+  description:
+    (Experimental) Useful if you want to load multiple streams from one
+    tap to multiple BigQuery schemas. If the tap sends the stream_id in <schema_name>-<table_name>
+    format then this option overwrites the default_target_schema value. Note, that
+    using schema_mapping you can overwrite the default_target_schema_select_permission
+    value to grant SELECT permissions to different groups per schemas or optionally
+    you can create indices automatically for the replicated tables.
+  label: Schema Mapping
+  kind: object
+- name: add_metadata_columns
+  description:
+    Metadata columns add extra row level information about data ingestions,
+    (i.e. when was the row read in source, when was inserted or deleted in bigquery
+    etc.) Metadata columns are creating automatically by adding extra columns to the
+    tables with a column prefix _sdc_. The column names are following the stitch naming
+    conventions documented at https://www.stitchdata.com/docs/data-structure/integration-schemas#sdc-columns.
+    Enabling metadata columns will flag the deleted rows by setting the _sdc_deleted_at
+    metadata column. Without the add_metadata_columns option the deleted rows from
+    singer taps will not be recognisable in BigQuery.
+  kind: boolean
+  value: false
+  label: Add Metadata Columns
+- name: hard_delete
+  description:
+    When hard_delete option is true then DELETE SQL commands will be performed
+    in BigQuery to delete rows in tables. It's achieved by continuously checking the
+    _sdc_deleted_at metadata column sent by the singer tap. Due to deleting rows requires
+    metadata columns, hard_delete option automatically enables the add_metadata_columns
+    option as well.
+  label: Hard Delete
+  kind: boolean
+  value: false
+- name: data_flattening_max_level
+  description:
+    Object type RECORD items from taps can be loaded into VARIANT columns
+    as JSON (default) or we can flatten the schema by creating columns automatically.
+    When value is 0 (default) then flattening functionality is turned off.
+  label: Data Flattening Max Level
+  value: 0
+  kind: integer
+- name: primary_key_required
+  description:
+    Log based and Incremental replications on tables with no Primary Key
+    cause duplicates when merging UPDATE events. When set to true, stop loading data
+    if no Primary Key is defined.
+  label: Primary Key Required
+  kind: boolean
+  value: true
+- name: validate_records
+  description:
+    Validate every single record message to the corresponding JSON schema.
+    This option is disabled by default and invalid RECORD messages will fail only
+    at load time by BigQuery. Enabling this option will detect invalid records earlier
+    but could cause performance degradation.
+  kind: boolean
+  value: false
+  label: Validate Records
+- name: temp_schema
+  description:
+    Name of the schema where the temporary tables will be created. Will
+    default to the same schema as the target tables.
+  label: Temp Schema
 settings_group_validation:
-  - - dataset_id
-    - project_id
+- - dataset_id
+  - project_id
 pip_url: pipelinewise-target-bigquery
 repo: https://github.com/transferwise/pipelinewise-target-bigquery
 domain_url: https://cloud.google.com/bigquery/
 maintenance_status: active
-keywords: []
+keywords: 
+- google
+- bigquery


### PR DESCRIPTION
Incorrect target name on transferwise bigquery. 
Side-effect, causes hub page [here](https://hub.meltano.com/loaders/target-bigquery) to have wrong `variant` hard link which take you to a Page Not Found error. 

Also this also requires `GOOGLE_APPLICATION_CREDENTIALS` to be in the env vars when running so I have exposed the config option here which parallels the default variant.