### PR TITLE
singer-io referencing wintersd package

### DIFF
--- a/_data/meltano/extractors/tap-mssql/singer-io.yml
+++ b/_data/meltano/extractors/tap-mssql/singer-io.yml
@@ -4,7 +4,7 @@ name: tap-mssql
 logo_url: /assets/logos/extractors/mssql.png
 namespace: tap_mssql
 variant: singer-io
-pip_url: tap-mssql
+pip_url: git+https://github.com/singer-io/tap-mssql.git
 repo: https://github.com/singer-io/tap-mssql
 settings: []
 capabilities:


### PR DESCRIPTION
This singer-io variant was referencing the pypi package which is wrong. This was a bit confusing but it actually looks like the tap-mssql on [pypi](https://pypi.org/project/tap-mssql/#history) is the wintersd variant which is a fork of the pipelinewise variant. Usually the singer-io variants have the pypi namespace and the pipelinewise version has the "pipelinewise-" prefix, so I see why we got confused. As far as I can see the only way to install the singer variant is to use the git url.