### PR TITLE
add setting to transferwise tap-mongodb and set as default

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -201,7 +201,7 @@ extractors:
   tap-mixpanel: hotgluexyz
   tap-mode: franloza
   tap-monday: gthesheep
-  tap-mongodb: singer-io
+  tap-mongodb: transferwise
   tap-ms-teams: singer-io
   tap-mssql: wintersrd
   tap-mysql: transferwise

--- a/_data/meltano/extractors/tap-mongodb/singer-io.yml
+++ b/_data/meltano/extractors/tap-mongodb/singer-io.yml
@@ -59,6 +59,6 @@ settings:
     instead of `<collection_name>`
   label: Include Schemas In Destination Stream Name
 domain_url: https://www.mongodb.com/
-maintenance_status: inactive
+maintenance_status: active
 keywords:
 - database

--- a/_data/meltano/extractors/tap-mongodb/transferwise.yml
+++ b/_data/meltano/extractors/tap-mongodb/transferwise.yml
@@ -11,8 +11,65 @@ capabilities:
 - catalog
 - discover
 - state
-settings_group_validation: []
-settings: []
+- log-based
+settings_group_validation:
+- - password
+  - user
+  - host
+  - auth_database
+  - database
+settings:
+- name: password
+  kind: password
+  label: Password
+  description: The MongoDB password.
+- name: user
+  label: User
+  description: The MongoDB user.
+- name: host
+  label: Host URL
+  description: The MongoDB host URL.
+- name: auth_database
+  label: Auth Database
+  description: The database name to authenticate on.
+- name: database
+  label: Database Name
+  description: Database name to sync from.
+- name: srv
+  label: Replica Set
+  kind: boolean
+  description: Uses a mongodb+srv protocol to connect. Disables the usage of port argument if set to True
+- name: port
+  kind: integer
+  label: Port
+  description: Connection port. Required if a non-srv connection is being used.
+- name: replica_set
+  label: Replica Set
+  description: Name of replica set
+- name: ssl
+  label: SSL
+  kind: boolean
+  value: false
+  description: Can be set to true to connect using ssl.
+- name: verify_mode
+  label: Verify Mode
+  kind: boolean
+  value: true
+  description: Default SSL verify mode.
+- name: include_schemas_in_destination_stream_name
+  kind: boolean
+  value: false
+  description: Forces the stream names to take the form `<database_name>_<collection_name>`
+    instead of `<collection_name>`
+  label: Include Schemas In Destination Stream Name
+- name: update_buffer_size
+  label: Update Buffer Size
+  kind: integer
+  description: (LOG_BASED) The size of the buffer that holds detected update operations in memory, the buffer is flushed once the size is reached.
+- name: await_time_ms
+  label: Await Time ms
+  kind: integer
+  description: (LOG_BASED) The maximum amount of time in milliseconds the loge_base method waits for new data changes before exiting.
 domain_url: https://www.mongodb.com/
 maintenance_status: active
 keywords:

--- a/_data/meltano/extractors/tap-mongodb/transferwise.yml
+++ b/_data/meltano/extractors/tap-mongodb/transferwise.yml
@@ -20,8 +20,8 @@ settings_group_validation:
   - database
 settings:
 - name: password
-  kind: password
   label: Password
+  kind: password
   description: The MongoDB password.
 - name: user
   label: User
@@ -36,12 +36,12 @@ settings:
   label: Database Name
   description: Database name to sync from.
 - name: srv
-  label: Replica Set
+  label: SRV
   kind: boolean
   description: Uses a mongodb+srv protocol to connect. Disables the usage of port argument if set to True
 - name: port
-  kind: integer
   label: Port
+  kind: integer
   description: Connection port. Required if a non-srv connection is being used.
 - name: replica_set
   label: Replica Set
@@ -49,19 +49,16 @@ settings:
 - name: ssl
   label: SSL
   kind: boolean
-  value: false
   description: Can be set to true to connect using ssl.
 - name: verify_mode
   label: Verify Mode
   kind: boolean
-  value: true
   description: Default SSL verify mode.
 - name: include_schemas_in_destination_stream_name
+  label: Include Schemas In Destination Stream Name
   kind: boolean
-  value: false
   description: Forces the stream names to take the form `<database_name>_<collection_name>`
     instead of `<collection_name>`
-  label: Include Schemas In Destination Stream Name
 - name: update_buffer_size
   label: Update Buffer Size
   kind: integer


### PR DESCRIPTION
Based on a thread in slack https://meltano.slack.com/archives/C01TCRBBJD7/p1660571129770879?thread_ts=1660402531.034259&cid=C01TCRBBJD7

The context is that I asked if transferwise should be the default over singer-io. I also see more successful telemetry usage for transferwise:

>I'm curious if you evaluated the singer-io variant vs transferwise while you were working on this. Right now singer-io is the default variant but I've heard a fair amount of community members choosing the transferwise variant, I'd like to make that the recommended default if its the best option. Do you have any insight you can share? What were the reasons you chose transferwise over singer-io?

And the response was:

>hi, yes, the default one dosen’t support some important options for mongodb authentication
>one example is the usage of mongodb+srv
>also a authSource different than the database you want to get data
>that’s quite normal for any mongodb deployment
>usually auth goes into a admin database and you use another for storing data


cc @sjcotto
