### PR TITLE
move superset command comments out of the copy text

### DIFF
--- a/_data/meltano/utilities/superset/apache.yml
+++ b/_data/meltano/utilities/superset/apache.yml
@@ -91,14 +91,18 @@ next_steps: |
 
      ```sh
      meltano invoke superset:create-admin
-     # This is equivalent to `superset fab create-admin` in the Superset documentation
      ```
+
+     This is equivalent to `superset fab create-admin` in the Superset documentation
+
   1. Optionally, load some example data to play with:
 
      ```sh
      meltano invoke superset:load-examples
-     # This is equivalent to `superset load_examples` in the Superset documentation
      ```
+
+     This is equivalent to `superset load_examples` in the Superset documentation
+
   1. Launch the Superset UI and log in using the username/password you created:
 
      ```sh


### PR DESCRIPTION
I ran into a case where I used the copy to clipboard feature for `create-admin` which prompts for input, it looks like the comment text auto populates the first prompt which is the username. So after accepting the defaults I wasnt able to login. I ended up opening the db and saw the comment text as the username. Moving these out of the copy to clipboard section seemed fine.

I didnt notice at first but it skips the first prompted because it was auto filled:

![Screen Shot 2022-06-28 at 12 00 22 PM](https://user-images.githubusercontent.com/27376735/176226336-34f83c99-7e49-432d-9543-1007bd96519a.png)


![Screen Shot 2022-06-28 at 12 00 46 PM](https://user-images.githubusercontent.com/27376735/176226451-3ba4574e-0e26-4851-8594-8674a1f9d4aa.png)
