### PR TITLE
Update search bar to include keywords

### DIFF
--- a/hub-2.0/ui/src/components/Search.vue
+++ b/hub-2.0/ui/src/components/Search.vue
@@ -50,11 +50,11 @@ export default {
         this.$static.allUtilities,
         this.$static.allTransformers,
       ];
-      return pluginCollections.flatMap((coll) =>
+      return pluginCollections.flatMap((coll) => 
         coll.edges.filter((plugin) => {
-          const pluginText =
-            plugin.node.name + plugin.node.description + plugin.node.label;
-          return pluginText
+          const pluginTextFields =
+            [plugin.node.name, plugin.node.description, plugin.node.label, plugin.node.keywords?.join(' ')]
+          return pluginTextFields.join(' ')
             .toLowerCase()
             .includes(this.search.toLowerCase().trim());
         })
@@ -76,6 +76,7 @@ query {
         name
         logo_url
         pluginType
+        keywords
       }
     }
   }
@@ -89,6 +90,7 @@ query {
         name
         logo_url
         pluginType
+        keywords
       }
     }
   }
@@ -126,6 +128,7 @@ query {
         name
         logo_url
         pluginType
+        keywords
       }
     }
   }


### PR DESCRIPTION
From a comment made by @aaronsteers [here](https://github.com/meltano/hub/pull/675#issuecomment-1187629484).

I forgot to include keywords in the search functionality and this makes it so they are searched now too.

![Screen Shot 2022-07-18 at 12 11 45 PM](https://user-images.githubusercontent.com/6589528/179566119-3b1d29c7-a302-4bf7-8752-a14fef8b2c12.png)

