### PR TITLE
change: update formatting and layout

### DIFF
--- a/hub-2.0/ui/src/assets/css/main.css
+++ b/hub-2.0/ui/src/assets/css/main.css
@@ -26,6 +26,7 @@ footer {
 
 .inline-code-block {
   display: inline;
+  padding: 3px;
 }
 
 /* BUTTONS AND LINKS */
@@ -63,7 +64,7 @@ footer {
 .plugins-list {
   width: 100%;
   height: auto;
-  background: #e8f0ff;
+  background: #ffffff;
   display: flex;
   flex-wrap: wrap;
   margin-top: 40px;
@@ -77,8 +78,7 @@ footer {
   display: flex;
   flex-direction: column;
   list-style-type: none;
-  padding: 0;
-  margin: 0;
+  margin: 20px auto;
   flex-basis: 50%;
 }
 
@@ -88,7 +88,8 @@ footer {
 }
 
 .plugins-list .page-single-plugin a:hover {
-  background: #b0e3c1;
+  border: 1px solid #62626e;
+  border-radius: 40px;
 }
 
 .plugins-list .pager-container {
@@ -128,13 +129,12 @@ footer {
 }
 
 .single-plugin-overview pre code {
-  background: #b0e3c1;
-  padding: 12px;
-  border: 1px solid #62626e;
+  background: #3439bf28;
+  padding: 4px;
 }
 
 .single-plugin-detail {
-  background: #e8f0ff;
+  background: #ffffff;
   color: #3438bf;
   display: flex;
   flex-wrap: wrap;
@@ -146,7 +146,7 @@ footer {
 .single-plugin-detail .single-plugin-top-bar {
   width: 100%;
   border-bottom: 2px solid #62626e;
-  background: #fbbf52;
+  background: #ffffff;
   text-align: left;
   padding-left: 10px;
 }

--- a/hub-2.0/ui/src/assets/css/main.css
+++ b/hub-2.0/ui/src/assets/css/main.css
@@ -129,13 +129,14 @@ footer {
 }
 
 .single-plugin-overview pre code {
-  background: #3439bf28;
-  padding: 4px;
+  background: #e5e7eb;
+  padding: 2px 4px;
+  font-family: "IBM Plex Mono";
 }
 
 .single-plugin-detail {
   background: #ffffff;
-  color: #3438bf;
+  color: #29292f;
   display: flex;
   flex-wrap: wrap;
   word-wrap: break-word;
@@ -146,7 +147,7 @@ footer {
 .single-plugin-detail .single-plugin-top-bar {
   width: 100%;
   border-bottom: 2px solid #62626e;
-  background: #ffffff;
+  background: #fff;
   text-align: left;
   padding-left: 10px;
 }

--- a/hub-2.0/ui/src/components/Search.vue
+++ b/hub-2.0/ui/src/components/Search.vue
@@ -49,7 +49,7 @@ export default {
   name: "SearchBar",
   data() {
     return {
-      search: ""
+      search: "",
     };
   },
   computed: {
@@ -60,7 +60,7 @@ export default {
         this.$static.allFiles,
         this.$static.allOrchestrators,
         this.$static.allUtilities,
-        this.$static.allTransformers
+        this.$static.allTransformers,
       ];
       return pluginCollections.flatMap((coll) =>
         coll.edges.filter((plugin) => {
@@ -68,7 +68,7 @@ export default {
             plugin.node.name,
             plugin.node.description,
             plugin.node.label,
-            plugin.node.keywords?.join(" ")
+            plugin.node.keywords?.join(" "),
           ];
           return pluginTextFields
             .join(" ")
@@ -76,8 +76,8 @@ export default {
             .includes(this.search.toLowerCase().trim());
         })
       );
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/components/Search.vue
+++ b/hub-2.0/ui/src/components/Search.vue
@@ -49,7 +49,7 @@ export default {
   name: "SearchBar",
   data() {
     return {
-      search: "",
+      search: ""
     };
   },
   computed: {
@@ -60,7 +60,7 @@ export default {
         this.$static.allFiles,
         this.$static.allOrchestrators,
         this.$static.allUtilities,
-        this.$static.allTransformers,
+        this.$static.allTransformers
       ];
       return pluginCollections.flatMap((coll) =>
         coll.edges.filter((plugin) => {
@@ -68,7 +68,7 @@ export default {
             plugin.node.name,
             plugin.node.description,
             plugin.node.label,
-            plugin.node.keywords?.join(" "),
+            plugin.node.keywords?.join(" ")
           ];
           return pluginTextFields
             .join(" ")
@@ -76,8 +76,8 @@ export default {
             .includes(this.search.toLowerCase().trim());
         })
       );
-    },
-  },
+    }
+  }
 };
 </script>
 
@@ -173,16 +173,12 @@ query {
   justify-content: center;
 
   .search-bar {
-    border: 2px solid red;
+    border: 2px solid #3438bf;
     width: 90%;
     border-radius: 0;
     font-size: 20px;
     background: #f1f1f2;
     padding-left: 20px;
-    &:focus-visible {
-      outline: 3px solid #3438bf;
-      border: 0;
-    }
   }
 
   .results {

--- a/hub-2.0/ui/src/pages/Extractors.vue
+++ b/hub-2.0/ui/src/pages/Extractors.vue
@@ -15,19 +15,23 @@
           class="page-single-plugin"
         >
           <g-link :to="edge.node.path">
-            <h2>{{ edge.node.label }}</h2>
             <g-image
               v-if="edge.node.logo_url"
               :src="
-                require(`!!assets-loader?width=175!@logos/${edge.node.logo_url.replace(
+                require(`!!assets-loader?width=175&height=80&fit=inside!@logos/${edge.node.logo_url.replace(
                   '/assets/logos/',
                   ''
                 )}`)
               "
             />
-            <p>Variant: {{ edge.node.variant }}</p>
-            <p>Mainenance Status: {{ edge.node.maintenance_status }}</p>
-            <p>Description: {{ edge.node.description }}</p>
+            <h2>{{ edge.node.label }}</h2>
+            <h2>
+              <code>{{ edge.node.name }}</code
+              ><br /><code>from {{ edge.node.variant }}</code>
+            </h2>
+            <p>
+              <i>{{ edge.node.maintenance_status }} status</i>
+            </p>
           </g-link>
         </li>
         <Pager
@@ -53,7 +57,7 @@ export default {
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allExtractors(perPage: 12, page: $page, sortBy: "label", order: ASC) @paginate {
+  allExtractors(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/hub-2.0/ui/src/pages/Files.vue
+++ b/hub-2.0/ui/src/pages/Files.vue
@@ -46,8 +46,8 @@ import { Pager } from "gridsome";
 export default {
   name: "FilesPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Files.vue
+++ b/hub-2.0/ui/src/pages/Files.vue
@@ -14,15 +14,20 @@
             <g-image
               v-if="edge.node.logo_url"
               :src="
-                require(`!!assets-loader?width=175!@logos/${edge.node.logo_url.replace(
+                require(`!!assets-loader?width=175&height=80&fit=inside!@logos/${edge.node.logo_url.replace(
                   '/assets/logos/',
                   ''
                 )}`)
               "
             />
-            <p>{{ edge.node.variant }}</p>
-            <p>{{ edge.node.maintenance_status }}</p>
-            <p>{{ edge.node.description }}</p>
+            <h2>{{ edge.node.label }}</h2>
+            <h2>
+              <code>{{ edge.node.name }}</code
+              ><br /><code>from {{ edge.node.variant }}</code>
+            </h2>
+            <p>
+              <i>{{ edge.node.maintenance_status }} status</i>
+            </p>
           </g-link>
         </li>
         <Pager
@@ -41,14 +46,14 @@ import { Pager } from "gridsome";
 export default {
   name: "FilesPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allFiles(perPage: 12, page: $page, sortBy: "label", order: ASC) @paginate {
+  allFiles(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/hub-2.0/ui/src/pages/Loaders.vue
+++ b/hub-2.0/ui/src/pages/Loaders.vue
@@ -47,8 +47,8 @@ import { Pager } from "gridsome";
 export default {
   name: "LoadersPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Loaders.vue
+++ b/hub-2.0/ui/src/pages/Loaders.vue
@@ -15,15 +15,20 @@
             <g-image
               v-if="edge.node.logo_url"
               :src="
-                require(`!!assets-loader?width=175!@logos/${edge.node.logo_url.replace(
+                require(`!!assets-loader?width=175&height=80&fit=inside!@logos/${edge.node.logo_url.replace(
                   '/assets/logos/',
                   ''
                 )}`)
               "
             />
-            <p>{{ edge.node.variant }}</p>
-            <p>{{ edge.node.maintenance_status }}</p>
-            <p>{{ edge.node.description }}</p>
+            <h2>{{ edge.node.label }}</h2>
+            <h2>
+              <code>{{ edge.node.name }}</code
+              ><br /><code>from {{ edge.node.variant }}</code>
+            </h2>
+            <p>
+              <i>{{ edge.node.maintenance_status }} status</i>
+            </p>
           </g-link>
         </li>
         <Pager
@@ -42,14 +47,14 @@ import { Pager } from "gridsome";
 export default {
   name: "LoadersPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allLoaders(perPage: 12, page: $page, sortBy: "label", order: ASC) @paginate {
+  allLoaders(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/hub-2.0/ui/src/pages/Orchestrators.vue
+++ b/hub-2.0/ui/src/pages/Orchestrators.vue
@@ -49,8 +49,8 @@ import { Pager } from "gridsome";
 export default {
   name: "OrchestratorsPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Orchestrators.vue
+++ b/hub-2.0/ui/src/pages/Orchestrators.vue
@@ -17,15 +17,20 @@
             <g-image
               v-if="edge.node.logo_url"
               :src="
-                require(`!!assets-loader?width=175!@logos/${edge.node.logo_url.replace(
+                require(`!!assets-loader?width=175&height=80&fit=inside!@logos/${edge.node.logo_url.replace(
                   '/assets/logos/',
                   ''
                 )}`)
               "
             />
-            <p>{{ edge.node.variant }}</p>
-            <p>{{ edge.node.maintenance_status }}</p>
-            <p>{{ edge.node.description }}</p>
+            <h2>{{ edge.node.label }}</h2>
+            <h2>
+              <code>{{ edge.node.name }}</code
+              ><br /><code>from {{ edge.node.variant }}</code>
+            </h2>
+            <p>
+              <i>{{ edge.node.maintenance_status }} status</i>
+            </p>
           </g-link>
         </li>
         <Pager
@@ -44,14 +49,14 @@ import { Pager } from "gridsome";
 export default {
   name: "OrchestratorsPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allOrchestrators(perPage: 12, page: $page, sortBy: "label", order: ASC) @paginate {
+  allOrchestrators(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/hub-2.0/ui/src/pages/Transformers.vue
+++ b/hub-2.0/ui/src/pages/Transformers.vue
@@ -17,15 +17,20 @@
             <g-image
               v-if="edge.node.logo_url"
               :src="
-                require(`!!assets-loader?width=175!@logos/${edge.node.logo_url.replace(
+                require(`!!assets-loader?width=175&height=80&fit=inside!@logos/${edge.node.logo_url.replace(
                   '/assets/logos/',
                   ''
                 )}`)
               "
             />
-            <p>{{ edge.node.variant }}</p>
-            <p>{{ edge.node.maintenance_status }}</p>
-            <p>{{ edge.node.description }}</p>
+            <h2>{{ edge.node.label }}</h2>
+            <h2>
+              <code>{{ edge.node.name }}</code
+              ><br /><code>from {{ edge.node.variant }}</code>
+            </h2>
+            <p>
+              <i>{{ edge.node.maintenance_status }} status</i>
+            </p>
           </g-link>
         </li>
         <Pager
@@ -44,14 +49,14 @@ import { Pager } from "gridsome";
 export default {
   name: "TransformersPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allTransformers(perPage: 12, page: $page, sortBy: "label", order: ASC) @paginate {
+  allTransformers(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/hub-2.0/ui/src/pages/Transformers.vue
+++ b/hub-2.0/ui/src/pages/Transformers.vue
@@ -49,8 +49,8 @@ import { Pager } from "gridsome";
 export default {
   name: "TransformersPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Utilities.vue
+++ b/hub-2.0/ui/src/pages/Utilities.vue
@@ -13,15 +13,20 @@
             <g-image
               v-if="edge.node.logo_url"
               :src="
-                require(`!!assets-loader?width=175!@logos/${edge.node.logo_url.replace(
+                require(`!!assets-loader?width=175&height=80&fit=inside!@logos/${edge.node.logo_url.replace(
                   '/assets/logos/',
                   ''
                 )}`)
               "
             />
-            <p>{{ edge.node.variant }}</p>
-            <p>{{ edge.node.maintenance_status }}</p>
-            <p>{{ edge.node.description }}</p>
+            <h2>{{ edge.node.label }}</h2>
+            <h2>
+              <code>{{ edge.node.name }}</code
+              ><br /><code>from {{ edge.node.variant }}</code>
+            </h2>
+            <p>
+              <i>{{ edge.node.maintenance_status }} status</i>
+            </p>
           </g-link>
         </li>
         <Pager
@@ -40,14 +45,14 @@ import { Pager } from "gridsome";
 export default {
   name: "UtilitiesPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allUtilities(perPage: 12, page: $page, sortBy: "label", order: ASC) @paginate {
+  allUtilities(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/hub-2.0/ui/src/pages/Utilities.vue
+++ b/hub-2.0/ui/src/pages/Utilities.vue
@@ -45,8 +45,8 @@ import { Pager } from "gridsome";
 export default {
   name: "UtilitiesPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Extractors.vue
+++ b/hub-2.0/ui/src/templates/Extractors.vue
@@ -3,25 +3,34 @@
     <div class="single-plugin-overview">
       <div class="single-plugin-detail">
         <div class="single-plugin-top-bar">
-          <h4>
-            {{ $page.extractors.label }} -
-            <span>{{ $page.extractors.description }}</span>
-          </h4>
+          <table>
+            <tr>
+              <td style="padding: 25px">
+                <g-image
+                  v-if="$page.extractors.logo_url"
+                  :src="
+                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.extractors.logo_url.replace(
+                      '/assets/logos/',
+                      ''
+                    )}`)
+                  "
+                />
+              </td>
+              <td>
+                <h1>
+                  {{ $page.extractors.label }}
+                </h1>
+                <h2>
+                  <code>{{ $page.extractors.name }} from {{ $page.extractors.variant }}</code>
+                </h2>
+                <p>
+                  <b>{{ $page.extractors.description }}</b>
+                </p>
+              </td>
+            </tr>
+          </table>
         </div>
         <div class="single-plugin-main">
-          <g-image
-            v-if="$page.extractors.logo_url"
-            :src="
-              require(`!!assets-loader?width=250!@logos/${$page.extractors.logo_url.replace(
-                '/assets/logos/',
-                ''
-              )}`)
-            "
-          />
-          <h1>
-            {{ $page.extractors.name }} //
-            <span>{{ $page.extractors.variant }}</span>
-          </h1>
           <p>{{ $page.extractors.usage }}</p>
           <p>
             The {{ $page.extractors.name }}
@@ -30,7 +39,7 @@
             <a :href="$page.extractors.domain_url">{{ $page.extractors.label }}</a> that can then be
             sent to a destination using a <g-link to="/loaders">loader</g-link>.
           </p>
-          <h3>Available Variants</h3>
+          <h3>Other Available Variants</h3>
           <ul>
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link :to="variant.node.path" v-if="variant.node.path !== $page.extractors.path">{{

--- a/hub-2.0/ui/src/templates/Files.vue
+++ b/hub-2.0/ui/src/templates/Files.vue
@@ -177,11 +177,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.files.name
+      title: this.$page.files.name,
     };
   },
   name: "FilesTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Files.vue
+++ b/hub-2.0/ui/src/templates/Files.vue
@@ -3,20 +3,34 @@
     <div class="single-plugin-overview">
       <div class="single-plugin-detail">
         <div class="single-plugin-top-bar">
-          <h4>
-            {{ $page.files.label }} - <span>{{ $page.files.description }}</span>
-          </h4>
+          <table>
+            <tr>
+              <td style="padding: 25px">
+                <g-image
+                  v-if="$page.files.logo_url"
+                  :src="
+                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.files.logo_url.replace(
+                      '/assets/logos/',
+                      ''
+                    )}`)
+                  "
+                />
+              </td>
+              <td>
+                <h1>
+                  {{ $page.files.label }}
+                </h1>
+                <h2>
+                  <code>{{ $page.files.name }} from {{ $page.files.variant }}</code>
+                </h2>
+                <p>
+                  <b>{{ $page.files.description }}</b>
+                </p>
+              </td>
+            </tr>
+          </table>
         </div>
         <div class="single-plugin-main">
-          <g-image
-            v-if="$page.files.logo_url"
-            :src="
-              require(`!!assets-loader?width=250!@logos/${$page.files.logo_url.replace(
-                '/assets/logos/',
-                ''
-              )}`)
-            "
-          />
           <h1>
             {{ $page.files.name }} //
             <span>{{ $page.files.variant }}</span>
@@ -27,7 +41,7 @@
             <a href="https://docs.meltano.com/concepts/plugins#file-bundles">file bundle</a>
             {{ $page.files.definition }}
           </p>
-          <h3>Available Variants</h3>
+          <h3>Other Available Variants</h3>
           <ul>
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link :to="variant.node.path" v-if="variant.node.path !== $page.files.path">{{
@@ -163,11 +177,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.files.name,
+      title: this.$page.files.name
     };
   },
   name: "FilesTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Loaders.vue
+++ b/hub-2.0/ui/src/templates/Loaders.vue
@@ -179,11 +179,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.loaders.name
+      title: this.$page.loaders.name,
     };
   },
   name: "LoadersTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Loaders.vue
+++ b/hub-2.0/ui/src/templates/Loaders.vue
@@ -3,21 +3,34 @@
     <div class="single-plugin-overview">
       <div class="single-plugin-detail">
         <div class="single-plugin-top-bar">
-          <h4>
-            {{ $page.loaders.label }} -
-            <span>{{ $page.loaders.description }}</span>
-          </h4>
+          <table>
+            <tr>
+              <td style="padding: 25px">
+                <g-image
+                  v-if="$page.loaders.logo_url"
+                  :src="
+                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.loaders.logo_url.replace(
+                      '/assets/logos/',
+                      ''
+                    )}`)
+                  "
+                />
+              </td>
+              <td>
+                <h1>
+                  {{ $page.loaders.label }}
+                </h1>
+                <h2>
+                  <code>{{ $page.loaders.name }} from {{ $page.loaders.variant }}</code>
+                </h2>
+                <p>
+                  <b>{{ $page.loaders.description }}</b>
+                </p>
+              </td>
+            </tr>
+          </table>
         </div>
         <div class="single-plugin-main">
-          <g-image
-            v-if="$page.loaders.logo_url"
-            :src="
-              require(`!!assets-loader?width=250!@logos/${$page.loaders.logo_url.replace(
-                '/assets/logos/',
-                ''
-              )}`)
-            "
-          />
           <h1>
             {{ $page.loaders.name }} //
             <span>{{ $page.loaders.variant }}</span>
@@ -32,7 +45,7 @@
             after it was pulled from a source using an
             <g-link to="/extractors">extractor</g-link>.
           </p>
-          <h3>Available Variants</h3>
+          <h3>Other Available Variants</h3>
           <ul>
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link :to="variant.node.path" v-if="variant.node.path !== $page.loaders.path">{{
@@ -166,11 +179,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.loaders.name,
+      title: this.$page.loaders.name
     };
   },
   name: "LoadersTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Orchestrators.vue
+++ b/hub-2.0/ui/src/templates/Orchestrators.vue
@@ -162,11 +162,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.orchestrators.name
+      title: this.$page.orchestrators.name,
     };
   },
   name: "OrchestratorsTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Orchestrators.vue
+++ b/hub-2.0/ui/src/templates/Orchestrators.vue
@@ -3,21 +3,34 @@
     <div class="single-plugin-overview">
       <div class="single-plugin-detail">
         <div class="single-plugin-top-bar">
-          <h4>
-            {{ $page.orchestrators.label }} -
-            <span>{{ $page.orchestrators.description }}</span>
-          </h4>
+          <table>
+            <tr>
+              <td style="padding: 25px">
+                <g-image
+                  v-if="$page.orchestrators.logo_url"
+                  :src="
+                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.orchestrators.logo_url.replace(
+                      '/assets/logos/',
+                      ''
+                    )}`)
+                  "
+                />
+              </td>
+              <td>
+                <h1>
+                  {{ $page.orchestrators.label }}
+                </h1>
+                <h2>
+                  <code>{{ $page.orchestrators.name }} from {{ $page.orchestrators.variant }}</code>
+                </h2>
+                <p>
+                  <b>{{ $page.orchestrators.description }}</b>
+                </p>
+              </td>
+            </tr>
+          </table>
         </div>
         <div class="single-plugin-main">
-          <g-image
-            v-if="$page.orchestrators.logo_url"
-            :src="
-              require(`!!assets-loader?width=250!@logos/${$page.orchestrators.logo_url.replace(
-                '/assets/logos/',
-                ''
-              )}`)
-            "
-          />
           <h1>
             {{ $page.orchestrators.name }} //
             <span>{{ $page.orchestrators.variant }}</span>
@@ -30,7 +43,7 @@
             >
             allows for workflows to be programmatically authored, scheduled, and monitored.
           </p>
-          <h3>Available Variants</h3>
+          <h3>Other Available Variants</h3>
           <ul>
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link
@@ -149,11 +162,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.orchestrators.name,
+      title: this.$page.orchestrators.name
     };
   },
   name: "OrchestratorsTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Transformers.vue
+++ b/hub-2.0/ui/src/templates/Transformers.vue
@@ -183,11 +183,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.transformers.name
+      title: this.$page.transformers.name,
     };
   },
   name: "TransformersTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Transformers.vue
+++ b/hub-2.0/ui/src/templates/Transformers.vue
@@ -3,21 +3,34 @@
     <div class="single-plugin-overview">
       <div class="single-plugin-detail">
         <div class="single-plugin-top-bar">
-          <h4>
-            {{ $page.transformers.label }} -
-            <span>{{ $page.transformers.description }}</span>
-          </h4>
+          <table>
+            <tr>
+              <td style="padding: 25px">
+                <g-image
+                  v-if="$page.transformers.logo_url"
+                  :src="
+                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.transformers.logo_url.replace(
+                      '/assets/logos/',
+                      ''
+                    )}`)
+                  "
+                />
+              </td>
+              <td>
+                <h1>
+                  {{ $page.transformers.label }}
+                </h1>
+                <h2>
+                  <code>{{ $page.transformers.name }} from {{ $page.transformers.variant }}</code>
+                </h2>
+                <p>
+                  <b>{{ $page.transformers.description }}</b>
+                </p>
+              </td>
+            </tr>
+          </table>
         </div>
         <div class="single-plugin-main">
-          <g-image
-            v-if="$page.transformers.logo_url"
-            :src="
-              require(`!!assets-loader?width=250!@logos/${$page.transformers.logo_url.replace(
-                '/assets/logos/',
-                ''
-              )}`)
-            "
-          />
           <h1>
             {{ $page.transformers.name }} //
             <span>{{ $page.transformers.variant }}</span>
@@ -28,7 +41,7 @@
             <a href="https://docs.meltano.com/concepts/plugins#transformer">transformer</a>
             uses SQL to transform data stored in your warehouse.
           </p>
-          <h3>Available Variants</h3>
+          <h3>Other Available Variants</h3>
           <ul>
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link
@@ -170,11 +183,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.transformers.name,
+      title: this.$page.transformers.name
     };
   },
   name: "TransformersTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Utilities.vue
+++ b/hub-2.0/ui/src/templates/Utilities.vue
@@ -178,11 +178,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.utilities.name
+      title: this.$page.utilities.name,
     };
   },
   name: "UtilitiesTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Utilities.vue
+++ b/hub-2.0/ui/src/templates/Utilities.vue
@@ -3,21 +3,34 @@
     <div class="single-plugin-overview">
       <div class="single-plugin-detail">
         <div class="single-plugin-top-bar">
-          <h4>
-            {{ $page.utilities.label }} -
-            <span>{{ $page.utilities.description }}</span>
-          </h4>
+          <table>
+            <tr>
+              <td style="padding: 25px">
+                <g-image
+                  v-if="$page.utilities.logo_url"
+                  :src="
+                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.utilities.logo_url.replace(
+                      '/assets/logos/',
+                      ''
+                    )}`)
+                  "
+                />
+              </td>
+              <td>
+                <h1>
+                  {{ $page.utilities.label }}
+                </h1>
+                <h2>
+                  <code>{{ $page.utilities.name }} from {{ $page.utilities.variant }}</code>
+                </h2>
+                <p>
+                  <b>{{ $page.utilities.description }}</b>
+                </p>
+              </td>
+            </tr>
+          </table>
         </div>
         <div class="single-plugin-main">
-          <g-image
-            v-if="$page.utilities.logo_url"
-            :src="
-              require(`!!assets-loader?width=250!@logos/${$page.utilities.logo_url.replace(
-                '/assets/logos/',
-                ''
-              )}`)
-            "
-          />
           <h1>
             {{ $page.utilities.name }} //
             <span>{{ $page.utilities.variant }}</span>
@@ -28,7 +41,7 @@
             <a href="https://docs.meltano.com/concepts/plugins#utilities">utility</a>
             is {{ $page.utilities.definition }}
           </p>
-          <h3>Available Variants</h3>
+          <h3>Other Available Variants</h3>
           <ul>
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link :to="variant.node.path" v-if="variant.node.path !== $page.utilities.path">{{
@@ -165,11 +178,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.utilities.name,
+      title: this.$page.utilities.name
     };
   },
   name: "UtilitiesTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 


### PR DESCRIPTION
A number of updates:

- Make background is on detail page and search page white to accommodate for many logos that are white backgrounds and not transparent. (Noted in https://github.com/meltano/hub/issues/733)
- Make code snippets work better on inline references. (Noted in https://github.com/meltano/hub/issues/733)
- Use light blue instead of green in color palette. (Noted in https://github.com/meltano/hub/issues/733)
- Bump page limit from 12 to 100.
- Update index page grid item layouts.

These updates start off just updating the Extractor pages (index and detail pages), and these changes will still need to be replicated to other plugin types (Loaders, Utilities, etc.). 

Note:

- Imports updates from draft PR https://github.com/meltano/hub/pull/702