### PR TITLE
Create pages for default plugins without variant

### DIFF
--- a/hub-2.0/ui/gridsome.server.js
+++ b/hub-2.0/ui/gridsome.server.js
@@ -11,7 +11,7 @@ const path = require("path");
 
 const dataRoot = "../../_data/";
 
-const defaultVariants = yaml.load(
+const defaultVariantData = yaml.load(
   fs.readFileSync(path.join(dataRoot, "default_variants.yml"))
 );
 
@@ -32,7 +32,7 @@ function buildData(dataPath, collection) {
       console.log(`${currentCollection}/${currentFolder}/${plugin}`);
       const readPlugin = yaml.load(fileContents);
       readPlugin.isDefault =
-        defaultVariants[path.basename(dataPath)][currentFolder] ===
+        defaultVariantData[path.basename(dataPath)][currentFolder] ===
         readPlugin.variant;
       readPlugin.pluginType = path.basename(dataPath).slice(0, -1);
       collection.addNode(readPlugin);
@@ -77,5 +77,83 @@ module.exports = function main(api) {
       transformersCollection
     );
     buildData(path.join(dataRoot, "meltano/utilities"), utilitiesCollection);
+  });
+
+  // Create defualt variant pages
+  api.createPages(async ({ createPage, graphql }) => {
+    const defaultPlugins = await graphql(`
+      {
+        allExtractors(filter: { isDefault: { eq: true } }) {
+          edges {
+            node {
+              id
+              path
+              name
+            }
+          }
+        }
+        allLoaders(filter: { isDefault: { eq: true } }) {
+          edges {
+            node {
+              id
+              path
+              name
+            }
+          }
+        }
+        allFiles(filter: { isDefault: { eq: true } }) {
+          edges {
+            node {
+              id
+              path
+              name
+            }
+          }
+        }
+        allOrchestrators(filter: { isDefault: { eq: true } }) {
+          edges {
+            node {
+              id
+              path
+              name
+            }
+          }
+        }
+        allTransformers(filter: { isDefault: { eq: true } }) {
+          edges {
+            node {
+              id
+              path
+              name
+            }
+          }
+        }
+        allUtilities(filter: { isDefault: { eq: true } }) {
+          edges {
+            node {
+              id
+              path
+              name
+            }
+          }
+        }
+      }
+    `);
+
+    Object.keys(defaultPlugins.data).forEach((query) => {
+      // For each default plugin we create an extra page one-level up
+      defaultPlugins.data[query].edges.forEach(({ node }) => {
+        createPage({
+          // Remove the variant part of the path
+          path: path.normalize(path.join(node.path, "..")),
+          // And send it to the same rendering template
+          component: `./src/templates/${query.substring(3)}.vue`,
+          context: {
+            id: node.id,
+            path: node.path,
+          },
+        });
+      });
+    });
   });
 };


### PR DESCRIPTION
Closes #655 

Rather than trying to create and manage redirects, I've instead set up some dynamic page generation that creates pages at
`/:type/:name` for each plugin which renders the same and uses the same data as `/:type/:name/:variant` when variant is the default.

You can see here after building the site that we end up with a new html file one level higher than the others:
![Screen Shot 2022-07-14 at 12 20 02 PM](https://user-images.githubusercontent.com/6589528/179047511-231bb3ed-6e23-4221-931f-73bb42fd4d1f.png)

It makes the site bundle slightly bigger but not by much.

Check it out here:

https://deploy-preview-671--meltano-hub-gridsome.netlify.app/extractors/tap-amazon-ads-dsp/

is the same as

https://deploy-preview-671--meltano-hub-gridsome.netlify.app/extractors/tap-amazon-ads-dsp/singer-io/
