### PR TITLE
Basic cache control from _headers file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,4 +63,4 @@ highlighter: rouge
 plugins:
   - jekyll-sitemap
 
-include: [_redirects]
+include: [_redirects, _headers]

--- a/_headers
+++ b/_headers
@@ -1,0 +1,3 @@
+/assets/logos/*
+    cache-control: max-age=604800
+    cache-control: public


### PR DESCRIPTION
Quick example of how to set cache control headers, the example includes all files in `/assets/logos/*` but we might want to include others. This should cover all the logos though which is bulk of the problem at the moment:

<img width="310" alt="Screen Shot 2022-06-22 at 2 09 37 PM" src="https://user-images.githubusercontent.com/333354/175117320-e3794a44-f413-4517-81bd-df615d47d0a5.png">
