### PR TITLE
Add variant links to plugin page

### DIFF
--- a/hub-2.0/ui/gridsome.server.js
+++ b/hub-2.0/ui/gridsome.server.js
@@ -172,6 +172,7 @@ module.exports = function main(api) {
           context: {
             id: node.id,
             path: node.path,
+            name: node.name,
           },
         });
       });

--- a/hub-2.0/ui/src/templates/Extractors.vue
+++ b/hub-2.0/ui/src/templates/Extractors.vue
@@ -30,7 +30,16 @@
             <a href="https://docs.github.com/en/rest">GitHub</a> that can then be sent to a
             destination using a <g-link to="/loaders">loader</g-link>.
           </p>
-          <p class="add-more-info">variant info here</p>
+          <h3>Available Variants</h3>
+          <ul>
+            <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
+              <g-link :to="variant.node.path" v-if="variant.node.path !== $page.extractors.path">{{
+                variant.node.variant
+              }}</g-link>
+              <span v-else>{{ variant.node.variant }}</span>
+              <span v-if="variant.node.isDefault"> (default)</span>
+            </li>
+          </ul>
           <h2>Getting Started</h2>
           <h3>Prerequisites</h3>
           <p>
@@ -166,7 +175,7 @@ export default {
 </script>
 
 <page-query lang="graphql">
-query Extractors($path: String!) {
+query Extractors($path: String!, $name: String!) {
   extractors: extractors(path: $path) {
     id
     description
@@ -191,6 +200,16 @@ query Extractors($path: String!) {
     }
     prereq
     usage
+  }
+  variants: allExtractors(filter: { name: { eq: $name } }) {
+    edges {
+      node {
+        name
+        variant
+        path
+        isDefault
+      }
+    }
   }
 }
 </page-query>

--- a/hub-2.0/ui/src/templates/Files.vue
+++ b/hub-2.0/ui/src/templates/Files.vue
@@ -27,7 +27,16 @@
             <a href="https://docs.meltano.com/concepts/plugins#file-bundles">file bundle</a>
             {{ $page.files.definition }}
           </p>
-          <p class="add-more-info">variant info here</p>
+          <h3>Available Variants</h3>
+          <ul>
+            <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
+              <g-link :to="variant.node.path" v-if="variant.node.path !== $page.files.path">{{
+                variant.node.variant
+              }}</g-link>
+              <span v-else>{{ variant.node.variant }}</span>
+              <span v-if="variant.node.isDefault"> (default)</span>
+            </li>
+          </ul>
           <h2>Getting Started</h2>
           <h3>Prerequisites</h3>
           <p>
@@ -163,7 +172,7 @@ export default {
 </script>
 
 <page-query lang="graphql">
-query Files($path: String!) {
+query Files($path: String!, $name: String!) {
   files: files(path: $path) {
     id
     path
@@ -176,6 +185,16 @@ query Files($path: String!) {
     repo
     maintenance_status
     definition
+  }
+  variants: allFiles(filter: { name: { eq: $name } }) {
+    edges {
+      node {
+        name
+        variant
+        path
+        isDefault
+      }
+    }
   }
 }
 </page-query>

--- a/hub-2.0/ui/src/templates/Loaders.vue
+++ b/hub-2.0/ui/src/templates/Loaders.vue
@@ -32,7 +32,16 @@
             after it was pulled from a source using an
             <g-link to="/extractors">extractor</g-link>.
           </p>
-          <p class="add-more-info">variant info here</p>
+          <h3>Available Variants</h3>
+          <ul>
+            <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
+              <g-link :to="variant.node.path" v-if="variant.node.path !== $page.loaders.path">{{
+                variant.node.variant
+              }}</g-link>
+              <span v-else>{{ variant.node.variant }}</span>
+              <span v-if="variant.node.isDefault"> (default)</span>
+            </li>
+          </ul>
           <h2>Getting Started</h2>
           <h3>Prerequisites</h3>
           <p>
@@ -166,7 +175,7 @@ export default {
 </script>
 
 <page-query lang="graphql">
-query Loaders($path: String!) {
+query Loaders($path: String!, $name: String!) {
   loaders: loaders(path: $path) {
     id
     description
@@ -188,6 +197,16 @@ query Loaders($path: String!) {
     }
     prereq
     usage
+  }
+  variants: allLoaders(filter: { name: { eq: $name } }) {
+    edges {
+      node {
+        name
+        variant
+        path
+        isDefault
+      }
+    }
   }
 }
 </page-query>

--- a/hub-2.0/ui/src/templates/Orchestrators.vue
+++ b/hub-2.0/ui/src/templates/Orchestrators.vue
@@ -30,7 +30,18 @@
             >
             allows for workflows to be programmatically authored, scheduled, and monitored.
           </p>
-          <p class="add-more-info">variant info here</p>
+          <h3>Available Variants</h3>
+          <ul>
+            <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
+              <g-link
+                :to="variant.node.path"
+                v-if="variant.node.path !== $page.orchestrators.path"
+                >{{ variant.node.variant }}</g-link
+              >
+              <span v-else>{{ variant.node.variant }}</span>
+              <span v-if="variant.node.isDefault"> (default)</span>
+            </li>
+          </ul>
           <h2>Getting Started</h2>
           <h3>Prerequisites</h3>
           <p>
@@ -147,7 +158,7 @@ export default {
 </script>
 
 <page-query lang="graphql">
-query Orchestrators($path: String!) {
+query Orchestrators($path: String!, $name: String!) {
   orchestrators: orchestrators(path: $path) {
     id
     path
@@ -181,6 +192,16 @@ query Orchestrators($path: String!) {
     }
     logo_url
     settings_preamble
+  }
+  variants: allOrchestrators(filter: { name: { eq: $name } }) {
+    edges {
+      node {
+        name
+        variant
+        path
+        isDefault
+      }
+    }
   }
 }
 </page-query>

--- a/hub-2.0/ui/src/templates/Transformers.vue
+++ b/hub-2.0/ui/src/templates/Transformers.vue
@@ -28,7 +28,18 @@
             <a href="https://docs.meltano.com/concepts/plugins#transformer">transformer</a>
             uses SQL to transform data stored in your warehouse.
           </p>
-          <p class="add-more-info">variant info here</p>
+          <h3>Available Variants</h3>
+          <ul>
+            <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
+              <g-link
+                :to="variant.node.path"
+                v-if="variant.node.path !== $page.transformers.path"
+                >{{ variant.node.variant }}</g-link
+              >
+              <span v-else>{{ variant.node.variant }}</span>
+              <span v-if="variant.node.isDefault"> (default)</span>
+            </li>
+          </ul>
           <h2>Getting Started</h2>
           <h3>Prerequisites</h3>
           <p>
@@ -168,7 +179,7 @@ export default {
 </script>
 
 <page-query lang="graphql">
-query Transformers($path: String!) {
+query Transformers($path: String!, $name: String!) {
   transformers: transformers(path: $path) {
     id
     path
@@ -239,6 +250,16 @@ query Transformers($path: String!) {
       debug {
         args
         description
+      }
+    }
+  }
+  variants: allTransformers(filter: { name: { eq: $name } }) {
+    edges {
+      node {
+        name
+        variant
+        path
+        isDefault
       }
     }
   }

--- a/hub-2.0/ui/src/templates/Utilities.vue
+++ b/hub-2.0/ui/src/templates/Utilities.vue
@@ -28,7 +28,16 @@
             <a href="https://docs.meltano.com/concepts/plugins#utilities">utility</a>
             is {{ $page.utilities.definition }}
           </p>
-          <p class="add-more-info">variant info here</p>
+          <h3>Available Variants</h3>
+          <ul>
+            <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
+              <g-link :to="variant.node.path" v-if="variant.node.path !== $page.utilities.path">{{
+                variant.node.variant
+              }}</g-link>
+              <span v-else>{{ variant.node.variant }}</span>
+              <span v-if="variant.node.isDefault"> (default)</span>
+            </li>
+          </ul>
           <h2>Getting Started</h2>
           <h3>Prerequisites</h3>
           <p>
@@ -165,7 +174,7 @@ export default {
 </script>
 
 <page-query lang="graphql">
-query Utilities($path: String!) {
+query Utilities($path: String!, $name: String!) {
   utilities: utilities(path: $path) {
     id
     name
@@ -225,6 +234,16 @@ query Utilities($path: String!) {
     }
     prereq
     usage
+  }
+  variants: allUtilities(filter: { name: { eq: $name } }) {
+    edges {
+      node {
+        name
+        variant
+        path
+        isDefault
+      }
+    }
   }
 }
 </page-query>


### PR DESCRIPTION
Closes #705 

This populates a new section at the top of the plugin page, showing what variants are available, which one is the default, and which one the user is currently on.

The entry in the list for the current page will not be a link to indicate the user is already looking at that variant, but until we fix the link styling it won't be apparent.