### PR TITLE
Fix link from Singer tap/target to Meltano extractor/loader page

### DIFF
--- a/_layouts/meltano_plugin.html
+++ b/_layouts/meltano_plugin.html
@@ -192,9 +192,9 @@ https://github.com/meltano/hub/blob/main/_data/meltano/{{page.meltano_type}}/{{p
     </p>
 
     {% if page.variant_specific %}
-      {% capture meltano_url %}{{page.meltano_type}}/{{page.name}}--{{plugin.variant}}#getting-started{% endcapture %}
+      {% capture meltano_url %}{{page.meltano_type}}/{{plugin.name}}--{{plugin.variant}}#getting-started{% endcapture %}
     {% else %}
-      {% capture meltano_url %}{{page.meltano_type}}/{{page.name}}#getting-started{% endcapture %}
+      {% capture meltano_url %}{{page.meltano_type}}/{{plugin.name}}#getting-started{% endcapture %}
     {% endif %}
 
     <p>


### PR DESCRIPTION
Would link to loaders/kinesis instead of loaders/target-kinesis.