### PR TITLE
change: keywords as single line with wordwrap

### DIFF
--- a/hub-2.0/ui/src/components/PluginSidebar.vue
+++ b/hub-2.0/ui/src/components/PluginSidebar.vue
@@ -83,8 +83,7 @@
     <h4>Meltano Stats</h4>
 
     <h4>Keywords</h4>
-    <p>{{ (keywords ?? []).join(', ') }}</p>
-
+    <p>{{ (keywords ?? []).join(", ") }}</p>
   </div>
 </template>
 

--- a/hub-2.0/ui/src/components/PluginSidebar.vue
+++ b/hub-2.0/ui/src/components/PluginSidebar.vue
@@ -83,7 +83,8 @@
     <h4>Meltano Stats</h4>
 
     <h4>Keywords</h4>
-    <p v-for="(keyword, index) in keywords" v-bind:key="index">{{ keyword }}</p>
+    <p>{{ keywords.join(', ') }}</p>
+
   </div>
 </template>
 

--- a/hub-2.0/ui/src/components/PluginSidebar.vue
+++ b/hub-2.0/ui/src/components/PluginSidebar.vue
@@ -83,7 +83,7 @@
     <h4>Meltano Stats</h4>
 
     <h4>Keywords</h4>
-    <p>{{ keywords.join(', ') }}</p>
+    <p>{{ (keywords ?? []).join(', ') }}</p>
 
   </div>
 </template>


### PR DESCRIPTION
When there are a lot of keywords (as with Spreadsheets Anywhere), this makes a more condensed output.

<img width="379" alt="image" src="https://user-images.githubusercontent.com/18150651/185515328-3678433e-0f75-4c14-9535-cb58830d30f7.png">

Note: In future, it might be night to have each of these to hyperlink back to a search for that keyword. (Above my capabilities as of now. 😅 )