### PR TITLE
Update Matatika variant of tap-google-sheets with new settings

### DIFF
--- a/_data/meltano/extractors/tap-google-sheets/matatika.yml
+++ b/_data/meltano/extractors/tap-google-sheets/matatika.yml
@@ -32,6 +32,12 @@ settings:
 - name: sheet_id
   label: Sheet ID
   description: Google Sheet ID
+- name: stream_name
+  label: Stream Name
+  description: Optionally change the name of the output file or table. By default that tap will use the file name of your Google Sheet.
+- name: child_sheet_name
+  label: Child Sheet Name
+  description: Optionally pick a different sheet within your Google Sheet to sync data from. By default the tap will sync data from the first visible sheet in your Google Sheet.
 domain_url: https://developers.google.com/webmaster-tools/search-console-api-original/v3/how-tos/search_analytics
 maintenance_status: active
 keywords:


### PR DESCRIPTION
We added some new settings to our variant of `tap-google-sheets`. 

This PR updates our variant on the hub with these new settings.