### PR TITLE
Add missing state capability for extractors

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -77,7 +77,6 @@ extractors:
   tap-brightpearl: zookal
   tap-bronto: fishtown-analytics
   tap-bynder: radico
-  tap-call-cap: llazarovgannett
   tap-campaign-monitor: singer-io
   tap-carbon-intensity: meltano
   tap-centra: icebug

--- a/_data/meltano/extractors/singer-tap-zenhub/chillu.yml
+++ b/_data/meltano/extractors/singer-tap-zenhub/chillu.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://github.com/ZenHubIO/API
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-3plcentral/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-3plcentral/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.3plcentral.com
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-3plcentral/singer-io.yml
+++ b/_data/meltano/extractors/tap-3plcentral/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.3plcentral.com
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-abcfinancial/dmzobel.yml
+++ b/_data/meltano/extractors/tap-abcfinancial/dmzobel.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://abcfinancial.3scale.net
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-activecampaign/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-activecampaign/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.activecampaign.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-activecampaign/singer-io.yml
+++ b/_data/meltano/extractors/tap-activecampaign/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.activecampaign.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-adyen/yoast.yml
+++ b/_data/meltano/extractors/tap-adyen/yoast.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.adyen.com/reporting
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-amazon-ads-dsp/goes-funky.yml
+++ b/_data/meltano/extractors/tap-amazon-ads-dsp/goes-funky.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://advertising.amazon.com/API/docs/en-us/dsp-reports-beta-3p/#/Reports
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-amazon-ads-dsp/isabella232.yml
+++ b/_data/meltano/extractors/tap-amazon-ads-dsp/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://advertising.amazon.com/API/docs/en-us/dsp-reports-beta-3p/#/Reports
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-amazon-ads-dsp/schonfeld.yml
+++ b/_data/meltano/extractors/tap-amazon-ads-dsp/schonfeld.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://advertising.amazon.com/API/docs/en-us/dsp-reports-beta-3p/#/Reports
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-amazon-ads-dsp/singer-io.yml
+++ b/_data/meltano/extractors/tap-amazon-ads-dsp/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://advertising.amazon.com/API/docs/en-us/dsp-reports-beta-3p/#/Reports
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-anaplan/kdamodaran1.yml
+++ b/_data/meltano/extractors/tap-anaplan/kdamodaran1.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.anaplan.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-anaplan/matthew-skinner.yml
+++ b/_data/meltano/extractors/tap-anaplan/matthew-skinner.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.anaplan.com/
 maintenance_status: active
 keywords:

--- a/_data/meltano/extractors/tap-appstore/miroapp.yml
+++ b/_data/meltano/extractors/tap-appstore/miroapp.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.apple.com/app-store-connect/api/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-autopilot/singer-io.yml
+++ b/_data/meltano/extractors/tap-autopilot/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://autopilotapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-autopilot/wcjohnson11.yml
+++ b/_data/meltano/extractors/tap-autopilot/wcjohnson11.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://autopilotapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-basecone/yoast.yml
+++ b/_data/meltano/extractors/tap-basecone/yoast.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.basecone.com/ApiReference/General
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-bigcommerce/singer-io.yml
+++ b/_data/meltano/extractors/tap-bigcommerce/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.bigcommerce.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-billwerk/bi-media.yml
+++ b/_data/meltano/extractors/tap-billwerk/bi-media.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://billwerk.io/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-bls/frasermarlow.yml
+++ b/_data/meltano/extractors/tap-bls/frasermarlow.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.bls.gov
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-braintree/singer-io.yml
+++ b/_data/meltano/extractors/tap-braintree/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.paypal.com/braintree/docs/start/overview
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-brightpearl/zookal.yml
+++ b/_data/meltano/extractors/tap-brightpearl/zookal.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.brightpearl.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-bynder/radico.yml
+++ b/_data/meltano/extractors/tap-bynder/radico.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.bynder.com/en/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-carbon-intensity/meltano.yml
+++ b/_data/meltano/extractors/tap-carbon-intensity/meltano.yml
@@ -9,6 +9,8 @@ repo: https://gitlab.com/meltano/tap-carbon-intensity
 pip_url: git+https://gitlab.com/meltano/tap-carbon-intensity.git
 capabilities:
 - discover
+- state
+- catalog
 domain_url: https://api.carbonintensity.org.uk/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-closeio/singer-io.yml
+++ b/_data/meltano/extractors/tap-closeio/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://close.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-clubhouse/envoy.yml
+++ b/_data/meltano/extractors/tap-clubhouse/envoy.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://clubhouse.io/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-clubspeed/lambtron.yml
+++ b/_data/meltano/extractors/tap-clubspeed/lambtron.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://clubspeed.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-contentful/dmzobel.yml
+++ b/_data/meltano/extractors/tap-contentful/dmzobel.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.contentful.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-coosto/yoast.yml
+++ b/_data/meltano/extractors/tap-coosto/yoast.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.coosto.com/en
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-criteo/jude188.yml
+++ b/_data/meltano/extractors/tap-criteo/jude188.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.criteo.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-csv/robertjmoore.yml
+++ b/_data/meltano/extractors/tap-csv/robertjmoore.yml
@@ -9,6 +9,7 @@ repo: https://github.com/robertjmoore/tap-csv
 capabilities:
 - discover
 - catalog
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://en.wikipedia.org/wiki/Comma-separated_values

--- a/_data/meltano/extractors/tap-customerx/rafaeljusi.yml
+++ b/_data/meltano/extractors/tap-customerx/rafaeljusi.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://doc.api.customerx.com.br/?version=latest
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dayforce/goodeggs.yml
+++ b/_data/meltano/extractors/tap-dayforce/goodeggs.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.ceridian.com/products/dayforce
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-db2/singer-io.yml
+++ b/_data/meltano/extractors/tap-db2/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.ibm.com/analytics/db2
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-density/envoy.yml
+++ b/_data/meltano/extractors/tap-density/envoy.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.density.io/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamics/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-dynamics/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/use-microsoft-dynamics-365-web-api
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/ahuynh3.yml
+++ b/_data/meltano/extractors/tap-dynamodb/ahuynh3.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/cosimon.yml
+++ b/_data/meltano/extractors/tap-dynamodb/cosimon.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/fixdauto.yml
+++ b/_data/meltano/extractors/tap-dynamodb/fixdauto.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/henriblancke.yml
+++ b/_data/meltano/extractors/tap-dynamodb/henriblancke.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/jannikweichert.yml
+++ b/_data/meltano/extractors/tap-dynamodb/jannikweichert.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/krillw.yml
+++ b/_data/meltano/extractors/tap-dynamodb/krillw.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/onemedical.yml
+++ b/_data/meltano/extractors/tap-dynamodb/onemedical.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/rpaterson.yml
+++ b/_data/meltano/extractors/tap-dynamodb/rpaterson.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-dynamodb/singer-io.yml
+++ b/_data/meltano/extractors/tap-dynamodb/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/dynamodb/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-eloqua/radico.yml
+++ b/_data/meltano/extractors/tap-eloqua/radico.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.oracle.com/en/cloud/saas/marketing/eloqua-develop/Developers/BulkAPI/Tutorials/Export.htm
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-exactsales/rafaeljusi.yml
+++ b/_data/meltano/extractors/tap-exactsales/rafaeljusi.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://exactdev.docs.apiary.io/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-facebook-posts/rowanv.yml
+++ b/_data/meltano/extractors/tap-facebook-posts/rowanv.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.facebook.com/docs/graph-api
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-facebook/hbellala.yml
+++ b/_data/meltano/extractors/tap-facebook/hbellala.yml
@@ -9,6 +9,7 @@ repo: https://github.com/hbellala/tap-facebook
 capabilities:
 - properties
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://developers.facebook.com/docs/marketing-apis

--- a/_data/meltano/extractors/tap-facebook/primedata-ai.yml
+++ b/_data/meltano/extractors/tap-facebook/primedata-ai.yml
@@ -7,6 +7,7 @@ variant: primedata-ai
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/primedata-ai/tap-facebook.git

--- a/_data/meltano/extractors/tap-fixerio/angaza.yml
+++ b/_data/meltano/extractors/tap-fixerio/angaza.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://fixer.io/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-fixerio/ebunt.yml
+++ b/_data/meltano/extractors/tap-fixerio/ebunt.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://fixer.io/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-fixerio/einartg.yml
+++ b/_data/meltano/extractors/tap-fixerio/einartg.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://fixer.io/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-fixerio/haaspt.yml
+++ b/_data/meltano/extractors/tap-fixerio/haaspt.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://fixer.io/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-fixerio/isabella232.yml
+++ b/_data/meltano/extractors/tap-fixerio/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://fixer.io/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-fixerio/lpillmann.yml
+++ b/_data/meltano/extractors/tap-fixerio/lpillmann.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://fixer.io/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-fixerio/singer-io.yml
+++ b/_data/meltano/extractors/tap-fixerio/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://fixer.io/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-freshdesk/singer-io.yml
+++ b/_data/meltano/extractors/tap-freshdesk/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.freshdesk.com/api/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-frontapp/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-frontapp/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://frontapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-frontapp/singer-io.yml
+++ b/_data/meltano/extractors/tap-frontapp/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://frontapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-fullstory/singer-io.yml
+++ b/_data/meltano/extractors/tap-fullstory/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.fullstory.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-gitlab/singer-io.yml
+++ b/_data/meltano/extractors/tap-gitlab/singer-io.yml
@@ -7,6 +7,7 @@ variant: singer-io
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: tap-gitlab

--- a/_data/meltano/extractors/tap-gmail-csv/food-spotter.yml
+++ b/_data/meltano/extractors/tap-gmail-csv/food-spotter.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.google.com/gmail/about/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-google-analytics/saidtezel.yml
+++ b/_data/meltano/extractors/tap-google-analytics/saidtezel.yml
@@ -9,6 +9,7 @@ repo: https://github.com/saidtezel/tap-google-analytics
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://developers.google.com/analytics/devguides/reporting/core/v4/

--- a/_data/meltano/extractors/tap-google-analytics/transferwise.yml
+++ b/_data/meltano/extractors/tap-google-analytics/transferwise.yml
@@ -9,6 +9,7 @@ repo: https://github.com/transferwise/pipelinewise-tap-google-analytics
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://developers.google.com/analytics/devguides/reporting/core/v4/

--- a/_data/meltano/extractors/tap-google-search-console/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-google-search-console/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.google.com/webmaster-tools/search-console-api-original/v3/how-tos/search_analytics
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-google-search-console/singer-io.yml
+++ b/_data/meltano/extractors/tap-google-search-console/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.google.com/webmaster-tools/search-console-api-original/v3/how-tos/search_analytics
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-google-sheets/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-google-sheets/bytecodeio.yml
@@ -9,6 +9,7 @@ repo: https://github.com/bytecodeio/tap-google-sheets
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 domain_url: https://developers.google.com/webmaster-tools/search-console-api-original/v3/how-tos/search_analytics

--- a/_data/meltano/extractors/tap-harvest-forecast/assembleinc.yml
+++ b/_data/meltano/extractors/tap-harvest-forecast/assembleinc.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://help.getharvest.com/api-v2/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-harvest-forecast/singer-io.yml
+++ b/_data/meltano/extractors/tap-harvest-forecast/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://help.getharvest.com/api-v2/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-harvest/singer-io.yml
+++ b/_data/meltano/extractors/tap-harvest/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://help.getharvest.com/api-v2/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-helpscout/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-helpscout/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.helpscout.com/mailbox-api/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-helpscout/singer-io.yml
+++ b/_data/meltano/extractors/tap-helpscout/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.helpscout.com/mailbox-api/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-holidays/goodeggs.yml
+++ b/_data/meltano/extractors/tap-holidays/goodeggs.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://holidayapi.com/docs
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ilevel/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-ilevel/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://ihsmarkit.com/products/ilevel.html
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ilevel/singer-io.yml
+++ b/_data/meltano/extractors/tap-ilevel/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://ihsmarkit.com/products/ilevel.html
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-impact/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-impact/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.impact.com/default
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-impact/singer-io.yml
+++ b/_data/meltano/extractors/tap-impact/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.impact.com/default
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-intercom/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-intercom/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.intercom.com/intercom-api-reference/v1.4/reference
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ireckonu/mashey.yml
+++ b/_data/meltano/extractors/tap-ireckonu/mashey.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://ireckonu.com/Content/Product/IRECKONU%20CORE
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kafka/gadget-inc.yml
+++ b/_data/meltano/extractors/tap-kafka/gadget-inc.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://kafka.apache.org/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kafka/isabella232.yml
+++ b/_data/meltano/extractors/tap-kafka/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://kafka.apache.org/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kafka/koszti.yml
+++ b/_data/meltano/extractors/tap-kafka/koszti.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://kafka.apache.org/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kafka/pbegle.yml
+++ b/_data/meltano/extractors/tap-kafka/pbegle.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://kafka.apache.org/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kafka/singer-io.yml
+++ b/_data/meltano/extractors/tap-kafka/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://kafka.apache.org/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kafka/stvhanna.yml
+++ b/_data/meltano/extractors/tap-kafka/stvhanna.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://kafka.apache.org/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-klaviyo/codyss.yml
+++ b/_data/meltano/extractors/tap-klaviyo/codyss.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://apidocs.klaviyo.com/reference/metrics
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/beamtech.yml
+++ b/_data/meltano/extractors/tap-kustomer/beamtech.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-kustomer/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/cdolan-summersalt.yml
+++ b/_data/meltano/extractors/tap-kustomer/cdolan-summersalt.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/drueffect.yml
+++ b/_data/meltano/extractors/tap-kustomer/drueffect.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/emrom1008.yml
+++ b/_data/meltano/extractors/tap-kustomer/emrom1008.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/isabella232.yml
+++ b/_data/meltano/extractors/tap-kustomer/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/jeffhuth-bytecode.yml
+++ b/_data/meltano/extractors/tap-kustomer/jeffhuth-bytecode.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/pathlight.yml
+++ b/_data/meltano/extractors/tap-kustomer/pathlight.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/rossbrg.yml
+++ b/_data/meltano/extractors/tap-kustomer/rossbrg.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kustomer/singer-io.yml
+++ b/_data/meltano/extractors/tap-kustomer/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.kustomerapp.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-kwanko/uptilab2.yml
+++ b/_data/meltano/extractors/tap-kwanko/uptilab2.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://platform.kwanko.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-linkedin-ads/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-linkedin-ads/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.microsoft.com/en-us/linkedin/marketing/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-linkedin-ads/singer-io.yml
+++ b/_data/meltano/extractors/tap-linkedin-ads/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.microsoft.com/en-us/linkedin/marketing/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-listen360/radico.yml
+++ b/_data/meltano/extractors/tap-listen360/radico.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.listen360.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-looker/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-looker/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.looker.com/reference/api-and-integration/api-reference/v3.1
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-looker/singer-io.yml
+++ b/_data/meltano/extractors/tap-looker/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.looker.com/reference/api-and-integration/api-reference/v3.1
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-lookml/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-lookml/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.looker.com/reference/api-and-integration/api-reference/v3.1
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-lookml/singer-io.yml
+++ b/_data/meltano/extractors/tap-lookml/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.looker.com/reference/api-and-integration/api-reference/v3.1
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-loopreturns/loopreturns.yml
+++ b/_data/meltano/extractors/tap-loopreturns/loopreturns.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.loopreturns.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mailchimp/lovepopcards.yml
+++ b/_data/meltano/extractors/tap-mailchimp/lovepopcards.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://mailchimp.com/developer/marketing/api/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mailgun/streetteam.yml
+++ b/_data/meltano/extractors/tap-mailgun/streetteam.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://documentation.mailgun.com/en/latest/api_reference.html
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mailshake/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-mailshake/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api-docs.mailshake.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mailshake/singer-io.yml
+++ b/_data/meltano/extractors/tap-mailshake/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api-docs.mailshake.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mambu/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-mambu/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.mambu.com/?shell
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mambu/singer-io.yml
+++ b/_data/meltano/extractors/tap-mambu/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.mambu.com/?shell
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mixpanel/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-mixpanel/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://mixpanel.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mixpanel/transferwise.yml
+++ b/_data/meltano/extractors/tap-mixpanel/transferwise.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://mixpanel.com/
 maintenance_status: active
 keywords:

--- a/_data/meltano/extractors/tap-mongodb/checkr.yml
+++ b/_data/meltano/extractors/tap-mongodb/checkr.yml
@@ -9,6 +9,7 @@ repo: https://github.com/checkr/tap-mongodb
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://www.mongodb.com/

--- a/_data/meltano/extractors/tap-mongodb/luandy64.yml
+++ b/_data/meltano/extractors/tap-mongodb/luandy64.yml
@@ -9,6 +9,7 @@ repo: https://github.com/luandy64/tap-mongodb
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://www.mongodb.com/

--- a/_data/meltano/extractors/tap-mongodb/madlittlemods.yml
+++ b/_data/meltano/extractors/tap-mongodb/madlittlemods.yml
@@ -9,6 +9,7 @@ repo: https://github.com/MadLittleMods/tap-mongodb
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://www.mongodb.com/

--- a/_data/meltano/extractors/tap-mongodb/rudybear.yml
+++ b/_data/meltano/extractors/tap-mongodb/rudybear.yml
@@ -9,6 +9,7 @@ repo: https://github.com/rudybear/tap-mongodb
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://www.mongodb.com/

--- a/_data/meltano/extractors/tap-mongodb/stvhanna.yml
+++ b/_data/meltano/extractors/tap-mongodb/stvhanna.yml
@@ -9,6 +9,7 @@ repo: https://github.com/stvhanna/tap-mongodb
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://www.mongodb.com/

--- a/_data/meltano/extractors/tap-mongodb/transferwise.yml
+++ b/_data/meltano/extractors/tap-mongodb/transferwise.yml
@@ -9,6 +9,7 @@ repo: https://github.com/transferwise/pipelinewise-tap-mongodb
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://www.mongodb.com/

--- a/_data/meltano/extractors/tap-ms-teams/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-ms-teams/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.microsoft.com/en-us/graph/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ms-teams/isabella232.yml
+++ b/_data/meltano/extractors/tap-ms-teams/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.microsoft.com/en-us/graph/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ms-teams/mauricio87.yml
+++ b/_data/meltano/extractors/tap-ms-teams/mauricio87.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.microsoft.com/en-us/graph/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ms-teams/singer-io.yml
+++ b/_data/meltano/extractors/tap-ms-teams/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.microsoft.com/en-us/graph/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mssql/singer-io.yml
+++ b/_data/meltano/extractors/tap-mssql/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.microsoft.com/en-us/sql-server/sql-server-2019
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-mysql/singer-io.yml
+++ b/_data/meltano/extractors/tap-mysql/singer-io.yml
@@ -9,6 +9,7 @@ repo: https://github.com/singer-io/tap-mysql
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation: []
 settings: []
 domain_url: https://www.mysql.com/

--- a/_data/meltano/extractors/tap-nikabot/phdesign.yml
+++ b/_data/meltano/extractors/tap-nikabot/phdesign.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.nikabot.com/swagger-ui.html#/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ordway/mozartdata.yml
+++ b/_data/meltano/extractors/tap-ordway/mozartdata.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.ordwaylabs.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ordway/mubarakrocky.yml
+++ b/_data/meltano/extractors/tap-ordway/mubarakrocky.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.ordwaylabs.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ordway/singer-io.yml
+++ b/_data/meltano/extractors/tap-ordway/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.ordwaylabs.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-outbrain/fishtown-analytics.yml
+++ b/_data/meltano/extractors/tap-outbrain/fishtown-analytics.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.outbrain.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-paypal/yoast.yml
+++ b/_data/meltano/extractors/tap-paypal/yoast.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.paypal.com/us/home
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-pendo/alisa-aylward-toast.yml
+++ b/_data/meltano/extractors/tap-pendo/alisa-aylward-toast.yml
@@ -7,6 +7,7 @@ variant: alisa-aylward-toast
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/alisa-aylward-toast/tap-pendo.git

--- a/_data/meltano/extractors/tap-pendo/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-pendo/bytecodeio.yml
@@ -7,6 +7,7 @@ variant: bytecodeio
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/bytecodeio/tap-pendo.git

--- a/_data/meltano/extractors/tap-pendo/diegobatt.yml
+++ b/_data/meltano/extractors/tap-pendo/diegobatt.yml
@@ -7,6 +7,7 @@ variant: diegobatt
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/diegobatt/tap-pendo.git

--- a/_data/meltano/extractors/tap-pendo/isabella232.yml
+++ b/_data/meltano/extractors/tap-pendo/isabella232.yml
@@ -7,6 +7,7 @@ variant: isabella232
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/isabella232/tap-pendo.git

--- a/_data/meltano/extractors/tap-pendo/jeffhuth-bytecode.yml
+++ b/_data/meltano/extractors/tap-pendo/jeffhuth-bytecode.yml
@@ -7,6 +7,7 @@ variant: jeffhuth-bytecode
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/jeffhuth-bytecode/tap-pendo.git

--- a/_data/meltano/extractors/tap-pepperjam/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-pepperjam/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://support.pepperjam.com/s/advertiser-api-documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-pepperjam/singer-io.yml
+++ b/_data/meltano/extractors/tap-pepperjam/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://support.pepperjam.com/s/advertiser-api-documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-persistiq/nickleomartin.yml
+++ b/_data/meltano/extractors/tap-persistiq/nickleomartin.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://apidocs.persistiq.com/#introduction
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-pivotal-tracker/goodeggs.yml
+++ b/_data/meltano/extractors/tap-pivotal-tracker/goodeggs.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.pivotaltracker.com/help/api/rest/v5#top
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-postmark/yoast.yml
+++ b/_data/meltano/extractors/tap-postmark/yoast.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://postmarkapp.com/developer
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-procore/hotgluexyz.yml
+++ b/_data/meltano/extractors/tap-procore/hotgluexyz.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.procore.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-quickbase/flash716.yml
+++ b/_data/meltano/extractors/tap-quickbase/flash716.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://help.quickbase.com/api-guide/intro.html
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-quickbase/singer-io.yml
+++ b/_data/meltano/extractors/tap-quickbase/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://help.quickbase.com/api-guide/intro.html
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-rakuten/chrisgoddard.yml
+++ b/_data/meltano/extractors/tap-rakuten/chrisgoddard.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://advhelp.rakutenmarketing.com/hc/en-us/articles/206630745-Create-a-Custom-Reporting-API
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-recharge/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-recharge/bytecodeio.yml
@@ -7,6 +7,7 @@ variant: bytecodeio
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/bytecodeio/tap-recharge.git

--- a/_data/meltano/extractors/tap-redshift/datadotworld.yml
+++ b/_data/meltano/extractors/tap-redshift/datadotworld.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/redshift/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-referral-saasquatch/singer-io.yml
+++ b/_data/meltano/extractors/tap-referral-saasquatch/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.saasquatch.com/api/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-responsys/singer-io.yml
+++ b/_data/meltano/extractors/tap-responsys/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.oracle.com/cx/marketing/campaign-management/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-revinate/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-revinate/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://porter.revinate.com/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-revinate/singer-io.yml
+++ b/_data/meltano/extractors/tap-revinate/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://porter.revinate.com/documentation
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-richpanel/richpanel-company.yml
+++ b/_data/meltano/extractors/tap-richpanel/richpanel-company.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://richpanel.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-rickandmorty/clrcrl.yml
+++ b/_data/meltano/extractors/tap-rickandmorty/clrcrl.yml
@@ -10,6 +10,7 @@ capabilities:
 - about
 - catalog
 - discover
+- state
 settings_group_validation:
 - []
 settings:

--- a/_data/meltano/extractors/tap-s3-csv/fishtown-analytics.yml
+++ b/_data/meltano/extractors/tap-s3-csv/fishtown-analytics.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://aws.amazon.com/s3/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-saasoptics/anelendata.yml
+++ b/_data/meltano/extractors/tap-saasoptics/anelendata.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://saasoptics.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-saasoptics/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-saasoptics/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://saasoptics.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-saasoptics/singer-io.yml
+++ b/_data/meltano/extractors/tap-saasoptics/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://saasoptics.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-sailthru/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-sailthru/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://getstarted.sailthru.com/developers/api-basics/introduction/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-sailthru/singer-io.yml
+++ b/_data/meltano/extractors/tap-sailthru/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://getstarted.sailthru.com/developers/api-basics/introduction/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-salesforce/singer-io.yml
+++ b/_data/meltano/extractors/tap-salesforce/singer-io.yml
@@ -7,6 +7,7 @@ variant: singer-io
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: tap-salesforce

--- a/_data/meltano/extractors/tap-salesforce/transferwise.yml
+++ b/_data/meltano/extractors/tap-salesforce/transferwise.yml
@@ -7,6 +7,7 @@ variant: transferwise
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: pipelinewise-tap-salesforce

--- a/_data/meltano/extractors/tap-sendgrid/codyss.yml
+++ b/_data/meltano/extractors/tap-sendgrid/codyss.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.sendgrid.com/docs/for-developers/sending-email/api-getting-started/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-sendgrid/isabella232.yml
+++ b/_data/meltano/extractors/tap-sendgrid/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.sendgrid.com/docs/for-developers/sending-email/api-getting-started/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-sendgrid/singer-io.yml
+++ b/_data/meltano/extractors/tap-sendgrid/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.sendgrid.com/docs/for-developers/sending-email/api-getting-started/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-sftp/bonobos.yml
+++ b/_data/meltano/extractors/tap-sftp/bonobos.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-shiphero/singer-io.yml
+++ b/_data/meltano/extractors/tap-shiphero/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.shiphero.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-slack/richard-clark.yml
+++ b/_data/meltano/extractors/tap-slack/richard-clark.yml
@@ -7,6 +7,7 @@ variant: richard-clark
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/richard-clark/tap-slack.git

--- a/_data/meltano/extractors/tap-sling/isabella232.yml
+++ b/_data/meltano/extractors/tap-sling/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.sling.is/#/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-sling/rfdearborn.yml
+++ b/_data/meltano/extractors/tap-sling/rfdearborn.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.sling.is/#/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-sling/singer-io.yml
+++ b/_data/meltano/extractors/tap-sling/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://api.sling.is/#/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-snapchat-ads/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-snapchat-ads/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.snapchat.com/docs/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-snapchat-ads/singer-io.yml
+++ b/_data/meltano/extractors/tap-snapchat-ads/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.snapchat.com/docs/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-starshipit/zookal.yml
+++ b/_data/meltano/extractors/tap-starshipit/zookal.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://github.com/Zookal/tap-starshipit
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-surveymonkey/abij.yml
+++ b/_data/meltano/extractors/tap-surveymonkey/abij.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.surveymonkey.com/api/v3/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-surveymonkey/horze-international.yml
+++ b/_data/meltano/extractors/tap-surveymonkey/horze-international.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.surveymonkey.com/api/v3/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-surveymonkey/ichensvmk.yml
+++ b/_data/meltano/extractors/tap-surveymonkey/ichensvmk.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.surveymonkey.com/api/v3/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-surveymonkey/isabella232.yml
+++ b/_data/meltano/extractors/tap-surveymonkey/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.surveymonkey.com/api/v3/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-surveymonkey/mikedillion.yml
+++ b/_data/meltano/extractors/tap-surveymonkey/mikedillion.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.surveymonkey.com/api/v3/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-surveymonkey/rahimnathwani.yml
+++ b/_data/meltano/extractors/tap-surveymonkey/rahimnathwani.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.surveymonkey.com/api/v3/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-surveymonkey/singer-io.yml
+++ b/_data/meltano/extractors/tap-surveymonkey/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.surveymonkey.com/api/v3/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-timebutler/taikonauten.yml
+++ b/_data/meltano/extractors/tap-timebutler/taikonauten.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://timebutler.de/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-toast/lambtron.yml
+++ b/_data/meltano/extractors/tap-toast/lambtron.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://pos.toasttab.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-toggl/lambtron.yml
+++ b/_data/meltano/extractors/tap-toggl/lambtron.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.toggl.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-trello/singer-io.yml
+++ b/_data/meltano/extractors/tap-trello/singer-io.yml
@@ -32,6 +32,7 @@ settings:
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation:
 - - start_date
   - consumer_key

--- a/_data/meltano/extractors/tap-trustpilot/fishtown-analytics.yml
+++ b/_data/meltano/extractors/tap-trustpilot/fishtown-analytics.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.trustpilot.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-twilio/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-twilio/bytecodeio.yml
@@ -7,6 +7,7 @@ variant: bytecodeio
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/bytecodeio/tap-twilio.git

--- a/_data/meltano/extractors/tap-twilio/singer-io.yml
+++ b/_data/meltano/extractors/tap-twilio/singer-io.yml
@@ -7,6 +7,7 @@ variant: singer-io
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: tap-twilio

--- a/_data/meltano/extractors/tap-twinfield/yoast.yml
+++ b/_data/meltano/extractors/tap-twinfield/yoast.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://accounting2.twinfield.com/webservices/documentation/#/ApiReference/Request/BrowseData
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-twitter-ads/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-twitter-ads/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.twitter.com
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-twitter-ads/singer-io.yml
+++ b/_data/meltano/extractors/tap-twitter-ads/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.twitter.com
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-twitter/bernietai.yml
+++ b/_data/meltano/extractors/tap-twitter/bernietai.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.twitter.com
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-typeform/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-typeform/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.typeform.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-typeform/singer-io.yml
+++ b/_data/meltano/extractors/tap-typeform/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developer.typeform.com/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-typo/typo-ai.yml
+++ b/_data/meltano/extractors/tap-typo/typo-ai.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://www.typo.ai/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ujet/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-ujet/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://ujet.cx/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-ujet/singer-io.yml
+++ b/_data/meltano/extractors/tap-ujet/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://ujet.cx/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-urban-airship/singer-io.yml
+++ b/_data/meltano/extractors/tap-urban-airship/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.airship.com/api/ua/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-wonolo/goodeggs.yml
+++ b/_data/meltano/extractors/tap-wonolo/goodeggs.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://wonolo.readme.io/docs/getting-started
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-woocommerce/hotgluexyz.yml
+++ b/_data/meltano/extractors/tap-woocommerce/hotgluexyz.yml
@@ -9,6 +9,7 @@ repo: https://github.com/hotgluexyz/tap-woocommerce
 capabilities:
 - catalog
 - discover
+- state
 settings:
 - name: site_url
   kind: string

--- a/_data/meltano/extractors/tap-wootric/singer-io.yml
+++ b/_data/meltano/extractors/tap-wootric/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://docs.wootric.com/api/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-workday-raas/isabella232.yml
+++ b/_data/meltano/extractors/tap-workday-raas/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://community.workday.com/api
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-workday-raas/singer-io.yml
+++ b/_data/meltano/extractors/tap-workday-raas/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://community.workday.com/api
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-yotpo/bombas.yml
+++ b/_data/meltano/extractors/tap-yotpo/bombas.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://apidocs.yotpo.com/reference
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-yotpo/fishtown-analytics.yml
+++ b/_data/meltano/extractors/tap-yotpo/fishtown-analytics.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://apidocs.yotpo.com/reference
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-yotpo/flopotok.yml
+++ b/_data/meltano/extractors/tap-yotpo/flopotok.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://apidocs.yotpo.com/reference
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-yotpo/isabella232.yml
+++ b/_data/meltano/extractors/tap-yotpo/isabella232.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://apidocs.yotpo.com/reference
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-yotpo/singer-io.yml
+++ b/_data/meltano/extractors/tap-yotpo/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://apidocs.yotpo.com/reference
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-yotpo/stvhanna.yml
+++ b/_data/meltano/extractors/tap-yotpo/stvhanna.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://apidocs.yotpo.com/reference
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-youtube-analytics/bytecodeio.yml
+++ b/_data/meltano/extractors/tap-youtube-analytics/bytecodeio.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.google.com/youtube/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-youtube-analytics/singer-io.yml
+++ b/_data/meltano/extractors/tap-youtube-analytics/singer-io.yml
@@ -10,6 +10,7 @@ settings: []
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://developers.google.com/youtube/
 maintenance_status: unknown
 keywords:

--- a/_data/meltano/extractors/tap-zendesk/transferwise.yml
+++ b/_data/meltano/extractors/tap-zendesk/transferwise.yml
@@ -7,6 +7,7 @@ variant: transferwise
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: pipelinewise-tap-zendesk

--- a/_data/meltano/extractors/tap-zoom/karbonhq.yml
+++ b/_data/meltano/extractors/tap-zoom/karbonhq.yml
@@ -7,6 +7,7 @@ variant: karbonhq
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: git+https://github.com/karbonhq/singer-tap-zoom.git

--- a/_data/meltano/extractors/tap-zoom/mashey.yml
+++ b/_data/meltano/extractors/tap-zoom/mashey.yml
@@ -9,6 +9,7 @@ pip_url: git+https://github.com/mashey/tap-zoom.git
 capabilities:
 - catalog
 - discover
+- state
 settings_group_validation:
 - - jwt
 - - client_id
@@ -19,7 +20,8 @@ settings:
   kind: password
   label: JSON Web Token
   documentation: https://marketplace.zoom.us/docs/guides/auth/jwt
-  description: Your Zoom JSON Web Token. The JWT is likely the easiest option for tap users. Configure the JWT with a very long expiry so it does not expire.
+  description: Your Zoom JSON Web Token. The JWT is likely the easiest option for
+    tap users. Configure the JWT with a very long expiry so it does not expire.
 - name: client_id
   label: Client ID
   documentation: https://marketplace.zoom.us/docs/guides/auth/oauth
@@ -29,12 +31,16 @@ settings:
   label: Client Secret
   kind: password
   documentation: https://marketplace.zoom.us/docs/guides/auth/oauth
-  description: The Zoom Client Secret that is generated when app credentials are created. See the [Zoom OAuth App Credentials documentation](https://marketplace.zoom.us/docs/guides/build/oauth-app#app-credentials) for more information.
+  description: The Zoom Client Secret that is generated when app credentials are created.
+    See the [Zoom OAuth App Credentials documentation](https://marketplace.zoom.us/docs/guides/build/oauth-app#app-credentials)
+    for more information.
 - name: refresh_token
   label: Refresh Token
   kind: password
   documentation: https://marketplace.zoom.us/docs/guides/auth/oauth
-  description: The Zoom Refresh Token that is provided after successfully authenticating with Zoom. See the [Zoom OAuth Access Token Request documentation](https://marketplace.zoom.us/docs/guides/auth/oauth#step-2-request-access-token) for more information.
+  description: The Zoom Refresh Token that is provided after successfully authenticating
+    with Zoom. See the [Zoom OAuth Access Token Request documentation](https://marketplace.zoom.us/docs/guides/auth/oauth#step-2-request-access-token)
+    for more information.
 domain_url: https://marketplace.zoom.us/docs/api-reference/introduction
 maintenance_status: active
 keywords:

--- a/_data/meltano/extractors/tap-zoom/singer-io.yml
+++ b/_data/meltano/extractors/tap-zoom/singer-io.yml
@@ -7,6 +7,7 @@ variant: singer-io
 capabilities:
 - catalog
 - discover
+- state
 settings: []
 settings_group_validation: []
 pip_url: tap-zoom


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/689

Update all extractor variants that are missing the state capability. I wrote a script to iterate all extractor variants that dont have the state capability and pull their README from github to see if they have any of these strings `['state.json', 'incremental', 'state file', '--state']`.

As part of that I found `tap-call-cap` was removed but still has a default variant set, so I removed it. I also found 11 variant repos that are no longer available on github. I'll open a separate PR to remove those.