### PR TITLE
Make list pages only show defaults, change path sep

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -14,37 +14,37 @@ module.exports = {
   templates: {
     Extractors: [
       {
-        path: "/extractors/:name/:variant",
+        path: "/extractors/:name--:variant",
         component: "./src/templates/Extractors.vue",
       },
     ],
     Loaders: [
       {
-        path: "/loaders/:name/:variant",
+        path: "/loaders/:name--:variant",
         component: "./src/templates/Loaders.vue",
       },
     ],
     Orchestrators: [
       {
-        path: "/orchestrators/:name/:variant",
+        path: "/orchestrators/:name--:variant",
         component: "./src/templates/Orchestrators.vue",
       },
     ],
     Transformers: [
       {
-        path: "/transformers/:name/:variant",
+        path: "/transformers/:name--:variant",
         component: "./src/templates/Transformers.vue",
       },
     ],
     Utilities: [
       {
-        path: "/utilities/:name/:variant",
+        path: "/utilities/:name--:variant",
         component: "./src/templates/Utilities.vue",
       },
     ],
     Files: [
       {
-        path: "/files/:name/:variant",
+        path: "/files/:name--:variant",
         component: "./src/templates/Files.vue",
       },
     ],

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -196,7 +196,7 @@ module.exports = function main(api) {
       defaultPlugins.data[query].edges.forEach(({ node }) => {
         createPage({
           // Remove the variant part of the path
-          path: path.normalize(path.join(node.path, "..")),
+          path: node.path.split("--")[0],
           // And send it to the same rendering template
           component: `./src/templates/${query.substring(3)}.vue`,
           context: {

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -15,7 +15,7 @@
           :key="plugin.node.id"
           class="result-item"
         >
-          <g-link :to="plugin.node.path">
+          <g-link :to="plugin.node.path.split('--')[0]">
             <div class="result-left">
               <g-image
                 v-if="plugin.node.logo_url"

--- a/src/pages/Extractors.vue
+++ b/src/pages/Extractors.vue
@@ -14,7 +14,7 @@
           :key="edge.node.id"
           class="page-single-plugin"
         >
-          <g-link :to="edge.node.path">
+          <g-link :to="edge.node.path.split('--')[0]">
             <g-image
               v-if="edge.node.logo_url"
               :src="
@@ -53,7 +53,13 @@ export default {
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allExtractors(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
+  allExtractors(
+    perPage: 100
+    page: $page
+    sortBy: "label"
+    order: ASC
+    filter: { isDefault: { eq: true } }
+  ) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -9,7 +9,7 @@
       </p>
       <ul class="plugins-list">
         <li v-for="edge in $page.allFiles.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path">
+          <g-link :to="edge.node.path.split('--')[0]">
             <h2>{{ edge.node.label }}</h2>
             <g-image
               v-if="edge.node.logo_url"
@@ -49,7 +49,13 @@ export default {
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allFiles(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
+  allFiles(
+    perPage: 100
+    page: $page
+    sortBy: "label"
+    order: ASC
+    filter: { isDefault: { eq: true } }
+  ) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/src/pages/Loaders.vue
+++ b/src/pages/Loaders.vue
@@ -10,7 +10,7 @@
       </p>
       <ul class="plugins-list">
         <li v-for="edge in $page.allLoaders.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path">
+          <g-link :to="edge.node.path.split('--')[0]">
             <h2>{{ edge.node.label }}</h2>
             <g-image
               v-if="edge.node.logo_url"
@@ -50,7 +50,13 @@ export default {
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allLoaders(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
+  allLoaders(
+    perPage: 100
+    page: $page
+    sortBy: "label"
+    order: ASC
+    filter: { isDefault: { eq: true } }
+  ) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/src/pages/Orchestrators.vue
+++ b/src/pages/Orchestrators.vue
@@ -12,7 +12,7 @@
           :key="edge.node.id"
           class="page-single-plugin"
         >
-          <g-link :to="edge.node.path">
+          <g-link :to="edge.node.path.split('--')[0]">
             <h2>{{ edge.node.label }}</h2>
             <g-image
               v-if="edge.node.logo_url"
@@ -52,7 +52,13 @@ export default {
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allOrchestrators(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
+  allOrchestrators(
+    perPage: 100
+    page: $page
+    sortBy: "label"
+    order: ASC
+    filter: { isDefault: { eq: true } }
+  ) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/src/pages/Transformers.vue
+++ b/src/pages/Transformers.vue
@@ -12,7 +12,7 @@
           :key="edge.node.id"
           class="page-single-plugin"
         >
-          <g-link :to="edge.node.path">
+          <g-link :to="edge.node.path.split('--')[0]">
             <h2>{{ edge.node.label }}</h2>
             <g-image
               v-if="edge.node.logo_url"
@@ -52,7 +52,13 @@ export default {
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allTransformers(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
+  allTransformers(
+    perPage: 100
+    page: $page
+    sortBy: "label"
+    order: ASC
+    filter: { isDefault: { eq: true } }
+  ) @paginate {
     pageInfo {
       totalPages
       currentPage

--- a/src/pages/Utilities.vue
+++ b/src/pages/Utilities.vue
@@ -8,7 +8,7 @@
       </p>
       <ul class="plugins-list">
         <li v-for="edge in $page.allUtilities.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path">
+          <g-link :to="edge.node.path.split('--')[0]">
             <h2>{{ edge.node.label }}</h2>
             <g-image
               v-if="edge.node.logo_url"
@@ -48,7 +48,13 @@ export default {
 
 <page-query lang="graphql">
 query ($page: Int) {
-  allUtilities(perPage: 100, page: $page, sortBy: "label", order: ASC) @paginate {
+  allUtilities(
+    perPage: 100
+    page: $page
+    sortBy: "label"
+    order: ASC
+    filter: { isDefault: { eq: true } }
+  ) @paginate {
     pageInfo {
       totalPages
       currentPage


### PR DESCRIPTION
Closes #767 

This PR:

- Makes it so that the plugin lists (`/extractors`, `/loaders` etc) display a single entry for each plugin (previously they would have a card for each available variant)
- Making the links on the list pages direct to the plugin path rather than the variant path (`/extractors/tap-csv` instead of `/extractors/tap-csv/transferwise`)
  - And also for search results dropdown
- Changes the path convention to match old hub (`/:plugintype/:name/:variant` -> `/:plugintype/:name--:variant`)

I prefer having the `/` separator between the name and variant because it matches our directory scheme a bit better. But it's probably wise to not break any existing links out in the wild.