### PR TITLE
Add action for daily rebuilds, grab new metrics

### DIFF
--- a/.github/workflows/daily_metrics_rebuild.yml
+++ b/.github/workflows/daily_metrics_rebuild.yml
@@ -3,6 +3,7 @@ name: nightly-netlify-build
 on:
   schedule:
     - cron: "15 9 * * *"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/daily_metrics_rebuild.yml
+++ b/.github/workflows/daily_metrics_rebuild.yml
@@ -1,0 +1,14 @@
+name: nightly-netlify-build
+
+on:
+  schedule:
+    - cron: "15 9 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: trigger netlify build
+        run: |
+          curl -X POST -d '{}' https://api.netlify.com/build_hooks/62c4902aa8c7b817c112c47b


### PR DESCRIPTION
Closes #640 

This action will be run 15 minutes after the updated plugin metrics are pushed to s3. Triggers a netlify rebuild via hook.
Will get us back to having fresh metrics every day

CC @tayloramurphy @aaronsteers 