### PR TITLE
More clear exception message when default variant not defined

### DIFF
--- a/_plugins/plugin_enricher.rb
+++ b/_plugins/plugin_enricher.rb
@@ -24,6 +24,9 @@ class PluginEnricher < Jekyll::Generator
     unsorted_hash = {}
     site.data['meltano'][meltano_type_plural].each do |plugin_name, variants|
       default_variant = defaults[plugin_name]
+      if default_variant.nil?
+        raise Exception.new "Default variant not defined for plugin: #{plugin_name}"
+      end
       enrich_variants(site, variants, default_variant, meltano_type_plural)
       unsorted_hash[plugin_name] = variants[default_variant]
 


### PR DESCRIPTION
We added the [default_variants.yml](https://github.com/meltano/hub/blob/main/_data/default_variants.yml) lookup file as part of the recent refactor. The purpose of having the lookup file is to allow us to change and look up the default variants much faster than having to iterate and opening up each variant definition file to get the `default` key value, its not that bad for a script but its painful for contributors when there are many variants. Also the default attribute is an attribute of the hub/meltano vs the actual plugin, so it made sense to pull it out.

We currently get a confusing error message when new plugins are added but they dont have a default variant set. Previously we were getting this error message which is confusing and not clear what is wrong:

```
/opt/build/repo/_plugins/plugin_enricher.rb:31:in `block in enrich_plugins': undefined method `fetch' for nil:NilClass (NoMethodError)
```

This PR changes it to:

```
Exception: Default variant not defined for plugin: tap-recruitee
```