### PR TITLE
Design overview fix list

### DIFF
--- a/hub-2.0/ui/src/assets/css/main.css
+++ b/hub-2.0/ui/src/assets/css/main.css
@@ -82,14 +82,13 @@ footer {
   flex-basis: 50%;
 }
 
+.plugins-list .page-single-plugin:hover {
+  border-bottom: 5px solid #02a5a5;
+}
+
 .plugins-list .page-single-plugin a {
   color: #3438bf;
   text-decoration: none;
-}
-
-.plugins-list .page-single-plugin a:hover {
-  border: 1px solid #62626e;
-  border-radius: 40px;
 }
 
 .plugins-list .pager-container {
@@ -207,7 +206,7 @@ footer {
   }
 
   .plugins-list .page-single-plugin {
-    flex-basis: 33.333333%;
+    flex-basis: 20%;
   }
 
   .single-plugin-overview {

--- a/hub-2.0/ui/src/components/PluginSidebar.vue
+++ b/hub-2.0/ui/src/components/PluginSidebar.vue
@@ -90,7 +90,7 @@
 <script>
 export default {
   name: "PluginSidebar",
-  props: ["name", "domain_url", "repo", "maintenance_status", "keywords", "variant", "plugin_type"]
+  props: ["name", "domain_url", "repo", "maintenance_status", "keywords", "variant", "plugin_type"],
 };
 </script>
 

--- a/hub-2.0/ui/src/components/PluginSidebar.vue
+++ b/hub-2.0/ui/src/components/PluginSidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="single-plugin-aside">
     <h4>Install</h4>
-    <pre><code>meltano add {{ name }}</code></pre>
+    <pre><code>meltano add {{plugin_type}} {{ name }}</code></pre>
     <h4>Homepage</h4>
     <div class="link-box">
       <img class="aside-icon" src="../assets/images/link-solid.svg" /><a :href="domain_url">{{
@@ -90,7 +90,7 @@
 <script>
 export default {
   name: "PluginSidebar",
-  props: ["name", "domain_url", "repo", "maintenance_status", "keywords", "variant"],
+  props: ["name", "domain_url", "repo", "maintenance_status", "keywords", "variant", "plugin_type"]
 };
 </script>
 

--- a/hub-2.0/ui/src/components/Search.vue
+++ b/hub-2.0/ui/src/components/Search.vue
@@ -49,7 +49,7 @@ export default {
   name: "SearchBar",
   data() {
     return {
-      search: ""
+      search: "",
     };
   },
   computed: {
@@ -60,7 +60,7 @@ export default {
         this.$static.allFiles,
         this.$static.allOrchestrators,
         this.$static.allUtilities,
-        this.$static.allTransformers
+        this.$static.allTransformers,
       ];
       return pluginCollections.flatMap((coll) =>
         coll.edges.filter((plugin) => {
@@ -68,7 +68,7 @@ export default {
             plugin.node.name,
             plugin.node.description,
             plugin.node.label,
-            plugin.node.keywords?.join(" ")
+            plugin.node.keywords?.join(" "),
           ];
           return pluginTextFields
             .join(" ")
@@ -76,8 +76,8 @@ export default {
             .includes(this.search.toLowerCase().trim());
         })
       );
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/components/Search.vue
+++ b/hub-2.0/ui/src/components/Search.vue
@@ -4,7 +4,7 @@
       type="text"
       name="search"
       id="search"
-      placeholder="Search for a plugin..."
+      placeholder="Search 300+ connectors and tools that work with Meltano…"
       class="search-bar"
       v-model="search"
     />
@@ -49,7 +49,7 @@ export default {
   name: "SearchBar",
   data() {
     return {
-      search: "",
+      search: ""
     };
   },
   computed: {
@@ -60,7 +60,7 @@ export default {
         this.$static.allFiles,
         this.$static.allOrchestrators,
         this.$static.allUtilities,
-        this.$static.allTransformers,
+        this.$static.allTransformers
       ];
       return pluginCollections.flatMap((coll) =>
         coll.edges.filter((plugin) => {
@@ -68,7 +68,7 @@ export default {
             plugin.node.name,
             plugin.node.description,
             plugin.node.label,
-            plugin.node.keywords?.join(" "),
+            plugin.node.keywords?.join(" ")
           ];
           return pluginTextFields
             .join(" ")
@@ -76,8 +76,8 @@ export default {
             .includes(this.search.toLowerCase().trim());
         })
       );
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Extractors.vue
+++ b/hub-2.0/ui/src/pages/Extractors.vue
@@ -46,8 +46,8 @@ import { Pager } from "gridsome";
 export default {
   name: "ExtractorsPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Extractors.vue
+++ b/hub-2.0/ui/src/pages/Extractors.vue
@@ -26,12 +26,8 @@
             />
             <h2>{{ edge.node.label }}</h2>
             <h2>
-              <code>{{ edge.node.name }}</code
-              ><br /><code>from {{ edge.node.variant }}</code>
+              <pre><code>{{ edge.node.name }}</code></pre>
             </h2>
-            <p>
-              <i>{{ edge.node.maintenance_status }} status</i>
-            </p>
           </g-link>
         </li>
         <Pager
@@ -50,8 +46,8 @@ import { Pager } from "gridsome";
 export default {
   name: "ExtractorsPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Files.vue
+++ b/hub-2.0/ui/src/pages/Files.vue
@@ -42,8 +42,8 @@ import { Pager } from "gridsome";
 export default {
   name: "FilesPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Files.vue
+++ b/hub-2.0/ui/src/pages/Files.vue
@@ -22,12 +22,8 @@
             />
             <h2>{{ edge.node.label }}</h2>
             <h2>
-              <code>{{ edge.node.name }}</code
-              ><br /><code>from {{ edge.node.variant }}</code>
+              <pre><code>{{ edge.node.name }}</code></pre>
             </h2>
-            <p>
-              <i>{{ edge.node.maintenance_status }} status</i>
-            </p>
           </g-link>
         </li>
         <Pager
@@ -46,8 +42,8 @@ import { Pager } from "gridsome";
 export default {
   name: "FilesPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Index.vue
+++ b/hub-2.0/ui/src/pages/Index.vue
@@ -6,7 +6,6 @@
         Meltano Hub is a central place to find any Meltano plugin as well as Singer taps and
         targets. The Hub is lovingly curated by Meltano and the wider Singer community.
       </h2>
-      <a href="https://docs.meltano.com/concepts/plugins" class="primary-button">Learn More</a>
     </div>
   </Layout>
 </template>
@@ -14,9 +13,9 @@
 <script>
 export default {
   metaInfo: {
-    title: "Home",
+    title: "Home"
   },
-  name: "HomePage",
+  name: "HomePage"
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Index.vue
+++ b/hub-2.0/ui/src/pages/Index.vue
@@ -13,9 +13,9 @@
 <script>
 export default {
   metaInfo: {
-    title: "Home"
+    title: "Home",
   },
-  name: "HomePage"
+  name: "HomePage",
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Loaders.vue
+++ b/hub-2.0/ui/src/pages/Loaders.vue
@@ -43,8 +43,8 @@ import { Pager } from "gridsome";
 export default {
   name: "LoadersPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Loaders.vue
+++ b/hub-2.0/ui/src/pages/Loaders.vue
@@ -23,12 +23,8 @@
             />
             <h2>{{ edge.node.label }}</h2>
             <h2>
-              <code>{{ edge.node.name }}</code
-              ><br /><code>from {{ edge.node.variant }}</code>
+              <pre><code>{{ edge.node.name }}</code></pre>
             </h2>
-            <p>
-              <i>{{ edge.node.maintenance_status }} status</i>
-            </p>
           </g-link>
         </li>
         <Pager
@@ -47,8 +43,8 @@ import { Pager } from "gridsome";
 export default {
   name: "LoadersPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Maintainers.vue
+++ b/hub-2.0/ui/src/pages/Maintainers.vue
@@ -28,8 +28,8 @@ import { Pager } from "gridsome";
 export default {
   name: "MaintainersPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 <page-query lang="graphql">

--- a/hub-2.0/ui/src/pages/Maintainers.vue
+++ b/hub-2.0/ui/src/pages/Maintainers.vue
@@ -8,8 +8,9 @@
           :key="index"
           class="page-single-plugin"
         >
-          <h2>{{ edge.node.label }}</h2>
-          <p>{{ edge.node.name }}</p>
+          <h2>
+            <a :href="`${edge.node.url}`">{{ edge.node.label }}</a>
+          </h2>
         </li>
         <Pager
           :info="$page.allMaintainers.pageInfo"
@@ -27,8 +28,8 @@ import { Pager } from "gridsome";
 export default {
   name: "MaintainersPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 <page-query lang="graphql">

--- a/hub-2.0/ui/src/pages/Orchestrators.vue
+++ b/hub-2.0/ui/src/pages/Orchestrators.vue
@@ -45,8 +45,8 @@ import { Pager } from "gridsome";
 export default {
   name: "OrchestratorsPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Orchestrators.vue
+++ b/hub-2.0/ui/src/pages/Orchestrators.vue
@@ -25,12 +25,8 @@
             />
             <h2>{{ edge.node.label }}</h2>
             <h2>
-              <code>{{ edge.node.name }}</code
-              ><br /><code>from {{ edge.node.variant }}</code>
+              <pre><code>{{ edge.node.name }}</code></pre>
             </h2>
-            <p>
-              <i>{{ edge.node.maintenance_status }} status</i>
-            </p>
           </g-link>
         </li>
         <Pager
@@ -49,8 +45,8 @@ import { Pager } from "gridsome";
 export default {
   name: "OrchestratorsPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Transformers.vue
+++ b/hub-2.0/ui/src/pages/Transformers.vue
@@ -25,12 +25,8 @@
             />
             <h2>{{ edge.node.label }}</h2>
             <h2>
-              <code>{{ edge.node.name }}</code
-              ><br /><code>from {{ edge.node.variant }}</code>
+              <pre><code>{{ edge.node.name }}</code></pre>
             </h2>
-            <p>
-              <i>{{ edge.node.maintenance_status }} status</i>
-            </p>
           </g-link>
         </li>
         <Pager
@@ -49,8 +45,8 @@ import { Pager } from "gridsome";
 export default {
   name: "TransformersPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Transformers.vue
+++ b/hub-2.0/ui/src/pages/Transformers.vue
@@ -45,8 +45,8 @@ import { Pager } from "gridsome";
 export default {
   name: "TransformersPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Utilities.vue
+++ b/hub-2.0/ui/src/pages/Utilities.vue
@@ -41,8 +41,8 @@ import { Pager } from "gridsome";
 export default {
   name: "UtilitiesPage",
   components: {
-    Pager
-  }
+    Pager,
+  },
 };
 </script>
 

--- a/hub-2.0/ui/src/pages/Utilities.vue
+++ b/hub-2.0/ui/src/pages/Utilities.vue
@@ -21,12 +21,8 @@
             />
             <h2>{{ edge.node.label }}</h2>
             <h2>
-              <code>{{ edge.node.name }}</code
-              ><br /><code>from {{ edge.node.variant }}</code>
+              <pre><code>{{ edge.node.name }}</code></pre>
             </h2>
-            <p>
-              <i>{{ edge.node.maintenance_status }} status</i>
-            </p>
           </g-link>
         </li>
         <Pager
@@ -45,8 +41,8 @@ import { Pager } from "gridsome";
 export default {
   name: "UtilitiesPage",
   components: {
-    Pager,
-  },
+    Pager
+  }
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Extractors.vue
+++ b/hub-2.0/ui/src/templates/Extractors.vue
@@ -31,7 +31,6 @@
           </table>
         </div>
         <div class="single-plugin-main">
-          <p>{{ $page.extractors.usage }}</p>
           <p>
             The {{ $page.extractors.name }}
             <a href="https://docs.meltano.com/concepts/plugins#extractors">Meltano extractor</a>
@@ -158,6 +157,7 @@
           :maintenance_status="$page.extractors.maintenance_status"
           :keywords="$page.extractors.keywords"
           :variant="$page.extractors.variant"
+          plugin_type="extractor"
         />
       </div>
     </div>
@@ -170,11 +170,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.extractors.name,
+      title: this.$page.extractors.name
     };
   },
   name: "ExtractorsTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 
@@ -218,9 +218,4 @@ query Extractors($path: String!, $name: String!) {
 }
 </page-query>
 
-<style lang="scss">
-.add-more-info {
-  color: red;
-  border: 1px solid red;
-}
-</style>
+<style lang="scss"></style>

--- a/hub-2.0/ui/src/templates/Extractors.vue
+++ b/hub-2.0/ui/src/templates/Extractors.vue
@@ -170,11 +170,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.extractors.name
+      title: this.$page.extractors.name,
     };
   },
   name: "ExtractorsTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Files.vue
+++ b/hub-2.0/ui/src/templates/Files.vue
@@ -31,11 +31,6 @@
           </table>
         </div>
         <div class="single-plugin-main">
-          <h1>
-            {{ $page.files.name }} //
-            <span>{{ $page.files.variant }}</span>
-          </h1>
-          <p>{{ $page.files.usage }}</p>
           <p>
             The {{ $page.files.name }}
             <a href="https://docs.meltano.com/concepts/plugins#file-bundles">file bundle</a>
@@ -69,7 +64,6 @@
               >
             </li>
           </ol>
-          <p>{{ $page.files.prereq }}</p>
           <h3>Installation and configuration</h3>
           <ol>
             <li>
@@ -128,15 +122,10 @@
             </li>
           </ul>
           <p>
-            The settings for extractor tap-github that are known to Meltano are documented below. To
-            quickly find the setting you're looking for, use the Table of Contents at the top of the
-            page.
+            The settings for {{ $page.files.name }} that are known to Meltano are documented below.
+            To quickly find the setting you're looking for, use the Table of Contents at the top of
+            the page.
           </p>
-          <p class="add-more-info">Account ID</p>
-          <p class="add-more-info">Personal Access Token</p>
-          <p class="add-more-info">Start Date</p>
-          <p class="add-more-info">End Date</p>
-          <p class="add-more-info">Anything else</p>
           <h2>Looking for help?</h2>
           <div>
             If you're having trouble getting the
@@ -165,6 +154,7 @@
           :maintenance_status="$page.files.maintenance_status"
           :keywords="$page.files.keywords"
           :variant="$page.files.variant"
+          plugin_type="file"
         />
       </div>
     </div>
@@ -177,11 +167,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.files.name,
+      title: this.$page.files.name
     };
   },
   name: "FilesTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 
@@ -213,9 +203,4 @@ query Files($path: String!, $name: String!) {
 }
 </page-query>
 
-<style>
-.add-more-info {
-  color: red;
-  border: 1px solid red;
-}
-</style>
+<style></style>

--- a/hub-2.0/ui/src/templates/Files.vue
+++ b/hub-2.0/ui/src/templates/Files.vue
@@ -167,11 +167,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.files.name
+      title: this.$page.files.name,
     };
   },
   name: "FilesTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Loaders.vue
+++ b/hub-2.0/ui/src/templates/Loaders.vue
@@ -168,11 +168,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.loaders.name
+      title: this.$page.loaders.name,
     };
   },
   name: "LoadersTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Loaders.vue
+++ b/hub-2.0/ui/src/templates/Loaders.vue
@@ -31,12 +31,6 @@
           </table>
         </div>
         <div class="single-plugin-main">
-          <h1>
-            {{ $page.loaders.name }} //
-            <span>{{ $page.loaders.variant }}</span>
-          </h1>
-
-          <p>{{ $page.loaders.usage }}</p>
           <p>
             The {{ $page.loaders.name }}
             <a href="https://docs.meltano.com/concepts/plugins#loaders">Meltano loader</a>
@@ -73,7 +67,6 @@
               >
             </li>
           </ol>
-          <p>{{ $page.loaders.prereq }}</p>
           <h3>Installation and configuration</h3>
           <ol>
             <li>
@@ -132,15 +125,10 @@
             </li>
           </ul>
           <p>
-            The settings for extractor tap-github that are known to Meltano are documented below. To
-            quickly find the setting you're looking for, use the Table of Contents at the top of the
-            page.
+            The settings for {{ $page.loaders.name }} that are known to Meltano are documented
+            below. To quickly find the setting you're looking for, use the Table of Contents at the
+            top of the page.
           </p>
-          <p class="add-more-info">Account ID</p>
-          <p class="add-more-info">Personal Access Token</p>
-          <p class="add-more-info">Start Date</p>
-          <p class="add-more-info">End Date</p>
-          <p class="add-more-info">Anything else</p>
           <h2>Looking for help?</h2>
           <div>
             If you're having trouble getting the {{ $page.loaders.name }} loader to work, look for
@@ -167,6 +155,7 @@
           :maintenance_status="$page.loaders.maintenance_status"
           :keywords="$page.loaders.keywords"
           :variant="$page.loaders.variant"
+          plugin_type="loader"
         />
       </div>
     </div>
@@ -179,11 +168,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.loaders.name,
+      title: this.$page.loaders.name
     };
   },
   name: "LoadersTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 
@@ -224,9 +213,4 @@ query Loaders($path: String!, $name: String!) {
 }
 </page-query>
 
-<style lang="scss">
-.add-more-info {
-  color: red;
-  border: 1px solid red;
-}
-</style>
+<style lang="scss"></style>

--- a/hub-2.0/ui/src/templates/Orchestrators.vue
+++ b/hub-2.0/ui/src/templates/Orchestrators.vue
@@ -31,11 +31,6 @@
           </table>
         </div>
         <div class="single-plugin-main">
-          <h1>
-            {{ $page.orchestrators.name }} //
-            <span>{{ $page.orchestrators.variant }}</span>
-          </h1>
-          <p>{{ $page.orchestrators.usage }}</p>
           <p>
             The {{ $page.orchestrators.name }}
             <a href="https://docs.meltano.com/concepts/plugins#orchestrators"
@@ -73,7 +68,6 @@
               >
             </li>
           </ol>
-          <p>{{ $page.orchestrators.prereq }}</p>
           <h3>Installation and configuration</h3>
 
           <p>Add the airflow orchestrator to your project using meltano add :</p>
@@ -89,18 +83,7 @@
           </ol>
 
           <h3>Next steps</h3>
-          <p>{{ $page.orchestrators.next_steps }}</p>
           <p>If you run into any issues, learn how to get help.</p>
-          <!-- <h2>Capabilities</h2>
-          <p>The current capabilities for
-          <pre class="inline-code-block"><code>{{ $page.orchestrators.name }}</code></pre> may have been automatically
-          set when originally added to the Hub. Please review the capabilities when using this extractor. If you find
-          they are out of date, please consider updating them by making a pull request to the YAML file that defines the
-          capabilities for this extractor.</p>
-          <p>This plugin has the following capabilities:</p>
-          <ul>
-            <li v-for="(capability, index) in $page.orchestrators.capabilities" v-bind:key="index">{{ capability }}</li>
-          </ul> -->
           <h2>Settings</h2>
           <p>
             {{ $page.orchestrators.name }} requires the configuration of the following settings:
@@ -111,17 +94,10 @@
             </li>
           </ul>
           <p>
-            The settings for extractor tap-github that are known to Meltano are documented below. To
-            quickly find the setting you're looking for, use the Table of Contents at the top of the
-            page.
+            The settings for {{ $page.orchestrators.name }} that are known to Meltano are documented
+            below. To quickly find the setting you're looking for, use the Table of Contents at the
+            top of the page.
           </p>
-          <!-- <h3>Personal Access Tokens (access_token)</h3>
-          <ul><li>Environment variable: TAP_GITHUB_ACCESS_TOKEN</li></ul> -->
-          <p class="add-more-info">Account ID</p>
-          <p class="add-more-info">Personal Access Token</p>
-          <p class="add-more-info">Start Date</p>
-          <p class="add-more-info">End Date</p>
-          <p class="add-more-info">Anything else</p>
           <h2>Looking for help?</h2>
           <div>
             If you're having trouble getting the
@@ -150,6 +126,7 @@
           :maintenance_status="$page.orchestrators.maintenance_status"
           :keywords="$page.orchestrators.keywords"
           :variant="$page.orchestrators.variant"
+          plugin_type="orchestrator"
         />
       </div>
     </div>
@@ -162,11 +139,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.orchestrators.name,
+      title: this.$page.orchestrators.name
     };
   },
   name: "OrchestratorsTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 
@@ -219,9 +196,4 @@ query Orchestrators($path: String!, $name: String!) {
 }
 </page-query>
 
-<style>
-.add-more-info {
-  color: red;
-  border: 1px solid red;
-}
-</style>
+<style></style>

--- a/hub-2.0/ui/src/templates/Orchestrators.vue
+++ b/hub-2.0/ui/src/templates/Orchestrators.vue
@@ -139,11 +139,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.orchestrators.name
+      title: this.$page.orchestrators.name,
     };
   },
   name: "OrchestratorsTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Transformers.vue
+++ b/hub-2.0/ui/src/templates/Transformers.vue
@@ -168,11 +168,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.transformers.name
+      title: this.$page.transformers.name,
     };
   },
   name: "TransformersTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Transformers.vue
+++ b/hub-2.0/ui/src/templates/Transformers.vue
@@ -31,11 +31,6 @@
           </table>
         </div>
         <div class="single-plugin-main">
-          <h1>
-            {{ $page.transformers.name }} //
-            <span>{{ $page.transformers.variant }}</span>
-          </h1>
-          <p>{{ $page.transformers.usage }}</p>
           <p>
             The {{ $page.transformers.name }}
             <a href="https://docs.meltano.com/concepts/plugins#transformer">transformer</a>
@@ -71,7 +66,6 @@
               >
             </li>
           </ol>
-          <p>{{ $page.transformers.prereq }}</p>
           <h3>Installation and configuration</h3>
           <ol>
             <li>
@@ -102,12 +96,7 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-          <!-- <h2>Capabilities</h2>
-          <p>The current capabilities for <pre class="inline-code-block"><code>{{ $page.transformers.name }}</code></pre> may have been automatically set when originally added to the Hub. Please review the capabilities when using this extractor. If you find they are out of date, please consider updating them by making a pull request to the YAML file that defines the capabilities for this extractor.</p>
-          <p>This plugin has the following capabilities:</p>
-          <ul>
-            <li v-for="(capability, index) in $page.transformers.capabilities" v-bind:key="index">{{capability}}</li>
-          </ul> -->
+
           <h2>Settings</h2>
           <p>
             Settings for {{ $page.transformers.name }} itself can be configured through
@@ -127,9 +116,9 @@
             </li>
           </ul>
           <p>
-            The settings for extractor tap-github that are known to Meltano are documented below. To
-            quickly find the setting you're looking for, use the Table of Contents at the top of the
-            page.
+            The settings for {{ $page.transformers.name }} that are known to Meltano are documented
+            below. To quickly find the setting you're looking for, use the Table of Contents at the
+            top of the page.
           </p>
           <h2>Commands</h2>
           <ol>
@@ -138,11 +127,6 @@
               <span>{{ command.description }}</span>
             </li>
           </ol>
-          <p class="add-more-info">Account ID</p>
-          <p class="add-more-info">Personal Access Token</p>
-          <p class="add-more-info">Start Date</p>
-          <p class="add-more-info">End Date</p>
-          <p class="add-more-info">Anything else</p>
           <h2>Looking for help?</h2>
           <div>
             If you're having trouble getting the
@@ -171,6 +155,7 @@
           :maintenance_status="$page.transformers.maintenance_status"
           :keywords="$page.transformers.keywords"
           :variant="$page.transformers.variant"
+          plugin_type="transformer"
         />
       </div>
     </div>
@@ -183,11 +168,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.transformers.name,
+      title: this.$page.transformers.name
     };
   },
   name: "TransformersTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 
@@ -279,9 +264,4 @@ query Transformers($path: String!, $name: String!) {
 }
 </page-query>
 
-<style>
-.add-more-info {
-  color: red;
-  border: 1px solid red;
-}
-</style>
+<style></style>

--- a/hub-2.0/ui/src/templates/Utilities.vue
+++ b/hub-2.0/ui/src/templates/Utilities.vue
@@ -167,11 +167,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.utilities.name
+      title: this.$page.utilities.name,
     };
   },
   name: "UtilitiesTemplate",
-  components: { PluginSidebar }
+  components: { PluginSidebar },
 };
 </script>
 

--- a/hub-2.0/ui/src/templates/Utilities.vue
+++ b/hub-2.0/ui/src/templates/Utilities.vue
@@ -31,11 +31,6 @@
           </table>
         </div>
         <div class="single-plugin-main">
-          <h1>
-            {{ $page.utilities.name }} //
-            <span>{{ $page.utilities.variant }}</span>
-          </h1>
-          <!-- <p>{{ $page.utilities.usage }}</p> -->
           <p>
             The {{ $page.utilities.name }}
             <a href="https://docs.meltano.com/concepts/plugins#utilities">utility</a>
@@ -69,8 +64,6 @@
               >
             </li>
           </ol>
-          <p>{{ $page.utilities.prereq }}</p>
-          <p>{{ $page.utilities.next_steps }}</p>
           <h3>Installation and configuration</h3>
           <ol>
             <li>
@@ -129,15 +122,10 @@
             </li>
           </ul>
           <p>
-            The settings for extractor tap-github that are known to Meltano are documented below. To
-            quickly find the setting you're looking for, use the Table of Contents at the top of the
-            page.
+            The settings for {{ $page.utilities.name }} that are known to Meltano are documented
+            below. To quickly find the setting you're looking for, use the Table of Contents at the
+            top of the page.
           </p>
-          <p class="add-more-info">Account ID</p>
-          <p class="add-more-info">Personal Access Token</p>
-          <p class="add-more-info">Start Date</p>
-          <p class="add-more-info">End Date</p>
-          <p class="add-more-info">Anything else</p>
           <h2>Looking for help?</h2>
           <div>
             If you're having trouble getting the
@@ -166,6 +154,7 @@
           :maintenance_status="$page.utilities.maintenance_status"
           :keywords="$page.utilities.keywords"
           :variant="$page.utilities.variant"
+          plugin_type="utility"
         />
       </div>
     </div>
@@ -178,11 +167,11 @@ import PluginSidebar from "../components/PluginSidebar.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.utilities.name,
+      title: this.$page.utilities.name
     };
   },
   name: "UtilitiesTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar }
 };
 </script>
 


### PR DESCRIPTION
This PR does the following:

- Removes the CTA button on the homepage
- Cleans up some css
- Makes plugin pages show five items per row instead of three
- Cleans up the cards on the plugin pages
- Adds a plugin_type prop type to the sidebar
- Fixes the placeholder text on the searchbar