### PR TITLE
feat: Componentize templates, plus several fixes and improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ yarn add --global @gridsome/cli
 
 ```console
 gridsome build
-gridsome server
+gridsome serve
 ```
 
 Or build for development and get live updates as files are changed:

--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -154,10 +154,6 @@ clrcrl:
   label: Claire Carroll
   url: https://github.com/clrcrl
   name: clrcrl
-cmbramwell:
-  label: Christian Bramwell
-  url: https://github.com/cmbramwell
-  name: cmbramwell
 cmoresid:
   label: Connor Moreside
   url: https://github.com/cmoresid
@@ -566,10 +562,6 @@ meltanolabs:
   label: Meltano Community
   url: https://github.com/MeltanoLabs
   name: meltanolabs
-meowwolf:
-  label: Meow Wolf
-  url: https://meowwolf.com/
-  name: meowwolf
 mikedillion:
   label: GitHub - mikedillion
   url: https://github.com/mikedillion
@@ -674,10 +666,6 @@ phdesign:
   label: Paul Heasley
   url: https://github.com/phdesign
   name: phdesign
-phillymedia:
-  label: GitHub - phillymedia
-  url: https://github.com/phillymedia
-  name: phillymedia
 pk-sakthivel:
   label: GitHub - pk-sakthivel
   url: https://github.com/pk-sakthivel
@@ -726,22 +714,10 @@ rafaeljusi:
   label: Rafael Jusi
   url: https://github.com/rafaeljusi
   name: rafaeljusi
-ragbadaskar:
-  label: Raghav B
-  url: https://github.com/ragbadaskar
-  name: ragbadaskar
 rahimnathwani:
   label: GitHub - rahimnathwani
   url: https://github.com/rahimnathwani
   name: rahimnathwani
-rangle:
-  label: Rangle
-  url: http://rangle.io/
-  name: rangle
-reachlocal:
-  label: ReachLocal, Inc.
-  url: http://www.reachlocal.com/
-  name: reachlocal
 rfainc:
   label: RFA
   url: https://github.com/RFAInc

--- a/_data/meltano/orchestrators/airflow/apache.yml
+++ b/_data/meltano/orchestrators/airflow/apache.yml
@@ -12,9 +12,11 @@ requires:
     variant: meltano
 commands:
   create-admin:
+    name: "create-admin"
     args: "users create --username admin --firstname FIRST_NAME --lastname LAST_NAME --role Admin --email admin@example.org"
     description: Create an admin user.
   ui:
+    name: "ui"
     args: webserver
     description: Start the Airflow webserver.
 next_steps: |

--- a/_data/meltano/transformers/dbt-bigquery/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt-bigquery/dbt-labs.yml
@@ -66,38 +66,50 @@ settings:
     The path to the `keyfile.json`` to use, if authenticating via service-account method.
 commands:
   clean:
+    name: clean
     args: clean
     description: Delete all folders in the clean-targets list (usually the dbt_modules and target directories.)
   compile:
+    name: compile
     args: compile
     description: Generates executable SQL from source model, test, and analysis files. Compiled SQL files are written to the target/ directory.
   deps:
+    name: deps
     args: deps
     description: Pull the most recent version of the dependencies listed in packages.yml
   run:
+    name: run
     args: run
     description: Compile SQL and execute against the current target database.
   seed:
+    name: seed
     args: seed
     description: Load data from csv files into your data warehouse.
   snapshot:
+    name: snapshot
     args: snapshot
     description: Execute snapshots defined in your project.
   test:
+    name: test
     args: test
     description: Runs tests on data in deployed models.
   freshness:
+    name: freshness
     args: source freshness
     description: Check the freshness of your source data.
   build:
+    name: build
     args: build
     description: Will run your models, tests, snapshots and seeds in DAG order.
   docs-generate:
+    name: docs-generate
     args: docs generate
     description: Generate documentation for your project.
   docs-serve:
+    name: docs-serve
     args: docs serve
     description: Serve documentation for your project. Make sure you ran `docs-generate` first.
   debug:
+    name: debug
     args: debug
     description: Debug your DBT project and warehouse connection.

--- a/_data/meltano/transformers/dbt-postgres/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt-postgres/dbt-labs.yml
@@ -75,38 +75,50 @@ settings:
     SSL Mode used to connect to the database.
 commands:
   clean:
+    name: clean
     args: clean
     description: Delete all folders in the clean-targets list (usually the dbt_modules and target directories.)
   compile:
+    name: compile
     args: compile
     description: Generates executable SQL from source model, test, and analysis files. Compiled SQL files are written to the target/ directory.
   deps:
+    name: deps
     args: deps
     description: Pull the most recent version of the dependencies listed in packages.yml
   run:
+    name: run
     args: run
     description: Compile SQL and execute against the current target database.
   seed:
+    name: seed
     args: seed
     description: Load data from csv files into your data warehouse.
   snapshot:
+    name: snapshot
     args: snapshot
     description: Execute snapshots defined in your project.
   test:
+    name: test
     args: test
     description: Runs tests on data in deployed models.
   freshness:
+    name: freshness
     args: source freshness
     description: Check the freshness of your source data.
   build:
+    name: build
     args: build
     description: Will run your models, tests, snapshots and seeds in DAG order.
   docs-generate:
+    name: docs-generate
     args: docs generate
     description: Generate documentation for your project.
   docs-serve:
+    name: docs-serve
     args: docs serve
     description: Serve documentation for your project. Make sure you ran `docs-generate` first.
   debug:
+    name: debug
     args: debug
     description: Debug your DBT project and warehouse connection.

--- a/_data/meltano/transformers/dbt-redshift/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt-redshift/dbt-labs.yml
@@ -106,38 +106,50 @@ settings:
     Enables cross-database sources.
 commands:
   clean:
+    name: clean
     args: clean
     description: Delete all folders in the clean-targets list (usually the dbt_modules and target directories.)
   compile:
+    name: compile
     args: compile
     description: Generates executable SQL from source model, test, and analysis files. Compiled SQL files are written to the target/ directory.
   deps:
+    name: deps
     args: deps
     description: Pull the most recent version of the dependencies listed in packages.yml
   run:
+    name: run
     args: run
     description: Compile SQL and execute against the current target database.
   seed:
+    name: seed
     args: seed
     description: Load data from csv files into your data warehouse.
   snapshot:
+    name: snapshot
     args: snapshot
     description: Execute snapshots defined in your project.
   test:
+    name: test
     args: test
     description: Runs tests on data in deployed models.
   freshness:
+    name: freshness
     args: source freshness
     description: Check the freshness of your source data.
   build:
+    name: build
     args: build
     description: Will run your models, tests, snapshots and seeds in DAG order.
   docs-generate:
+    name: docs-generate
     args: docs generate
     description: Generate documentation for your project.
   docs-serve:
+    name: docs-serve
     args: docs serve
     description: Serve documentation for your project. Make sure you ran `docs-generate` first.
   debug:
+    name: debug
     args: debug
     description: Debug your DBT project and warehouse connection.

--- a/_data/meltano/transformers/dbt-snowflake/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt-snowflake/dbt-labs.yml
@@ -51,41 +51,53 @@ settings:
   description: The schema to build models into by default.
 commands:
   clean:
+    name: clean
     args: clean
     description: Delete all folders in the clean-targets list (usually the dbt_modules
       and target directories.)
   compile:
+    name: clean
     args: compile
     description: Generates executable SQL from source model, test, and analysis files.
       Compiled SQL files are written to the target/ directory.
   deps:
+    name: deps
     args: deps
     description: Pull the most recent version of the dependencies listed in packages.yml
   run:
+    name: run
     args: run
     description: Compile SQL and execute against the current target database.
   seed:
+    name: seed
     args: seed
     description: Load data from csv files into your data warehouse.
   snapshot:
+    name: snapshot
     args: snapshot
     description: Execute snapshots defined in your project.
   test:
+    name: test
     args: test
     description: Runs tests on data in deployed models.
   freshness:
+    name: freshness
     args: source freshness
     description: Check the freshness of your source data.
   build:
+    name: build
     args: build
     description: Will run your models, tests, snapshots and seeds in DAG order.
   docs-generate:
+    name: docs-generate
     args: docs generate
     description: Generate documentation for your project.
   docs-serve:
+    name: docs-serve
     args: docs serve
     description: Serve documentation for your project. Make sure you ran `docs-generate` first.
   debug:
+    name: debug
     args: debug
     description: Debug your DBT project and warehouse connection.
 logo_url: /assets/logos/transformers/dbt-snowflake.png

--- a/_data/meltano/transformers/dbt/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt/dbt-labs.yml
@@ -35,41 +35,53 @@ settings:
   value: $MELTANO_TRANSFORM__PACKAGE_NAME $MELTANO_EXTRACTOR_NAMESPACE my_meltano_project
 commands:
   clean:
+    name: clean
     args: clean
     description: Delete all folders in the clean-targets list (usually the dbt_modules
       and target directories.)
   compile:
+    name: compile
     args: compile --models $DBT_MODELS
     description: Generates executable SQL from source model, test, and analysis files.
       Compiled SQL files are written to the target/ directory.
   deps:
+    name: deps
     args: deps
     description: Pull the most recent version of the dependencies listed in packages.yml
   run:
+    name: run
     args: run --models $DBT_MODELS
     description: Compile SQL and execute against the current target database.
   seed:
+    name: seed
     args: seed
     description: Load data from csv files into your data warehouse.
   snapshot:
+    name: snapshot
     args: snapshot
     description: Execute snapshots defined in your project.
   test:
+    name: test
     args: test
     description: Runs tests on data in deployed models.
   freshness:
+    name: freshness
     args: source freshness
     description: Check the freshness of your source data.
   build:
+    name: build
     args: build
     description: Will run your models, tests, snapshots and seeds in DAG order.
   docs-generate:
+    name: docs-generate
     args: docs generate
     description: Generate documentation for your project.
   docs-serve:
+    name: docs-serve
     args: docs serve
     description: Serve documentation for your project. Make sure you ran `docs-generate` first.
   debug:
+    name: debug
     args: debug
     description: Debug your DBT project and warehouse connection.
 logo_url: /assets/logos/transformers/dbt.png

--- a/_data/meltano/utilities/datahub/datahub-project.yml
+++ b/_data/meltano/utilities/datahub/datahub-project.yml
@@ -9,6 +9,7 @@ logo_url: /assets/logos/utilities/datahub.png
 variant: datahub-project
 commands:
   ingest-dbt:
+    name: ingest-dbt
     args: ingest run --config ${MELTANO_PROJECT_ROOT}/utilities/datahub/dbt.dhub.yml
     description: Push dbt metadata to datahub
 requires:

--- a/_data/meltano/utilities/sqlfluff/sqlfluff.yml
+++ b/_data/meltano/utilities/sqlfluff/sqlfluff.yml
@@ -7,12 +7,15 @@ repo: https://github.com/sqlfluff/sqlfluff
 variant: sqlfluff
 commands:
   lint:
+    name: lint
     args: lint
     description: Lint SQL in transform models.
   fix:
+    name: fix
     args: fix
     description: Automatically fix SQL files according to your defined rules.
   fix-force:
+    name: fix-force
     args: fix --force
     description: Automatically fix SQL files according to your defined rules (does not ask for confirmation).
 logo_url: /assets/logos/utilities/sqlfluff.png

--- a/_data/meltano/utilities/superset/apache.yml
+++ b/_data/meltano/utilities/superset/apache.yml
@@ -38,13 +38,16 @@ settings:
   description: App secret key used for securely signing the session cookie and encrypting sensitive information on the database. Equivalent to the `SECRET_KEY` setting in `superset_config.py`.
 commands:
   ui:
+    name: ui
     executable: gunicorn
     args: --bind $SUPERSET_UI_BIND_HOST:$SUPERSET_UI_PORT --timeout $SUPERSET_UI_TIMEOUT --workers $SUPERSET_UI_WORKERS superset.app:create_app()
     description: Start the Superset UI. Will be available on the configured `ui.bind_host` and `ui.port`, which default to `http://localhost:8088`
   create-admin:
+    name: create-admin
     args: fab create-admin
     description: Create an admin user.
   load-examples:
+    name: load-examples
     args: load_examples
     description: Load examples.
 logo_url: /assets/logos/utilities/superset.png

--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -1,43 +1,37 @@
 <template>
-    <div>
-      <h2 id="capabilities">Capabilities</h2>
-      <span v-if="capabilities">
-        <p>
-            The current capabilities for
-            <pre class="inline-code-block"><code>{{ name }}</code></pre>
-            may have been automatically set when originally added to the Hub. Please review the
-            capabilities when using this extractor. If you find they are out of date, please
-            consider updating them by making a pull request to the YAML file that defines the
-            capabilities for this extractor.
-        </p>
-          <p>This plugin has the following capabilities:</p>
-          <ul>
-            <li v-for="(capability, index) in $page.extractors.capabilities" v-bind:key="index">
-              {{ capability }}
-            </li>
-          </ul>
-        <p>
-          You can
-          <a
-            href="https://docs.meltano.com/guide/configuration#overriding-discoverable-plugin-properties"
-            >override these capabilities or specify additional ones</a
-          >
-          in your <code>meltano.yml</code> by adding the <code>capabilities</code> key.
-        </p>
-      </span>
-      <span v-else
-        >This plugin currently has no capabilities defined. If you know the capabilities required by this
-        plugin, <a href="#contribute">please contribute!</a></span
-      >
-    </div>
-  </template>
+  <div>
+    <h2 id="capabilities">Capabilities</h2>
+    <span v-if="capabilities">
+      <p>The current capabilities for
+      <pre class="inline-code-block"><code>{{ name }}</code></pre> may have been automatically set when originally added
+      to the Hub. Please review the capabilities when using this {{ plugin_type }}. If you find they are out of date,
+      please consider updating them by making a pull request to the YAML file that defines the capabilities for this
+      {{ plugin_type }}.</p>
+      <p>This plugin has the following capabilities:</p>
+      <ul>
+        <li v-for="(capability, index) in $page.extractors.capabilities" v-bind:key="index">
+          {{ capability }}
+        </li>
+      </ul>
+      <p>
+        You can
+        <a href="https://docs.meltano.com/guide/configuration#overriding-discoverable-plugin-properties">override these
+          capabilities or specify additional ones</a>
+        in your <code>meltano.yml</code> by adding the <code>capabilities</code> key.
+      </p>
+    </span>
+    <span v-else>This plugin currently has no capabilities defined. If you know the capabilities required by this
+      plugin, <a href="#contribute">please contribute!</a></span>
+  </div>
+</template>
   
   <script>
-  export default {
-    name: "PluginCapabilitiesSection",
-    props: ["capabilities", "name"],
-  };
-  </script>
+export default {
+  name: "PluginCapabilitiesSection",
+  props: ["capabilities", "name", "plugin_type"],
+};
+</script>
   
-  <style></style>
+  <style>
+  </style>
   

--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -35,7 +35,7 @@
 <script>
 export default {
   name: "PluginCapabilitiesSection",
-  props: ["capabilities", "name", "plugin_type"]
+  props: ["capabilities", "name", "plugin_type"],
 };
 </script>
 

--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -12,7 +12,7 @@
       >
       <p>This plugin has the following capabilities:</p>
       <ul>
-        <li v-for="(capability, index) in $page.extractors.capabilities" v-bind:key="index">
+        <li v-for="(capability, index) in capabilities" v-bind:key="index">
           {{ capability }}
         </li>
       </ul>
@@ -35,7 +35,7 @@
 <script>
 export default {
   name: "PluginCapabilitiesSection",
-  props: ["capabilities", "name", "plugin_type"],
+  props: ["capabilities", "name", "plugin_type"]
 };
 </script>
 

--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -1,0 +1,43 @@
+<template>
+    <div>
+      <h2 id="capabilities">Capabilities</h2>
+      <span v-if="capabilities.length">
+        <p>
+            The current capabilities for
+            <pre class="inline-code-block"><code>{{ name }}</code></pre>
+            may have been automatically set when originally added to the Hub. Please review the
+            capabilities when using this extractor. If you find they are out of date, please
+            consider updating them by making a pull request to the YAML file that defines the
+            capabilities for this extractor.
+        </p>
+          <p>This plugin has the following capabilities:</p>
+          <ul>
+            <li v-for="(capability, index) in $page.extractors.capabilities" v-bind:key="index">
+              {{ capability }}
+            </li>
+          </ul>
+        <p>
+          You can
+          <a
+            href="https://docs.meltano.com/guide/configuration#overriding-discoverable-plugin-properties"
+            >override these capabilities or specify additional ones</a
+          >
+          in your <code>meltano.yml</code> by adding the <code>capabilities</code> key.
+        </p>
+      </span>
+      <span v-else
+        >This plugin currently has no capabilities defined. If you know the capabilities required by this
+        plugin, <a href="#contribute">please contribute!</a></span
+      >
+    </div>
+  </template>
+  
+  <script>
+  export default {
+    name: "PluginCapabilitiesSection",
+    props: ["capabilities", "name"],
+  };
+  </script>
+  
+  <style></style>
+  

--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
       <h2 id="capabilities">Capabilities</h2>
-      <span v-if="capabilities.length">
+      <span v-if="capabilities">
         <p>
             The current capabilities for
             <pre class="inline-code-block"><code>{{ name }}</code></pre>

--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -2,11 +2,14 @@
   <div>
     <h2 id="capabilities">Capabilities</h2>
     <span v-if="capabilities">
-      <p>The current capabilities for
-      <pre class="inline-code-block"><code>{{ name }}</code></pre> may have been automatically set when originally added
-      to the Hub. Please review the capabilities when using this {{ plugin_type }}. If you find they are out of date,
-      please consider updating them by making a pull request to the YAML file that defines the capabilities for this
-      {{ plugin_type }}.</p>
+      <span
+        >The current capabilities for
+        <pre class="inline-code-block"><code>{{ name }}</code></pre>
+        may have been automatically set when originally added to the Hub. Please review the
+        capabilities when using this {{ plugin_type }}. If you find they are out of date, please
+        consider updating them by making a pull request to the YAML file that defines the
+        capabilities for this {{ plugin_type }}.</span
+      >
       <p>This plugin has the following capabilities:</p>
       <ul>
         <li v-for="(capability, index) in $page.extractors.capabilities" v-bind:key="index">
@@ -15,23 +18,25 @@
       </ul>
       <p>
         You can
-        <a href="https://docs.meltano.com/guide/configuration#overriding-discoverable-plugin-properties">override these
-          capabilities or specify additional ones</a>
+        <a
+          href="https://docs.meltano.com/guide/configuration#overriding-discoverable-plugin-properties"
+          >override these capabilities or specify additional ones</a
+        >
         in your <code>meltano.yml</code> by adding the <code>capabilities</code> key.
       </p>
     </span>
-    <span v-else>This plugin currently has no capabilities defined. If you know the capabilities required by this
-      plugin, <a href="#contribute">please contribute!</a></span>
+    <span v-else
+      >This plugin currently has no capabilities defined. If you know the capabilities required by
+      this plugin, <a href="#contribute">please contribute!</a></span
+    >
   </div>
 </template>
-  
-  <script>
+
+<script>
 export default {
   name: "PluginCapabilitiesSection",
   props: ["capabilities", "name", "plugin_type"],
 };
 </script>
-  
-  <style>
-  </style>
-  
+
+<style></style>

--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -30,7 +30,7 @@
 <script>
 export default {
   name: "PluginCommandsSection",
-  props: ["commands", "name", "plugin_type"]
+  props: ["commands", "name", "plugin_type"],
 };
 </script>
 

--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -6,16 +6,16 @@
       <pre><code>meltano invoke</code></pre>
       :</span
     >
-    <div v-for="(key, value, index) in commands" v-bind:key="index">
+    <div v-for="(value, key, index) in commands" v-bind:key="index">
       <span v-if="value">
         <h3>
-          <pre><code>{{ key.name }}</code></pre>
+          <pre><code>{{ value.name }}</code></pre>
         </h3>
         <span
           >Equivalent to:
-          <pre><code>{{ key.args }}</code></pre>
+          <pre><code>{{ value.args }}</code></pre>
         </span>
-        <p>{{ key.description }}</p>
+        <p>{{ value.description }}</p>
         <h3>How to use</h3>
         <span
           >Run this command using
@@ -30,7 +30,7 @@
 <script>
 export default {
   name: "PluginCommandsSection",
-  props: ["commands", "name", "plugin_type"],
+  props: ["commands", "name", "plugin_type"]
 };
 </script>
 

--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -1,36 +1,41 @@
 <template>
-    <div v-if="commands">
-        <h2 id="commands">Commands</h2>
-        <p>The {{ name }} {{ plugin_type }} supports the following commands that can be used with
-        <pre><code>meltano invoke</code></pre>:</p>
-        <div v-for="(key, value, index) in commands" v-bind:key="index">
-            <span v-if="value">
-                <h3>
-                    <pre><code>{{ key.name }}</code></pre>
-                </h3>
-                <p>Equivalent to:
-                <pre><code>{{ key.args }}</code></pre>
-                </p>
-                <p>{{ key.description }}</p>
-                <h3>How to use</h3>
-                <p>Run this command using
-                <pre><code>meltano invoke</code></pre>
-                </p>
-                <pre><code>meltano invoke {{ name }}:thing-to-do [additional arguments...]</code></pre>
-            </span>
-        </div>
+  <div v-if="commands">
+    <h2 id="commands">Commands</h2>
+    <span
+      >The {{ name }} {{ plugin_type }} supports the following commands that can be used with
+      <pre><code>meltano invoke</code></pre>
+      :</span
+    >
+    <div v-for="(key, value, index) in commands" v-bind:key="index">
+      <span v-if="value">
+        <h3>
+          <pre><code>{{ key.name }}</code></pre>
+        </h3>
+        <span
+          >Equivalent to:
+          <pre><code>{{ key.args }}</code></pre>
+        </span>
+        <p>{{ key.description }}</p>
+        <h3>How to use</h3>
+        <span
+          >Run this command using
+          <pre><code>meltano invoke</code></pre>
+        </span>
+        <pre><code>meltano invoke {{ name }}:thing-to-do [additional arguments...]</code></pre>
+      </span>
     </div>
+  </div>
 </template>
 
 <script>
 export default {
-    name: "PluginCommandsSection",
-    props: ["commands", "name", "plugin_type"],
+  name: "PluginCommandsSection",
+  props: ["commands", "name", "plugin_type"],
 };
 </script>
 
 <style>
 pre {
-    display: inline-block
+  display: inline-block;
 }
 </style>

--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -1,0 +1,36 @@
+<template>
+    <div v-if="commands">
+        <h2 id="commands">Commands</h2>
+        <p>The {{ name }} {{ plugin_type }} supports the following commands that can be used with
+        <pre><code>meltano invoke</code></pre>:</p>
+        <div v-for="(key, value, index) in commands" v-bind:key="index">
+            <span v-if="value">
+                <h3>
+                    <pre><code>{{ key.name }}</code></pre>
+                </h3>
+                <p>Equivalent to:
+                <pre><code>{{ key.args }}</code></pre>
+                </p>
+                <p>{{ key.description }}</p>
+                <h3>How to use</h3>
+                <p>Run this command using
+                <pre><code>meltano invoke</code></pre>
+                </p>
+                <pre><code>meltano invoke {{ name }}:thing-to-do [additional arguments...]</code></pre>
+            </span>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "PluginCommandsSection",
+    props: ["commands", "name", "plugin_type"],
+};
+</script>
+
+<style>
+pre {
+    display: inline-block
+}
+</style>

--- a/src/components/PluginHelpSection.vue
+++ b/src/components/PluginHelpSection.vue
@@ -10,7 +10,7 @@
     <h2 id="looking-for-help">Looking for help?</h2>
     <div>
       If you're having trouble getting the
-      {{ $page.extractors.name }} extractor to work, look for an
+      {{ name }} extractor to work, look for an
       <a :href="`${repo}/issues`">existing issue in its repository</a>, file a
       <a :href="`${repo}/issues/new`">new issue</a>, or
       <a href="https://meltano.com/slack">join the Meltano Slack community</a>

--- a/src/components/PluginHelpSection.vue
+++ b/src/components/PluginHelpSection.vue
@@ -24,7 +24,7 @@
 <script>
 export default {
   name: "PluginHelpSection",
-  props: ["name", "plugin_type", "variant", "repo"]
+  props: ["name", "plugin_type", "variant", "repo"],
 };
 </script>
 

--- a/src/components/PluginHelpSection.vue
+++ b/src/components/PluginHelpSection.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="help-module">
+    <h2 id="contribute">Something missing?</h2>
+    <p>This page is generated from a YAML file that you can contribute changes to.</p>
+    <a
+      v-if="name"
+      :href="`https://github.com/meltano/hub/blob/main/_data/meltano/${plugin_type}/${name}/${variant}.yml`"
+      >Edit it on GitHub!</a
+    >
+    <h2 id="looking-for-help">Looking for help?</h2>
+    <div>
+      If you're having trouble getting the
+      {{ $page.extractors.name }} extractor to work, look for an
+      <a :href="`${repo}/issues`">existing issue in its repository</a>, file a
+      <a :href="`${repo}/issues/new`">new issue</a>, or
+      <a href="https://meltano.com/slack">join the Meltano Slack community</a>
+      and ask for help in the
+      <pre class="inline-code-block"><code>#plugins-general</code></pre>
+      channel.
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PluginHelpSection",
+  props: ["name", "plugin_type", "variant", "repo"]
+};
+</script>
+
+<style lang="scss">
+.help-module {
+  margin-bottom: 40px;
+}
+</style>

--- a/src/components/PluginRequiresSection.vue
+++ b/src/components/PluginRequiresSection.vue
@@ -1,0 +1,20 @@
+<template>
+  <div v-if="requires">
+    <h3>Requires</h3>
+    <p>This {{ plugin_type }} requires the following plugins and variants to work:</p>
+    <ul>
+      <li v-for="(file, index) in requires.files" v-bind:key="index">
+        {{ file.name }} - {{ file.variant }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PluginRequiresSection",
+  props: ["requires", "plugin_type"]
+};
+</script>
+
+<style></style>

--- a/src/components/PluginRequiresSection.vue
+++ b/src/components/PluginRequiresSection.vue
@@ -13,7 +13,7 @@
 <script>
 export default {
   name: "PluginRequiresSection",
-  props: ["requires", "plugin_type"]
+  props: ["requires", "plugin_type"],
 };
 </script>
 

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h2 id="settings">Settings</h2>
-    <span v-if="settings.length">
+    <span v-if="settings">
       <p>
         The
         <code>{{ name }}</code> settings that are known to Meltano are documented below. To quickly
@@ -47,7 +47,7 @@
 <script>
 export default {
   name: "PluginSettingsSection",
-  props: ["settings", "name"],
+  props: ["settings", "name"]
 };
 </script>
 

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -47,7 +47,7 @@
 <script>
 export default {
   name: "PluginSettingsSection",
-  props: ["settings", "name"]
+  props: ["settings", "name"],
 };
 </script>
 

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <h2 id="settings">Settings</h2>
+    <span v-if="settings.length">
+      <p>
+        The
+        <code>{{ name }}</code> settings that are known to Meltano are documented below. To quickly
+        find the setting you're looking for, click on any setting name from the list:
+      </p>
+      <ul>
+        <li v-for="(setting, index) in settings" v-bind:key="index">
+          <a :href="'#' + setting.name + '-setting'"
+            ><code>{{ setting.name }}</code></a
+          >
+        </li>
+      </ul>
+      <p>
+        You can
+        <a
+          href="https://docs.meltano.com/guide/configuration#overriding-discoverable-plugin-properties"
+          >override these settings or specify additional ones</a
+        >
+        in your <code>meltano.yml</code> by adding the <code>settings</code> key.
+      </p>
+      <p>
+        Please consider adding any settings you have defined locally to this definition on
+        MeltanoHub by making a
+        <a href="#contributing">pull request to the YAML file</a>.
+      </p>
+      <span v-for="(setting, index) in settings" v-bind:key="index">
+        <h3 :id="setting.name + '-setting'">
+          <code>{{ setting.label }} ({{ setting.name }})</code>
+        </h3>
+        <p>
+          <span v-if="setting.description">{{ setting.description }}</span>
+          <span v-else><a href="#contribute">[No description provided.]</a></span>
+        </p>
+      </span>
+    </span>
+    <span v-else
+      >This plugin currently has no settings defined. If you know the settings required by this
+      plugin, <a href="#contribute">please contribute!</a></span
+    >
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PluginSettingsSection",
+  props: ["settings", "name"]
+};
+</script>
+
+<style></style>

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -4,8 +4,8 @@ import Search from "../components/Search.vue";
 export default {
   name: "HeaderLayout",
   components: {
-    Search
-  }
+    Search,
+  },
 };
 </script>
 <template>

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -4,8 +4,8 @@ import Search from "../components/Search.vue";
 export default {
   name: "HeaderLayout",
   components: {
-    Search,
-  },
+    Search
+  }
 };
 </script>
 <template>
@@ -18,14 +18,15 @@ export default {
       </strong>
       <nav class="nav">
         <button class="hamburger"></button>
-        <a
+        <!-- The below needs a reload of the page to fully work. Figure out why that is. -->
+        <!-- <a
           class="github-button"
           href="https://github.com/meltano/meltano"
           data-size="large"
           data-show-count="true"
           aria-label="Star meltano/meltano on GitHub"
           >Star</a
-        >
+        > -->
         <div class="dropdown">
           <a class="page-link" href="#">Plugins</a>
           <div class="dropdown-content">

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -18,8 +18,10 @@ export default {
       </strong>
       <nav class="nav">
         <button class="hamburger"></button>
-        <!-- The below needs a reload of the page to fully work. Figure out why that is. -->
-        <!-- <a
+        <!--
+          TODO: Debug stars.
+          The below needs a reload of the page to fully work.
+        <a
           class="github-button"
           href="https://github.com/meltano/meltano"
           data-size="large"

--- a/src/templates/Extractors.vue
+++ b/src/templates/Extractors.vue
@@ -155,7 +155,10 @@
               </p>
             </span>
           </span>
-          <span v-else>This plugin currently has no settings defined. If you know the settings required by this plugin, <a href="#contribute">please contribute!</a></span>
+          <span v-else
+            >This plugin currently has no settings defined. If you know the settings required by
+            this plugin, <a href="#contribute">please contribute!</a></span
+          >
           <h2 id="contribute">Something missing?</h2>
           <p>
             This page is generated from a YAML file that you can contribute changes to.

--- a/src/templates/Extractors.vue
+++ b/src/templates/Extractors.vue
@@ -48,8 +48,8 @@
               <span v-if="variant.node.isDefault"> (default)</span>
             </li>
           </ul>
-          <h2>Getting Started</h2>
-          <h3>Prerequisites</h3>
+          <h2 id="getting-started">Getting Started</h2>
+          <h3 id="prereqs">Prerequisites</h3>
           <p>
             If you haven't already, follow the initial steps of the
             <a href="https://docs.meltano.com/getting-started.html">Getting Started guide</a>:
@@ -67,7 +67,7 @@
             </li>
           </ol>
           <p>{{ $page.extractors.prereq }}</p>
-          <h3>Installation and configuration</h3>
+          <h3 id="installation">Installation and configuration</h3>
           <ol>
             <li>
               Add the {{ $page.extractors.name }} extractor to your project using
@@ -102,7 +102,7 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-          <h2>Capabilities</h2>
+          <h2 id="capabilities">Capabilities</h2>
           <div>
             The current capabilities for
             <pre class="inline-code-block"><code>{{ $page.extractors.name }}</code></pre>
@@ -117,25 +117,46 @@
               {{ capability }}
             </li>
           </ul>
-          <h2>Settings</h2>
-          <p>{{ $page.extractors.name }} requires the configuration of the following settings:</p>
-          <ul>
-            <li v-for="(setting, index) in $page.extractors.settings" v-bind:key="index">
-              {{ setting.name }}
-            </li>
-          </ul>
-          <h2>Looking for help?</h2>
-          <div>
-            If you're having trouble getting the
-            {{ $page.extractors.name }} extractor to work, look for an
-            <a :href="$page.extractors.repo + '/issues'">existing issue in its repository</a>, file
-            a <a :href="$page.extractors.repo + '/issues/new'">new issue</a>, or
-            <a href="https://meltano.com/slack">join the Meltano Slack community</a>
-            and ask for help in the
-            <pre class="inline-code-block"><code>#plugins-general channel</code></pre>
-            .
-          </div>
-          <h3>Found an issue on this page?</h3>
+          <h2 id="settings">Settings</h2>
+          <span v-if="$page.extractors.settings.length">
+            <p>
+              The
+              <code>{{ $page.extractors.name }}</code> settings that are known to Meltano are
+              documented below. To quickly find the setting you're looking for, click on any setting
+              name from the list:
+            </p>
+            <ul>
+              <li v-for="(setting, index) in $page.extractors.settings" v-bind:key="index">
+                <a :href="'#' + setting.name + '-setting'"
+                  ><code>{{ setting.name }}</code></a
+                >
+              </li>
+            </ul>
+            <p>
+              You can
+              <a
+                href="https://docs.meltano.com/guide/configuration#overriding-discoverable-plugin-properties"
+                >override these settings or specify additional ones</a
+              >
+              in your <code>meltano.yml</code> by adding the <code>settings</code> key.
+            </p>
+            <p>
+              Please consider adding any settings you have defined locally to this definition on
+              MeltanoHub by making a
+              <a href="#contributing">pull request to the YAML file</a>.
+            </p>
+            <span v-for="(setting, index) in $page.extractors.settings" v-bind:key="index">
+              <h3 :id="setting.name + '-setting'">
+                <code>{{ setting.label }} ({{ setting.name }})</code>
+              </h3>
+              <p>
+                <span v-if="setting.description">{{ setting.description }}</span>
+                <span v-else><a href="#contribute">[No description provided.]</a></span>
+              </p>
+            </span>
+          </span>
+          <span v-else>This plugin currently has no settings defined. If you know the settings required by this plugin, <a href="#contribute">please contribute!</a></span>
+          <h2 id="contribute">Something missing?</h2>
           <p>
             This page is generated from a YAML file that you can contribute changes to.
             <a
@@ -149,6 +170,17 @@
               >Edit it on GitHub!</a
             >
           </p>
+          <h2 id="looking-for-help">Looking for help?</h2>
+          <div>
+            If you're having trouble getting the
+            {{ $page.extractors.name }} extractor to work, look for an
+            <a :href="$page.extractors.repo + '/issues'">existing issue in its repository</a>, file
+            a <a :href="$page.extractors.repo + '/issues/new'">new issue</a>, or
+            <a href="https://meltano.com/slack">join the Meltano Slack community</a>
+            and ask for help in the
+            <pre class="inline-code-block"><code>#plugins-general</code></pre>
+            channel.
+          </div>
         </div>
         <PluginSidebar
           :name="$page.extractors.name"

--- a/src/templates/Extractors.vue
+++ b/src/templates/Extractors.vue
@@ -105,6 +105,7 @@
           <PluginCapabilitiesSection
             :capabilities="$page.extractors.capabilities"
             :name="$page.extractors.name"
+            plugin_type="extractor"
           />
           <PluginSettingsSection
             :settings="$page.extractors.settings"
@@ -140,7 +141,7 @@ import PluginCapabilitiesSection from "../components/PluginCapabilitiesSection.v
 export default {
   metaInfo() {
     return {
-      title: this.$page.extractors.name
+      title: this.$page.extractors.name,
     };
   },
   name: "ExtractorsTemplate",
@@ -148,8 +149,8 @@ export default {
     PluginSidebar,
     PluginSettingsSection,
     PluginHelpSection,
-    PluginCapabilitiesSection
-  }
+    PluginCapabilitiesSection,
+  },
 };
 </script>
 

--- a/src/templates/Extractors.vue
+++ b/src/templates/Extractors.vue
@@ -168,11 +168,11 @@ import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.extractors.name
+      title: this.$page.extractors.name,
     };
   },
   name: "ExtractorsTemplate",
-  components: { PluginSidebar, PluginSettingsSection }
+  components: { PluginSidebar, PluginSettingsSection },
 };
 </script>
 

--- a/src/templates/Extractors.vue
+++ b/src/templates/Extractors.vue
@@ -102,50 +102,20 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-          <h2 id="capabilities">Capabilities</h2>
-          <div>
-            The current capabilities for
-            <pre class="inline-code-block"><code>{{ $page.extractors.name }}</code></pre>
-            may have been automatically set when originally added to the Hub. Please review the
-            capabilities when using this extractor. If you find they are out of date, please
-            consider updating them by making a pull request to the YAML file that defines the
-            capabilities for this extractor.
-          </div>
-          <p>This plugin has the following capabilities:</p>
-          <ul>
-            <li v-for="(capability, index) in $page.extractors.capabilities" v-bind:key="index">
-              {{ capability }}
-            </li>
-          </ul>
+          <PluginCapabilitiesSection
+            :capabilities="$page.extractors.capabilities"
+            :name="$page.extractors.name"
+          />
           <PluginSettingsSection
             :settings="$page.extractors.settings"
             :name="$page.extractors.name"
           />
-          <h2 id="contribute">Something missing?</h2>
-          <p>
-            This page is generated from a YAML file that you can contribute changes to.
-            <a
-              :href="
-                'https://github.com/meltano/hub/blob/main/_data/meltano/extractors/' +
-                $page.extractors.name +
-                '/' +
-                $page.extractors.variant +
-                '.yml'
-              "
-              >Edit it on GitHub!</a
-            >
-          </p>
-          <h2 id="looking-for-help">Looking for help?</h2>
-          <div>
-            If you're having trouble getting the
-            {{ $page.extractors.name }} extractor to work, look for an
-            <a :href="$page.extractors.repo + '/issues'">existing issue in its repository</a>, file
-            a <a :href="$page.extractors.repo + '/issues/new'">new issue</a>, or
-            <a href="https://meltano.com/slack">join the Meltano Slack community</a>
-            and ask for help in the
-            <pre class="inline-code-block"><code>#plugins-general</code></pre>
-            channel.
-          </div>
+          <PluginHelpSection
+            :name="$page.extractors.name"
+            :variant="$page.extractors.variant"
+            :repo="$page.extractors.repo"
+            plugin_type="extractors"
+          />
         </div>
         <PluginSidebar
           :name="$page.extractors.name"
@@ -164,15 +134,22 @@
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
 import PluginSettingsSection from "../components/PluginSettingsSection.vue";
+import PluginHelpSection from "../components/PluginHelpSection.vue";
+import PluginCapabilitiesSection from "../components/PluginCapabilitiesSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.extractors.name,
+      title: this.$page.extractors.name
     };
   },
   name: "ExtractorsTemplate",
-  components: { PluginSidebar, PluginSettingsSection },
+  components: {
+    PluginSidebar,
+    PluginSettingsSection,
+    PluginHelpSection,
+    PluginCapabilitiesSection
+  }
 };
 </script>
 

--- a/src/templates/Extractors.vue
+++ b/src/templates/Extractors.vue
@@ -117,48 +117,10 @@
               {{ capability }}
             </li>
           </ul>
-          <h2 id="settings">Settings</h2>
-          <span v-if="$page.extractors.settings.length">
-            <p>
-              The
-              <code>{{ $page.extractors.name }}</code> settings that are known to Meltano are
-              documented below. To quickly find the setting you're looking for, click on any setting
-              name from the list:
-            </p>
-            <ul>
-              <li v-for="(setting, index) in $page.extractors.settings" v-bind:key="index">
-                <a :href="'#' + setting.name + '-setting'"
-                  ><code>{{ setting.name }}</code></a
-                >
-              </li>
-            </ul>
-            <p>
-              You can
-              <a
-                href="https://docs.meltano.com/guide/configuration#overriding-discoverable-plugin-properties"
-                >override these settings or specify additional ones</a
-              >
-              in your <code>meltano.yml</code> by adding the <code>settings</code> key.
-            </p>
-            <p>
-              Please consider adding any settings you have defined locally to this definition on
-              MeltanoHub by making a
-              <a href="#contributing">pull request to the YAML file</a>.
-            </p>
-            <span v-for="(setting, index) in $page.extractors.settings" v-bind:key="index">
-              <h3 :id="setting.name + '-setting'">
-                <code>{{ setting.label }} ({{ setting.name }})</code>
-              </h3>
-              <p>
-                <span v-if="setting.description">{{ setting.description }}</span>
-                <span v-else><a href="#contribute">[No description provided.]</a></span>
-              </p>
-            </span>
-          </span>
-          <span v-else
-            >This plugin currently has no settings defined. If you know the settings required by
-            this plugin, <a href="#contribute">please contribute!</a></span
-          >
+          <PluginSettingsSection
+            :settings="$page.extractors.settings"
+            :name="$page.extractors.name"
+          />
           <h2 id="contribute">Something missing?</h2>
           <p>
             This page is generated from a YAML file that you can contribute changes to.
@@ -201,15 +163,16 @@
 
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
+import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.extractors.name,
+      title: this.$page.extractors.name
     };
   },
   name: "ExtractorsTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar, PluginSettingsSection }
 };
 </script>
 

--- a/src/templates/Files.vue
+++ b/src/templates/Files.vue
@@ -129,11 +129,11 @@ import PluginHelpSection from "../components/PluginHelpSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.files.name
+      title: this.$page.files.name,
     };
   },
   name: "FilesTemplate",
-  components: { PluginSidebar, PluginSettingsSection, PluginHelpSection }
+  components: { PluginSidebar, PluginSettingsSection, PluginHelpSection },
 };
 </script>
 

--- a/src/templates/Files.vue
+++ b/src/templates/Files.vue
@@ -157,11 +157,11 @@ import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.files.name
+      title: this.$page.files.name,
     };
   },
   name: "FilesTemplate",
-  components: { PluginSidebar, PluginSettingsSection }
+  components: { PluginSidebar, PluginSettingsSection },
 };
 </script>
 

--- a/src/templates/Files.vue
+++ b/src/templates/Files.vue
@@ -114,18 +114,7 @@
               {{ capability }}
             </li>
           </ul>
-          <h2>Settings</h2>
-          <p>{{ $page.files.name }} requires the configuration of the following settings:</p>
-          <ul>
-            <li v-for="(setting, index) in $page.files.settings" v-bind:key="index">
-              {{ setting.name }}
-            </li>
-          </ul>
-          <p>
-            The settings for {{ $page.files.name }} that are known to Meltano are documented below.
-            To quickly find the setting you're looking for, use the Table of Contents at the top of
-            the page.
-          </p>
+          <PluginSettingsSection :settings="$page.files.settings" :name="$page.files.name" />
           <h2>Looking for help?</h2>
           <div>
             If you're having trouble getting the
@@ -163,15 +152,16 @@
 
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
+import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.files.name,
+      title: this.$page.files.name
     };
   },
   name: "FilesTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar, PluginSettingsSection }
 };
 </script>
 

--- a/src/templates/Files.vue
+++ b/src/templates/Files.vue
@@ -99,42 +99,13 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-          <h2>Capabilities</h2>
-          <div>
-            The current capabilities for
-            <pre class="inline-code-block"><code>{{ $page.files.name }}</code></pre>
-            may have been automatically set when originally added to the Hub. Please review the
-            capabilities when using this extractor. If you find they are out of date, please
-            consider updating them by making a pull request to the YAML file that defines the
-            capabilities for this extractor.
-          </div>
-          <p>This plugin has the following capabilities:</p>
-          <ul>
-            <li v-for="(capability, index) in $page.files.capabilities" v-bind:key="index">
-              {{ capability }}
-            </li>
-          </ul>
           <PluginSettingsSection :settings="$page.files.settings" :name="$page.files.name" />
-          <h2>Looking for help?</h2>
-          <div>
-            If you're having trouble getting the
-            {{ $page.files.name }} extractor to work, look for an
-            <a href="https://github.com/singer-io/tap-github/issues"
-              >existing issue in its repository</a
-            >, file a <a href="https://github.com/singer-io/tap-github/issues/new">new issue</a>, or
-            <a href="https://meltano.com/slack">join the Meltano Slack community</a>
-            and ask for help in the
-            <pre class="inline-code-block"><code>#plugins-general channel</code></pre>
-            .
-          </div>
-          <h3>Found an issue on this page?</h3>
-          <p>
-            This page is generated from a YAML file that you can contribute changes to.
-            <a
-              href="https://github.com/meltano/hub/blob/main/_data/meltano/extractors/tap-github/singer-io.yml"
-              >Edit it on GitHub!</a
-            >
-          </p>
+          <PluginHelpSection
+            :name="$page.files.name"
+            :variant="$page.files.variant"
+            :repo="$page.files.repo"
+            plugin_type="files"
+          />
         </div>
         <PluginSidebar
           :name="$page.files.name"
@@ -153,15 +124,16 @@
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
 import PluginSettingsSection from "../components/PluginSettingsSection.vue";
+import PluginHelpSection from "../components/PluginHelpSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.files.name,
+      title: this.$page.files.name
     };
   },
   name: "FilesTemplate",
-  components: { PluginSidebar, PluginSettingsSection },
+  components: { PluginSidebar, PluginSettingsSection, PluginHelpSection }
 };
 </script>
 

--- a/src/templates/Loaders.vue
+++ b/src/templates/Loaders.vue
@@ -158,11 +158,11 @@ import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.loaders.name
+      title: this.$page.loaders.name,
     };
   },
   name: "LoadersTemplate",
-  components: { PluginSidebar, PluginSettingsSection }
+  components: { PluginSidebar, PluginSettingsSection },
 };
 </script>
 

--- a/src/templates/Loaders.vue
+++ b/src/templates/Loaders.vue
@@ -117,18 +117,7 @@
               {{ capability }}
             </li>
           </ul>
-          <h2>Settings</h2>
-          <p>{{ $page.loaders.name }} requires the configuration of the following settings:</p>
-          <ul>
-            <li v-for="(setting, index) in $page.loaders.settings" v-bind:key="index">
-              {{ setting.name }}
-            </li>
-          </ul>
-          <p>
-            The settings for {{ $page.loaders.name }} that are known to Meltano are documented
-            below. To quickly find the setting you're looking for, use the Table of Contents at the
-            top of the page.
-          </p>
+          <PluginSettingsSection :settings="$page.loaders.settings" :name="$page.loaders.name" />
           <h2>Looking for help?</h2>
           <div>
             If you're having trouble getting the {{ $page.loaders.name }} loader to work, look for
@@ -164,15 +153,16 @@
 
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
+import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.loaders.name,
+      title: this.$page.loaders.name
     };
   },
   name: "LoadersTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar, PluginSettingsSection }
 };
 </script>
 

--- a/src/templates/Loaders.vue
+++ b/src/templates/Loaders.vue
@@ -102,21 +102,6 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-          <!-- <h2 v-if="$page.loaders.capabilities">Capabilities</h2>
-          <div v-if="$page.loaders.capabilities">
-            The current capabilities for
-            <pre class="inline-code-block"><code>{{ $page.loaders.name }}</code></pre>
-            may have been automatically set when originally added to the Hub. Please review the
-            capabilities when using this extractor. If you find they are out of date, please
-            consider updating them by making a pull request to the YAML file that defines the
-            capabilities for this extractor.
-          </div>
-          <p v-if="$page.loaders.capabilities">This plugin has the following capabilities:</p>
-          <ul v-if="$page.loaders.capabilities">
-            <li v-for="(capability, index) in $page.loaders.capabilities" v-bind:key="index">
-              {{ capability }}
-            </li>
-          </ul> -->
           <PluginCapabilitiesSection
             :capabilities="$page.loaders.capabilities"
             :name="$page.loaders.name"

--- a/src/templates/Loaders.vue
+++ b/src/templates/Loaders.vue
@@ -120,6 +120,7 @@
           <PluginCapabilitiesSection
             :capabilities="$page.loaders.capabilities"
             :name="$page.loaders.name"
+            plugin_type="loader"
           />
           <PluginSettingsSection :settings="$page.loaders.settings" :name="$page.loaders.name" />
           <PluginHelpSection
@@ -152,11 +153,16 @@ import PluginCapabilitiesSection from "../components/PluginCapabilitiesSection.v
 export default {
   metaInfo() {
     return {
-      title: this.$page.loaders.name
+      title: this.$page.loaders.name,
     };
   },
   name: "LoadersTemplate",
-  components: { PluginSidebar, PluginSettingsSection, PluginHelpSection, PluginCapabilitiesSection }
+  components: {
+    PluginSidebar,
+    PluginSettingsSection,
+    PluginHelpSection,
+    PluginCapabilitiesSection,
+  },
 };
 </script>
 

--- a/src/templates/Loaders.vue
+++ b/src/templates/Loaders.vue
@@ -102,7 +102,7 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-          <h2 v-if="$page.loaders.capabilities">Capabilities</h2>
+          <!-- <h2 v-if="$page.loaders.capabilities">Capabilities</h2>
           <div v-if="$page.loaders.capabilities">
             The current capabilities for
             <pre class="inline-code-block"><code>{{ $page.loaders.name }}</code></pre>
@@ -116,26 +116,18 @@
             <li v-for="(capability, index) in $page.loaders.capabilities" v-bind:key="index">
               {{ capability }}
             </li>
-          </ul>
+          </ul> -->
+          <PluginCapabilitiesSection
+            :capabilities="$page.loaders.capabilities"
+            :name="$page.loaders.name"
+          />
           <PluginSettingsSection :settings="$page.loaders.settings" :name="$page.loaders.name" />
-          <h2>Looking for help?</h2>
-          <div>
-            If you're having trouble getting the {{ $page.loaders.name }} loader to work, look for
-            an <a :href="$page.loaders.domain_url">existing issue in its repository</a>, file a
-            <a href="https://github.com/singer-io/tap-github/issues/new">new issue</a>, or
-            <a href="https://meltano.com/slack">join the Meltano Slack community</a>
-            and ask for help in the
-            <pre class="inline-code-block"><code>#plugins-general channel</code></pre>
-            .
-          </div>
-          <h3>Found an issue on this page?</h3>
-          <p>
-            This page is generated from a YAML file that you can contribute changes to.
-            <a
-              href="https://github.com/meltano/hub/blob/main/_data/meltano/extractors/tap-github/singer-io.yml"
-              >Edit it on GitHub!</a
-            >
-          </p>
+          <PluginHelpSection
+            :name="$page.loaders.name"
+            :variant="$page.loaders.variant"
+            :repo="$page.loaders.repo"
+            plugin_type="loaders"
+          />
         </div>
         <PluginSidebar
           :name="$page.loaders.name"
@@ -154,15 +146,17 @@
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
 import PluginSettingsSection from "../components/PluginSettingsSection.vue";
+import PluginHelpSection from "../components/PluginHelpSection.vue";
+import PluginCapabilitiesSection from "../components/PluginCapabilitiesSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.loaders.name,
+      title: this.$page.loaders.name
     };
   },
   name: "LoadersTemplate",
-  components: { PluginSidebar, PluginSettingsSection },
+  components: { PluginSidebar, PluginSettingsSection, PluginHelpSection, PluginCapabilitiesSection }
 };
 </script>
 
@@ -182,6 +176,7 @@ query Loaders($path: String!, $name: String!) {
     maintenance_status
     keywords
     domain_url
+    capabilities
     settings {
       name
       label

--- a/src/templates/Orchestrators.vue
+++ b/src/templates/Orchestrators.vue
@@ -130,11 +130,11 @@ import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.orchestrators.name
+      title: this.$page.orchestrators.name,
     };
   },
   name: "OrchestratorsTemplate",
-  components: { PluginSidebar, PluginSettingsSection }
+  components: { PluginSidebar, PluginSettingsSection },
 };
 </script>
 

--- a/src/templates/Orchestrators.vue
+++ b/src/templates/Orchestrators.vue
@@ -68,6 +68,11 @@
               >
             </li>
           </ol>
+          <PluginRequiresSection
+            :requires="$page.orchestrators.requires"
+            plugin_type="orchestrator"
+            :name="$page.orchestrators.name"
+          />
           <h3>Installation and configuration</h3>
 
           <p>Add the airflow orchestrator to your project using meltano add :</p>
@@ -88,26 +93,17 @@
             :settings="$page.orchestrators.settings"
             :name="$page.orchestrators.name"
           />
-          <h2>Looking for help?</h2>
-          <div>
-            If you're having trouble getting the
-            {{ $page.orchestrators.name }} orchestrator to work, look for an
-            <a href="https://github.com/singer-io/tap-github/issues"
-              >existing issue in its repository</a
-            >, file a <a href="https://github.com/singer-io/tap-github/issues/new">new issue</a>, or
-            <a href="https://meltano.com/slack">join the Meltano Slack community</a>
-            and ask for help in the
-            <pre class="inline-code-block"><code>#plugins-general channel</code></pre>
-            .
-          </div>
-          <h3>Found an issue on this page?</h3>
-          <p>
-            This page is generated from a YAML file that you can contribute changes to.
-            <a
-              href="https://github.com/meltano/hub/blob/main/_data/meltano/extractors/tap-github/singer-io.yml"
-              >Edit it on GitHub!</a
-            >
-          </p>
+          <PluginCommandsSection
+            :commands="$page.orchestrators.commands"
+            :name="$page.orchestrators.name"
+            plugin_type="orchestrator"
+          />
+          <PluginHelpSection
+            :name="$page.orchestrators.name"
+            :variant="$page.orchestrators.variant"
+            :repo="$page.orchestrators.repo"
+            plugin_type="orchestrators"
+          />
         </div>
         <PluginSidebar
           :name="$page.orchestrators.name"
@@ -126,15 +122,24 @@
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
 import PluginSettingsSection from "../components/PluginSettingsSection.vue";
+import PluginCommandsSection from "../components/PluginCommandsSection.vue";
+import PluginRequiresSection from "../components/PluginRequiresSection.vue";
+import PluginHelpSection from "../components/PluginHelpSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.orchestrators.name,
+      title: this.$page.orchestrators.name
     };
   },
   name: "OrchestratorsTemplate",
-  components: { PluginSidebar, PluginSettingsSection },
+  components: {
+    PluginSidebar,
+    PluginSettingsSection,
+    PluginCommandsSection,
+    PluginRequiresSection,
+    PluginHelpSection
+  }
 };
 </script>
 
@@ -160,10 +165,12 @@ query Orchestrators($path: String!, $name: String!) {
     maintenance_status
     commands {
       create_admin {
+        name
         args
         description
       }
       ui {
+        name
         args
         description
       }

--- a/src/templates/Orchestrators.vue
+++ b/src/templates/Orchestrators.vue
@@ -129,7 +129,7 @@ import PluginHelpSection from "../components/PluginHelpSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.orchestrators.name
+      title: this.$page.orchestrators.name,
     };
   },
   name: "OrchestratorsTemplate",
@@ -138,8 +138,8 @@ export default {
     PluginSettingsSection,
     PluginCommandsSection,
     PluginRequiresSection,
-    PluginHelpSection
-  }
+    PluginHelpSection,
+  },
 };
 </script>
 

--- a/src/templates/Orchestrators.vue
+++ b/src/templates/Orchestrators.vue
@@ -84,20 +84,10 @@
 
           <h3>Next steps</h3>
           <p>If you run into any issues, learn how to get help.</p>
-          <h2>Settings</h2>
-          <p>
-            {{ $page.orchestrators.name }} requires the configuration of the following settings:
-          </p>
-          <ul>
-            <li v-for="(setting, index) in $page.orchestrators.settings" v-bind:key="index">
-              {{ setting.name }}
-            </li>
-          </ul>
-          <p>
-            The settings for {{ $page.orchestrators.name }} that are known to Meltano are documented
-            below. To quickly find the setting you're looking for, use the Table of Contents at the
-            top of the page.
-          </p>
+          <PluginSettingsSection
+            :settings="$page.orchestrators.settings"
+            :name="$page.orchestrators.name"
+          />
           <h2>Looking for help?</h2>
           <div>
             If you're having trouble getting the
@@ -135,15 +125,16 @@
 
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
+import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.orchestrators.name,
+      title: this.$page.orchestrators.name
     };
   },
   name: "OrchestratorsTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar, PluginSettingsSection }
 };
 </script>
 

--- a/src/templates/Transformers.vue
+++ b/src/templates/Transformers.vue
@@ -149,11 +149,11 @@ import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.transformers.name
+      title: this.$page.transformers.name,
     };
   },
   name: "TransformersTemplate",
-  components: { PluginSidebar, PluginSettingsSection }
+  components: { PluginSidebar, PluginSettingsSection },
 };
 </script>
 

--- a/src/templates/Transformers.vue
+++ b/src/templates/Transformers.vue
@@ -66,6 +66,11 @@
               >
             </li>
           </ol>
+          <PluginRequiresSection
+            :requires="$page.transformers.requires"
+            :name="$page.transformers.name"
+            plugin_type="transformer"
+          />
           <h3>Installation and configuration</h3>
           <ol>
             <li>
@@ -100,33 +105,17 @@
             :settings="$page.transformers.settings"
             :name="$page.transformers.name"
           />
-          <h2>Commands</h2>
-          <ol>
-            <li v-for="(command, index) in $page.transformers.commands" v-bind:key="index">
-              <h3>{{ command.args }}</h3>
-              <span>{{ command.description }}</span>
-            </li>
-          </ol>
-          <h2>Looking for help?</h2>
-          <div>
-            If you're having trouble getting the
-            {{ $page.transformers.name }} extractor to work, look for an
-            <a href="https://github.com/singer-io/tap-github/issues"
-              >existing issue in its repository</a
-            >, file a <a href="https://github.com/singer-io/tap-github/issues/new">new issue</a>, or
-            <a href="https://meltano.com/slack">join the Meltano Slack community</a>
-            and ask for help in the
-            <pre class="inline-code-block"><code>#plugins-general channel</code></pre>
-            .
-          </div>
-          <h3>Found an issue on this page?</h3>
-          <p>
-            This page is generated from a YAML file that you can contribute changes to.
-            <a
-              href="https://github.com/meltano/hub/blob/main/_data/meltano/extractors/tap-github/singer-io.yml"
-              >Edit it on GitHub!</a
-            >
-          </p>
+          <PluginCommandsSection
+            :commands="$page.transformers.commands"
+            :name="$page.transformers.name"
+            plugin_type="transformer"
+          />
+          <PluginHelpSection
+            :name="$page.transformers.name"
+            :variant="$page.transformers.variant"
+            :repo="$page.transformers.repo"
+            plugin_type="transformers"
+          />
         </div>
         <PluginSidebar
           :name="$page.transformers.name"
@@ -145,15 +134,24 @@
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
 import PluginSettingsSection from "../components/PluginSettingsSection.vue";
+import PluginCommandsSection from "../components/PluginCommandsSection.vue";
+import PluginRequiresSection from "../components/PluginRequiresSection.vue";
+import PluginHelpSection from "../components/PluginHelpSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.transformers.name,
+      title: this.$page.transformers.name
     };
   },
   name: "TransformersTemplate",
-  components: { PluginSidebar, PluginSettingsSection },
+  components: {
+    PluginSidebar,
+    PluginSettingsSection,
+    PluginCommandsSection,
+    PluginRequiresSection,
+    PluginHelpSection
+  }
 };
 </script>
 
@@ -185,50 +183,62 @@ query Transformers($path: String!, $name: String!) {
       clean {
         args
         description
+        name
       }
       compile {
         args
         description
+        name
       }
       deps {
         args
         description
+        name
       }
       run {
         args
         description
+        name
       }
       seed {
         args
         description
+        name
       }
       snapshot {
         args
         description
+        name
       }
       test {
         args
         description
+        name
       }
       freshness {
         args
         description
+        name
       }
       build {
         args
         description
+        name
       }
       docs_generate {
         args
         description
+        name
       }
       docs_serve {
         args
         description
+        name
       }
       debug {
         args
         description
+        name
       }
     }
   }

--- a/src/templates/Transformers.vue
+++ b/src/templates/Transformers.vue
@@ -96,30 +96,10 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-
-          <h2>Settings</h2>
-          <p>
-            Settings for {{ $page.transformers.name }} itself can be configured through
-            <a href="https://docs.getdbt.com/reference/dbt_project.yml">dbt_project.yml</a>
-            as usual, which can be found at transform/dbt_project.yml in your Meltano project.
-          </p>
-          <p>
-            The
-            <a href="https://docs.meltano.com/contribute/plugins#setting-definitions">settings</a>
-            for transformer {{ $page.transformers.name }} that are known to Meltano are documented
-            below. To quickly find the setting you're looking for, use the Table of Contents at the
-            top of the page.
-          </p>
-          <ul>
-            <li v-for="(setting, index) in $page.transformers.settings" v-bind:key="index">
-              {{ setting.name }}
-            </li>
-          </ul>
-          <p>
-            The settings for {{ $page.transformers.name }} that are known to Meltano are documented
-            below. To quickly find the setting you're looking for, use the Table of Contents at the
-            top of the page.
-          </p>
+          <PluginSettingsSection
+            :settings="$page.transformers.settings"
+            :name="$page.transformers.name"
+          />
           <h2>Commands</h2>
           <ol>
             <li v-for="(command, index) in $page.transformers.commands" v-bind:key="index">
@@ -164,15 +144,16 @@
 
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
+import PluginSettingsSection from "../components/PluginSettingsSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.transformers.name,
+      title: this.$page.transformers.name
     };
   },
   name: "TransformersTemplate",
-  components: { PluginSidebar },
+  components: { PluginSidebar, PluginSettingsSection }
 };
 </script>
 

--- a/src/templates/Transformers.vue
+++ b/src/templates/Transformers.vue
@@ -141,7 +141,7 @@ import PluginHelpSection from "../components/PluginHelpSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.transformers.name
+      title: this.$page.transformers.name,
     };
   },
   name: "TransformersTemplate",
@@ -150,8 +150,8 @@ export default {
     PluginSettingsSection,
     PluginCommandsSection,
     PluginRequiresSection,
-    PluginHelpSection
-  }
+    PluginHelpSection,
+  },
 };
 </script>
 

--- a/src/templates/Utilities.vue
+++ b/src/templates/Utilities.vue
@@ -102,6 +102,7 @@
           <PluginCapabilitiesSection
             :capabilities="$page.utilities.capabilities"
             :name="$page.utilities.name"
+            plugin_type="utility"
           />
           <PluginSettingsSection
             :settings="$page.utilities.settings"
@@ -143,7 +144,7 @@ import PluginHelpSection from "../components/PluginHelpSection.vue";
 export default {
   metaInfo() {
     return {
-      title: this.$page.utilities.name
+      title: this.$page.utilities.name,
     };
   },
   name: "UtilitiesTemplate",
@@ -152,8 +153,8 @@ export default {
     PluginSettingsSection,
     PluginCommandsSection,
     PluginCapabilitiesSection,
-    PluginHelpSection
-  }
+    PluginHelpSection,
+  },
 };
 </script>
 

--- a/src/templates/Utilities.vue
+++ b/src/templates/Utilities.vue
@@ -99,53 +99,25 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-          <h2>Capabilities</h2>
-          <div>
-            The current capabilities for
-            <pre class="inline-code-block"><code>{{ $page.utilities.name }}</code></pre>
-            may have been automatically set when originally added to the Hub. Please review the
-            capabilities when using this extractor. If you find they are out of date, please
-            consider updating them by making a pull request to the YAML file that defines the
-            capabilities for this extractor.
-          </div>
-          <p>This plugin has the following capabilities:</p>
-          <ul>
-            <li v-for="(capability, index) in $page.utilities.capabilities" v-bind:key="index">
-              {{ capability }}
-            </li>
-          </ul>
-          <h2>Settings</h2>
-          <p>{{ $page.utilities.name }} requires the configuration of the following settings:</p>
-          <ul>
-            <li v-for="(setting, index) in $page.utilities.settings" v-bind:key="index">
-              {{ setting.name }}
-            </li>
-          </ul>
-          <p>
-            The settings for {{ $page.utilities.name }} that are known to Meltano are documented
-            below. To quickly find the setting you're looking for, use the Table of Contents at the
-            top of the page.
-          </p>
-          <h2>Looking for help?</h2>
-          <div>
-            If you're having trouble getting the
-            {{ $page.utilities.name }} extractor to work, look for an
-            <a href="https://github.com/singer-io/tap-github/issues"
-              >existing issue in its repository</a
-            >, file a <a href="https://github.com/singer-io/tap-github/issues/new">new issue</a>, or
-            <a href="https://meltano.com/slack">join the Meltano Slack community</a>
-            and ask for help in the
-            <pre class="inline-code-block"><code>#plugins-general channel</code></pre>
-            .
-          </div>
-          <h3>Found an issue on this page?</h3>
-          <p>
-            This page is generated from a YAML file that you can contribute changes to.
-            <a
-              href="https://github.com/meltano/hub/blob/main/_data/meltano/extractors/tap-github/singer-io.yml"
-              >Edit it on GitHub!</a
-            >
-          </p>
+          <PluginCapabilitiesSection
+            :capabilities="$page.utilities.capabilities"
+            :name="$page.utilities.name"
+          />
+          <PluginSettingsSection
+            :settings="$page.utilities.settings"
+            :name="$page.utilities.name"
+          />
+          <PluginCommandsSection
+            :commands="$page.utilities.commands"
+            :name="$page.utilities.name"
+            plugin_type="utilities"
+          />
+          <PluginHelpSection
+            :name="$page.utilities.name"
+            :variant="$page.utilities.variant"
+            :repo="$page.utilities.repo"
+            plugin_type="utility"
+          />
         </div>
         <PluginSidebar
           :name="$page.utilities.name"
@@ -163,15 +135,25 @@
 
 <script>
 import PluginSidebar from "../components/PluginSidebar.vue";
+import PluginSettingsSection from "../components/PluginSettingsSection.vue";
+import PluginCommandsSection from "../components/PluginCommandsSection.vue";
+import PluginCapabilitiesSection from "../components/PluginCapabilitiesSection.vue";
+import PluginHelpSection from "../components/PluginHelpSection.vue";
 
 export default {
   metaInfo() {
     return {
-      title: this.$page.utilities.name,
+      title: this.$page.utilities.name
     };
   },
   name: "UtilitiesTemplate",
-  components: { PluginSidebar },
+  components: {
+    PluginSidebar,
+    PluginSettingsSection,
+    PluginCommandsSection,
+    PluginCapabilitiesSection,
+    PluginHelpSection
+  }
 };
 </script>
 
@@ -194,30 +176,37 @@ query Utilities($path: String!, $name: String!) {
     next_steps
     commands {
       lint {
+        name
         args
         description
       }
       fix {
+        name
         args
         description
       }
       fix_force {
+        name
         args
         description
       }
       ingest_dbt {
+        name
         args
         description
       }
       ui {
+        name
         args
         description
       }
       create_admin {
+        name
         args
         description
       }
       load_examples {
+        name
         args
         description
       }


### PR DESCRIPTION
Updated description/scope (from Alex):

Make the templates DRY and less cluttered looking by re-org-ing them into components:

- [x] Sidebar
- [ ] Getting Started
- [ ] Other Variants
- [x] Capabilities
- [x] Settings
- [x] Commands
- [x] Looking For Help