### PR TITLE
unpin target-gcs because it wasnt a valid release

### DIFF
--- a/_data/meltano/loaders/target-gcs/datateer.yml
+++ b/_data/meltano/loaders/target-gcs/datateer.yml
@@ -5,7 +5,7 @@ namespace: target_gcs
 logo_url: /assets/logos/loaders/gcs.png
 variant: datateer
 repo: https://github.com/Datateer/target-gcs
-pip_url: git+https://github.com/Datateer/target-gcs.git@0.11.3
+pip_url: git+https://github.com/Datateer/target-gcs.git
 settings_group_validation:
 - - bucket_name
   - credentials_file


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/708

cc @jerrydeng 