### PR TITLE
Set gthesheep TikTok tap variant to default

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -304,7 +304,7 @@ extractors:
   tap-thinkific: birdiecare
   tap-thunderboard: matatika
   tap-tickettailor: fishtown-analytics
-  tap-tiktok: uptilab2
+  tap-tiktok: gthesheep
   tap-timebutler: taikonauten
   tap-toast: lambtron
   tap-toggl: singer-io

--- a/_data/meltano/extractors/tap-tiktok/gthesheep.yml
+++ b/_data/meltano/extractors/tap-tiktok/gthesheep.yml
@@ -4,6 +4,7 @@ name: tap-tiktok
 logo_url: /assets/logos/extractors/tiktok.png
 namespace: tap_tiktok
 variant: gthesheep
+default: true
 pip_url: git+https://github.com/gthesheep/tap-tiktok.git
 repo: https://github.com/gthesheep/tap-tiktok
 capabilities:

--- a/_data/meltano/extractors/tap-tiktok/gthesheep.yml
+++ b/_data/meltano/extractors/tap-tiktok/gthesheep.yml
@@ -4,7 +4,6 @@ name: tap-tiktok
 logo_url: /assets/logos/extractors/tiktok.png
 namespace: tap_tiktok
 variant: gthesheep
-default: true
 pip_url: git+https://github.com/gthesheep/tap-tiktok.git
 repo: https://github.com/gthesheep/tap-tiktok
 capabilities:


### PR DESCRIPTION
## Checklist

- [x] Add/update the file in the appropriate folder (`/taps` or `/targets`). The name of the file should match the name of the tap. If there is already one, add a descriptor to the name such as `-search`.
- [x] Add/update the PNG logo image in `/assets/logos/<taps or targets>`. The image name must match the YAML file name.
- [x] Tag `@tayloramurphy` or `@pnadolny13` to flag it for review. Or post to the [#hub](https://meltano.slack.com/archives/C01UGBSJNG5) channel on Meltano slack.

## Reviewer Checklist

- [ ] Validate file against JSON Schema. https://www.jsonschema.net/home is an option.
- [ ] Build website locally and validate everything works.

@pnadolny13 @tayloramurphy - the difference between the 2 taps appears to be the inclusion of [reservation ads](https://github.com/uptilab2/tap-tiktok/blob/main/tap_tiktok/streams.py) based on the schema, I've added a [task](https://github.com/GtheSheep/tap-tiktok/issues/1) to my repo to add these as I'll be working on the tap this week anyway to add audience stats