### PR TITLE
Add build step for static JSON API

### DIFF
--- a/hub-2.0/ui/gridsome.server.js
+++ b/hub-2.0/ui/gridsome.server.js
@@ -8,6 +8,7 @@
 const fs = require("fs");
 const yaml = require("js-yaml");
 const path = require("path");
+const buildJSONApi = require("./src/api/plugins");
 
 const dataRoot = "../../_data/";
 
@@ -69,6 +70,12 @@ module.exports = function main(api) {
     const transformersCollection = actions.addCollection({
       typeName: "Transformers",
     });
+    const transformsCollection = actions.addCollection({
+      typeName: "Transforms",
+    });
+    const mappersCollection = actions.addCollection({
+      typeName: "Mappers",
+    });
     const utilitiesCollection = actions.addCollection({
       typeName: "Utilities",
     });
@@ -87,6 +94,8 @@ module.exports = function main(api) {
       path.join(dataRoot, "meltano/transformers"),
       transformersCollection
     );
+    buildData(path.join(dataRoot, "meltano/transforms"), transformsCollection);
+    buildData(path.join(dataRoot, "meltano/mappers"), mappersCollection);
     buildData(path.join(dataRoot, "meltano/utilities"), utilitiesCollection);
     buildMaintainers(readMaintainers, maintainersCollection);
   });
@@ -168,4 +177,7 @@ module.exports = function main(api) {
       });
     });
   });
+
+  // Build JSON files to serve the static Meltano API
+  buildJSONApi(api);
 };

--- a/hub-2.0/ui/package.json
+++ b/hub-2.0/ui/package.json
@@ -11,8 +11,10 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
+    "graphql-tag": "^2.12.6",
     "gridsome": "^0.7.0",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "write": "^2.0.0"
   },
   "resolutions": {
     "gridsome/sharp": "0.29.3"

--- a/hub-2.0/ui/src/api/plugins.js
+++ b/hub-2.0/ui/src/api/plugins.js
@@ -176,7 +176,7 @@ module.exports = function buildJSONApi(gridsome) {
               };
               if (plugin.isDefault) {
                 indexEntry.default_variant = plugin.variant;
-                indexEntry.logo_url = plugin.logo_url || null;
+                indexEntry.logo_url = logoUrl || null;
               }
               typeIndex[plugin.name] = indexEntry;
 

--- a/hub-2.0/ui/src/api/plugins.js
+++ b/hub-2.0/ui/src/api/plugins.js
@@ -1,0 +1,205 @@
+const write = require("write");
+const path = require("path");
+const { gql } = require("graphql-tag");
+
+const outputRoot = "dist/meltano/api/v1/plugins";
+
+const fieldFragment = gql`
+  fragment Fields on Node {
+    description
+    label
+    name
+    namespace
+    logo_url
+    variant
+    pip_url
+    repo
+    settings {
+      name
+      kind
+      label
+      description
+      value
+      env
+      options {
+        label
+        value
+      }
+      aliases
+      value_post_processor
+      value_processor
+      placeholder
+    }
+    capabilities
+  }
+`;
+const apiRoutes = [
+  {
+    query: gql`
+      ${fieldFragment}
+      {
+        data: allExtractors {
+          edges {
+            node {
+              ...Fields
+            }
+          }
+        }
+      }
+    `,
+    path: "extractors",
+  },
+  {
+    query: gql`
+      ${fieldFragment}
+      {
+        data: allLoaders {
+          edges {
+            node {
+              ...Fields
+            }
+          }
+        }
+      }
+    `,
+    path: "loaders",
+  },
+  {
+    query: gql`
+      ${fieldFragment}
+      {
+        data: allFiles {
+          edges {
+            node {
+              ...Fields
+            }
+          }
+        }
+      }
+    `,
+    path: "files",
+  },
+  {
+    query: gql`
+      ${fieldFragment}
+      {
+        data: allMappers {
+          edges {
+            node {
+              ...Fields
+            }
+          }
+        }
+      }
+    `,
+    path: "mappers",
+  },
+  {
+    query: gql`
+      ${fieldFragment}
+      {
+        data: allOrchestrators {
+          edges {
+            node {
+              ...Fields
+            }
+          }
+        }
+      }
+    `,
+    path: "orchestrators",
+  },
+  {
+    query: gql`
+      ${fieldFragment}
+      {
+        data: allTransformers {
+          edges {
+            node {
+              ...Fields
+            }
+          }
+        }
+      }
+    `,
+    path: "transformers",
+  },
+  {
+    query: gql`
+      ${fieldFragment}
+      {
+        data: allTransforms {
+          edges {
+            node {
+              ...Fields
+            }
+          }
+        }
+      }
+    `,
+    path: "transforms",
+  },
+  {
+    query: gql`
+      ${fieldFragment}
+      {
+        data: allUtilities {
+          edges {
+            node {
+              ...Fields
+            }
+          }
+        }
+      }
+    `,
+    path: "utilities",
+  },
+];
+
+const removeEmpty = (obj) => {
+  Object.entries(obj).forEach(
+    ([key, val]) =>
+      (val && typeof val === "object" && removeEmpty(val)) ||
+      // eslint-disable-next-line no-param-reassign
+      ((val === null || val === "") && delete obj[key])
+  );
+  return obj;
+};
+
+module.exports = function buildJSONApi(gridsome) {
+  gridsome.afterBuild(async () => {
+    const allPlugins = [];
+    const promises = apiRoutes.map(async (item) => {
+      try {
+        // eslint-disable-next-line no-underscore-dangle
+        const result = await gridsome._app.graphql(item.query);
+        const allPluginsOfType = [];
+        result.data.data.edges.map(async (edge) => {
+          const plugin = removeEmpty(edge.node);
+          allPluginsOfType.push(plugin);
+          allPlugins.push(plugin);
+          write(
+            path.join(
+              outputRoot,
+              item.path,
+              `${plugin.name}--${plugin.variant}`
+            ),
+            JSON.stringify(plugin)
+          );
+        });
+        return write(
+          path.join(outputRoot, item.path, "index"),
+          JSON.stringify(allPluginsOfType)
+        );
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        throw e;
+      }
+    });
+    // wait for all promises to finish
+    await Promise.all(promises);
+
+    return write(path.join(outputRoot, "index"), JSON.stringify(allPlugins));
+  });
+};

--- a/hub-2.0/ui/yarn.lock
+++ b/hub-2.0/ui/yarn.lock
@@ -1517,6 +1517,13 @@ acorn@^8.7.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
+add-filename-increment@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/add-filename-increment/-/add-filename-increment-1.0.0.tgz#106feea10dcda5d2bfe25a5e83d347382f9dd97d"
+  integrity sha512-pFV8VZX8jxuVMIycKvGZkWF/ihnUubu9lbQVnOnZWp7noVxbKQTNj7zG2y9fXdPcuZ6lAN3Drr517HaivGCjdQ==
+  dependencies:
+    strip-filename-increment "^2.0.1"
+
 address@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/address/-/address-1.2.0.tgz#d352a62c92fee90f89a693eccd2a8b2139ab02d9"
@@ -4640,6 +4647,13 @@ graphql-playground-middleware-express@^1.7.12:
   integrity sha512-M/zbTyC1rkgiQjFSgmzAv6umMHOphYLNWZp6Ye5QrD77WfGOOoSqDsVmGUczc2pDkEPEzzGB/bvBO5rdzaTRgw==
   dependencies:
     graphql-playground-html "^1.6.30"
+
+graphql-tag@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
 
 graphql-type-json@0.3.2:
   version "0.3.2"
@@ -8626,6 +8640,11 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==
 
+strip-filename-increment@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-filename-increment/-/strip-filename-increment-2.0.1.tgz#3feca2ebd529d4cdcad0281a9bbb2660b096fcc6"
+  integrity sha512-+v5xsiTTsdYqkPj7qz1zlngIsjZedhHDi3xp/9bMurV8kXe9DAr732gNVqtt4X8sI3hOqS3nlFfps5gyVcux6w==
+
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -8926,6 +8945,11 @@ tsconfig-paths@^3.14.1:
     json5 "^1.0.1"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
+
+tslib@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -9579,6 +9603,13 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+write@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/write/-/write-2.0.0.tgz#d6320a5f764fbd6ee93022f61273d62fa23dbd04"
+  integrity sha512-yam9TAqN8sAZokECAejo9HpT2j2s39OgK8i8yxadrFBVo+iSWLfnipRVFulfAw1d2dz5vSuGmlMHYRKG4fysOA==
+  dependencies:
+    add-filename-increment "^1.0.0"
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This replicates the existing API structure and builds it as part of `gridsome build`.

Schema validation passes:

```bash

# New build
poetry run python utility_scripts/api/api_schema_validate.py hub-2.0/ui/dist/meltano/api/v1/plugins/
INFO:api_schema_validate.py:API schema validation started...
INFO:api_schema_validate.py:Validating API schema for plugin type: utilities
INFO:api_schema_validate.py:Validating API schema for plugin type: orchestrators
INFO:api_schema_validate.py:Validating API schema for plugin type: transforms
INFO:api_schema_validate.py:Validating API schema for plugin type: transformers
INFO:api_schema_validate.py:Validating API schema for plugin type: files
INFO:api_schema_validate.py:Validating API schema for plugin type: mappers
INFO:api_schema_validate.py:Validating API schema for plugin type: extractors
INFO:api_schema_validate.py:Validating API schema for plugin type: loaders
INFO:api_schema_validate.py:API schema validation complete.
INFO:api_schema_validate.py:All plugins pass the JSON Schema.
INFO:api_schema_validate.py:{
    "extractors": 554,
    "files": 11,
    "loaders": 41,
    "mappers": 2,
    "orchestrators": 1,
    "transformers": 5,
    "transforms": 9,
    "utilities": 4
}

# Old build
poetry run python utility_scripts/api/api_schema_validate.py _site/meltano/api/v1/plugins/
INFO:api_schema_validate.py:API schema validation started...
INFO:api_schema_validate.py:Validating API schema for plugin type: utilities
INFO:api_schema_validate.py:Validating API schema for plugin type: orchestrators
INFO:api_schema_validate.py:Validating API schema for plugin type: transforms
INFO:api_schema_validate.py:Validating API schema for plugin type: transformers
INFO:api_schema_validate.py:Validating API schema for plugin type: files
INFO:api_schema_validate.py:Validating API schema for plugin type: mappers
INFO:api_schema_validate.py:Validating API schema for plugin type: extractors
INFO:api_schema_validate.py:Validating API schema for plugin type: loaders
INFO:api_schema_validate.py:API schema validation complete.
INFO:api_schema_validate.py:All plugins pass the JSON Schema.
INFO:api_schema_validate.py:{
    "extractors": 554,
    "files": 11,
    "loaders": 41,
    "mappers": 2,
    "orchestrators": 1,
    "transformers": 5,
    "transforms": 9,
    "utilities": 4
}
```

