### PR TITLE
dont default tap GA secrets location

### DIFF
--- a/_data/meltano/extractors/tap-google-analytics/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-google-analytics/meltanolabs.yml
@@ -28,9 +28,8 @@ settings_group_validation:
 settings:
 - name: key_file_location
   kind: file
-  value: $MELTANO_PROJECT_ROOT/client_secrets.json
   label: Client Secrets File Location
-  placeholder: Ex. client_secrets.json
+  placeholder: Ex. $MELTANO_PROJECT_ROOT/client_secrets.json
   description: |
     #### How to get
 


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/611

This was causing the Squared CI pipelines to fail once I locked the plugin definitions.