### PR TITLE
feat: Add tailwind to Hub using gridsome plugin

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -7,7 +7,15 @@
 module.exports = {
   siteName: "Meltano Hub",
   icon: "./src/meltano-favicon-192x192.png",
-  plugins: [],
+  plugins: [
+    {
+      use: "gridsome-plugin-tailwindcss",
+
+      options: {
+        tailwindConfig: "./tailwind.config.js",
+      },
+    },
+  ],
   chainWebpack: (config) => {
     config.resolve.alias.set("@logos", "@/../assets/logos");
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.7",
     "graphql-tag": "^2.12.6",
     "gridsome": "^0.7.0",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gridsome": "^0.7.0",
     "js-yaml": "^4.1.0",
     "marked": "^4.1.0",
+    "tailwindcss": "^3.1.8",
     "write": "^2.0.0"
   },
   "resolutions": {
@@ -26,6 +27,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-vue": "^9.2.0",
+    "gridsome-plugin-tailwindcss": "^4.1.1",
     "prettier": "2.7.1",
     "sass": "^1.52.3",
     "sass-loader": "^10",

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -127,12 +127,6 @@ footer {
   text-decoration: none;
 }
 
-.single-plugin-overview pre code {
-  background: #e5e7eb;
-  padding: 2px 4px;
-  font-family: "IBM Plex Mono";
-}
-
 .single-plugin-detail {
   background: #ffffff;
   color: #29292f;

--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <p class="text-3xl" id="capabilities">Capabilities</p>
+    <p class="text-3xl py-4" id="capabilities">Capabilities</p>
     <span v-if="capabilities">
       <span
         >The current capabilities for
@@ -11,7 +11,7 @@
         capabilities for this {{ plugin_type }}.</span
       >
       <p>This plugin has the following capabilities:</p>
-      <ul>
+      <ul class="list-disc list-inside">
         <li v-for="(capability, index) in capabilities" v-bind:key="index">
           {{ capability }}
         </li>

--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h2 id="capabilities">Capabilities</h2>
+    <p class="text-3xl" id="capabilities">Capabilities</p>
     <span v-if="capabilities">
       <span
         >The current capabilities for

--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="commands">
-    <p class="text-3xl" id="commands">Commands</p>
+    <p class="text-3xl py-4" id="commands">Commands</p>
     <span
       >The {{ name }} {{ plugin_type }} supports the following commands that can be used with
       <pre><code>meltano invoke</code></pre>

--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="commands">
-    <h2 id="commands">Commands</h2>
+    <p class="text-3xl" id="commands">Commands</p>
     <span
       >The {{ name }} {{ plugin_type }} supports the following commands that can be used with
       <pre><code>meltano invoke</code></pre>

--- a/src/components/PluginHelpSection.vue
+++ b/src/components/PluginHelpSection.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="help-module">
-    <h2 id="contribute">Something missing?</h2>
+    <p class="text-3xl" id="contribute">Something missing?</p>
     <p>This page is generated from a YAML file that you can contribute changes to.</p>
     <a
       v-if="name"
       :href="`https://github.com/meltano/hub/blob/main/_data/meltano/${plugin_type}/${name}/${variant}.yml`"
       >Edit it on GitHub!</a
     >
-    <h2 id="looking-for-help">Looking for help?</h2>
+    <p class="text-2xl" id="looking-for-help">Looking for help?</p>
     <div>
       If you're having trouble getting the
       {{ name }} extractor to work, look for an

--- a/src/components/PluginHelpSection.vue
+++ b/src/components/PluginHelpSection.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="help-module">
-    <p class="text-3xl" id="contribute">Something missing?</p>
+    <p class="text-3xl py-4" id="contribute">Something missing?</p>
     <p>This page is generated from a YAML file that you can contribute changes to.</p>
     <a
       v-if="name"
       :href="`https://github.com/meltano/hub/blob/main/_data/meltano/${plugin_type}/${name}/${variant}.yml`"
       >Edit it on GitHub!</a
     >
-    <p class="text-2xl" id="looking-for-help">Looking for help?</p>
+    <p class="text-3xl py-4" id="looking-for-help">Looking for help?</p>
     <div>
       If you're having trouble getting the
       {{ name }} extractor to work, look for an

--- a/src/components/PluginPrereqSection.vue
+++ b/src/components/PluginPrereqSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h3 id="prereqs">Prerequisites</h3>
+    <p class="text-3xl" id="prereqs">Prerequisites</p>
     <p>
       If you haven't already, follow the initial steps of the
       <a href="https://docs.meltano.com/getting-started.html">Getting Started guide</a>:

--- a/src/components/PluginPrereqSection.vue
+++ b/src/components/PluginPrereqSection.vue
@@ -15,11 +15,7 @@
         >
       </li>
     </ol>
-    <div
-      class="prose mt-3 bg-slate-100 p-2"
-      v-if="plugin.prereq"
-      v-html="plugin.prereq_rendered"
-    ></div>
+    <div class="prose mt-3 p-2" v-if="plugin.prereq" v-html="plugin.prereq_rendered"></div>
   </div>
 </template>
 

--- a/src/components/PluginPrereqSection.vue
+++ b/src/components/PluginPrereqSection.vue
@@ -15,7 +15,7 @@
         >
       </li>
     </ol>
-    <div v-if="plugin.prereq" v-html="plugin.prereq_rendered"></div>
+    <div class="prose mt-3 bg-slate-100" v-if="plugin.prereq" v-html="plugin.prereq_rendered"></div>
   </div>
 </template>
 

--- a/src/components/PluginPrereqSection.vue
+++ b/src/components/PluginPrereqSection.vue
@@ -15,7 +15,11 @@
         >
       </li>
     </ol>
-    <div class="prose mt-3 bg-slate-100" v-if="plugin.prereq" v-html="plugin.prereq_rendered"></div>
+    <div
+      class="prose mt-3 bg-slate-100 p-2"
+      v-if="plugin.prereq"
+      v-html="plugin.prereq_rendered"
+    ></div>
   </div>
 </template>
 

--- a/src/components/PluginPrereqSection.vue
+++ b/src/components/PluginPrereqSection.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <p class="text-3xl" id="prereqs">Prerequisites</p>
+    <p class="text-xl py-3" id="prereqs">Prerequisites</p>
     <p>
       If you haven't already, follow the initial steps of the
       <a href="https://docs.meltano.com/getting-started.html">Getting Started guide</a>:
     </p>
-    <ol>
+    <ol class="list-decimal list-inside pl-4">
       <li>
         <a href="https://docs.meltano.com/getting-started.html#install-meltano">Install Meltano</a>
       </li>

--- a/src/components/PluginRequiresSection.vue
+++ b/src/components/PluginRequiresSection.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="requires">
-    <p class="text-3xl">Requires</p>
+    <p class="text-3xl py-4">Requires</p>
     <p>This {{ plugin_type }} requires the following plugins and variants to work:</p>
-    <ul>
+    <ul class="list-disc list-inside">
       <li v-for="(file, index) in requires.files" v-bind:key="index">
         {{ file.name }} - {{ file.variant }}
       </li>

--- a/src/components/PluginRequiresSection.vue
+++ b/src/components/PluginRequiresSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="requires">
-    <h3>Requires</h3>
+    <p class="text-3xl">Requires</p>
     <p>This {{ plugin_type }} requires the following plugins and variants to work:</p>
     <ul>
       <li v-for="(file, index) in requires.files" v-bind:key="index">

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -32,14 +32,12 @@
         <p class="text-xl mt-3" :id="setting.name + '-setting'">
           <code>{{ setting.label }} ({{ setting.name }})</code>
         </p>
-        <p>
-          <div
-            class="prose bg-slate-100"
-            v-if="setting.description"
-            v-html="setting.description_rendered"
-          ></div>
-          <span v-else><a href="#contribute">[No description provided.]</a></span>
-        </p>
+        <div
+          class="prose bg-slate-100"
+          v-if="setting.description"
+          v-html="setting.description_rendered"
+        ></div>
+        <span v-else><a href="#contribute">[No description provided.]</a></span>
       </span>
     </span>
     <span v-else

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h2 id="settings">Settings</h2>
+    <p class="text-3xl" id="settings">Settings</p>
     <span v-if="settings">
       <span v-if="preamble" v-html="preamble"></span>
       <p>
@@ -29,9 +29,9 @@
         <a href="#contributing">pull request to the YAML file</a>.
       </p>
       <span v-for="(setting, index) in settings" v-bind:key="index">
-        <h3 :id="setting.name + '-setting'">
+        <p class="text-2xl" :id="setting.name + '-setting'">
           <code>{{ setting.label }} ({{ setting.name }})</code>
-        </h3>
+        </p>
         <p>
           <span v-if="setting.description" v-html="setting.description_rendered"></span>
           <span v-else><a href="#contribute">[No description provided.]</a></span>

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -2,7 +2,7 @@
   <div>
     <p class="text-3xl py-4" id="settings">Settings</p>
     <span class="space-y-3" v-if="settings">
-      <div class="prose bg-slate-100 mt-3" v-if="preamble" v-html="preamble"></div>
+      <div class="prose bg-slate-100 mt-3 p-2" v-if="preamble" v-html="preamble"></div>
       <p>
         The
         <code>{{ name }}</code> settings that are known to Meltano are documented below. To quickly
@@ -33,7 +33,7 @@
           <code>{{ setting.label }} ({{ setting.name }})</code>
         </p>
         <div
-          class="prose bg-slate-100"
+          class="prose bg-slate-100 p-2"
           v-if="setting.description"
           v-html="setting.description_rendered"
         ></div>

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
-    <p class="text-3xl" id="settings">Settings</p>
-    <span v-if="settings">
+    <p class="text-3xl py-4" id="settings">Settings</p>
+    <span class="space-y-3" v-if="settings">
       <span v-if="preamble" v-html="preamble"></span>
       <p>
         The
         <code>{{ name }}</code> settings that are known to Meltano are documented below. To quickly
         find the setting you're looking for, click on any setting name from the list:
       </p>
-      <ul>
+      <ul class="list-disc list-inside pl-4">
         <li v-for="(setting, index) in settings" v-bind:key="index">
           <a :href="'#' + setting.name + '-setting'"
             ><code>{{ setting.name }}</code></a
@@ -29,7 +29,7 @@
         <a href="#contributing">pull request to the YAML file</a>.
       </p>
       <span v-for="(setting, index) in settings" v-bind:key="index">
-        <p class="text-2xl" :id="setting.name + '-setting'">
+        <p class="text-xl mt-3" :id="setting.name + '-setting'">
           <code>{{ setting.label }} ({{ setting.name }})</code>
         </p>
         <p>

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -2,7 +2,7 @@
   <div>
     <p class="text-3xl py-4" id="settings">Settings</p>
     <span class="space-y-3" v-if="settings">
-      <span v-if="preamble" v-html="preamble"></span>
+      <div class="prose bg-slate-100 mt-3" v-if="preamble" v-html="preamble"></div>
       <p>
         The
         <code>{{ name }}</code> settings that are known to Meltano are documented below. To quickly
@@ -33,7 +33,11 @@
           <code>{{ setting.label }} ({{ setting.name }})</code>
         </p>
         <p>
-          <span v-if="setting.description" v-html="setting.description_rendered"></span>
+          <div
+            class="prose bg-slate-100"
+            v-if="setting.description"
+            v-html="setting.description_rendered"
+          ></div>
           <span v-else><a href="#contribute">[No description provided.]</a></span>
         </p>
       </span>

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -2,7 +2,7 @@
   <div>
     <p class="text-3xl py-4" id="settings">Settings</p>
     <span class="space-y-3" v-if="settings">
-      <div class="prose bg-slate-100 mt-3 p-2" v-if="preamble" v-html="preamble"></div>
+      <div class="prose mt-3 p-2" v-if="preamble" v-html="preamble"></div>
       <p>
         The
         <code>{{ name }}</code> settings that are known to Meltano are documented below. To quickly

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -1,92 +1,104 @@
 <template>
-  <div class="single-plugin-aside">
-    <p class="text-lg">Install</p>
-    <pre><code>meltano add {{plugin_type}} {{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code></pre>
+  <div class="single-plugin-aside space-y-3">
+    <div>
+      <p class="text-lg">Install</p>
+      <pre><code>meltano add {{plugin_type}} {{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code></pre>
+    </div>
+    <div></div>
     <p class="text-lg">Homepage</p>
     <div class="link-box">
       <img class="aside-icon" src="../assets/images/link-solid.svg" /><a :href="domain_url">{{
         domain_url
       }}</a>
     </div>
-    <p class="text-lg">Maintenance Status</p>
-    <img
-      v-if="maintenance_status === 'active'"
-      alt="Maintenance Status"
-      src="https://img.shields.io/badge/Maintenance%20Status-Active%20(Stable)-brightgreen"
-    />
-    <img
-      v-else-if="maintenance_status === 'unknown'"
-      alt="Maintenance Status"
-      src="https://img.shields.io/badge/Maintenance%20Status-Unknown-lightgrey"
-    />
-    <img
-      v-else-if="maintenance_status === 'development'"
-      alt="Maintenance Status"
-      src="https://img.shields.io/badge/Maintenance%20Status-Development%20(Under%20Construction)-orange"
-    />
-    <img
-      v-else-if="maintenance_status === 'beta'"
-      alt="Maintenance Status"
-      src="https://img.shields.io/badge/Maintenance%20Status-Prerelease%20(Beta)-yellow"
-    />
-    <img
-      v-else-if="maintenance_status === 'inactive'"
-      alt="Maintenance Status"
-      src="https://img.shields.io/badge/Maintenance%20Status-Inactive%20or%20Stale-red"
-    />
-    <p class="text-lg">Repo</p>
-    <div class="link-box">
-      <img class="aside-icon" src="../assets/images/git-alt-brands.svg" /><a :href="repo">{{
-        repo
-      }}</a>
+    <div>
+      <p class="text-lg">Maintenance Status</p>
+      <img
+        v-if="maintenance_status === 'active'"
+        alt="Maintenance Status"
+        src="https://img.shields.io/badge/Maintenance%20Status-Active%20(Stable)-brightgreen"
+      />
+      <img
+        v-else-if="maintenance_status === 'unknown'"
+        alt="Maintenance Status"
+        src="https://img.shields.io/badge/Maintenance%20Status-Unknown-lightgrey"
+      />
+      <img
+        v-else-if="maintenance_status === 'development'"
+        alt="Maintenance Status"
+        src="https://img.shields.io/badge/Maintenance%20Status-Development%20(Under%20Construction)-orange"
+      />
+      <img
+        v-else-if="maintenance_status === 'beta'"
+        alt="Maintenance Status"
+        src="https://img.shields.io/badge/Maintenance%20Status-Prerelease%20(Beta)-yellow"
+      />
+      <img
+        v-else-if="maintenance_status === 'inactive'"
+        alt="Maintenance Status"
+        src="https://img.shields.io/badge/Maintenance%20Status-Inactive%20or%20Stale-red"
+      />
     </div>
 
-    <ul class="shields">
-      <li>
-        <img
-          alt="Stars"
-          :src="`https://img.shields.io/${repoType}/stars/${parsedRepo.user}/${parsedRepo.repo_name}?style=flat-square&label=Stars`"
-        />
-      </li>
-      <li>
-        <img
-          alt="Forks"
-          :src="`https://img.shields.io/${repoType}/forks/${parsedRepo.user}/${parsedRepo.repo_name}?style=flat-square&label=Forks`"
-        />
-      </li>
-      <li>
-        <img
-          alt="Open Issues"
-          :src="`https://img.shields.io/${
-            repoType === 'github' ? 'github/issues-raw' : 'gitlab/issues/open-raw'
-          }/${parsedRepo.user}/${parsedRepo.repo_name}?label=Open%20Issues`"
-        />
-      </li>
-      <li>
-        <img
-          alt="Open PRs"
-          :src="`https://img.shields.io/${
-            repoType === 'github' ? 'github/issues-pr-raw' : 'gitlab/merge-requests/open'
-          }/${parsedRepo.user}/${parsedRepo.repo_name}?label=Open%20Pull%20Requests`"
-        />
-      </li>
-      <li>
-        <img
-          alt="Contributors"
-          :src="`https://img.shields.io/${repoType}/contributors/${parsedRepo.user}/${parsedRepo.repo_name}?label=Contributors`"
-        />
-      </li>
-      <li>
-        <img
-          alt="License"
-          :src="`https://img.shields.io/${repoType}/license/${parsedRepo.user}/${parsedRepo.repo_name}?color=c0c0c4&label=License&style=flat-square`"
-        />
-      </li>
-    </ul>
-    <p class="text-lg">Maintainer</p>
+    <div>
+      <p class="text-lg">Repo</p>
+      <div class="link-box">
+        <img class="aside-icon" src="../assets/images/git-alt-brands.svg" /><a :href="repo">{{
+          repo
+        }}</a>
+      </div>
+    </div>
+
+    <div>
+      <ul class="list-disc list-inside shields space-y-2">
+        <li>
+          <img
+            alt="Stars"
+            :src="`https://img.shields.io/${repoType}/stars/${parsedRepo.user}/${parsedRepo.repo_name}?style=flat-square&label=Stars`"
+          />
+        </li>
+        <li>
+          <img
+            alt="Forks"
+            :src="`https://img.shields.io/${repoType}/forks/${parsedRepo.user}/${parsedRepo.repo_name}?style=flat-square&label=Forks`"
+          />
+        </li>
+        <li>
+          <img
+            alt="Open Issues"
+            :src="`https://img.shields.io/${
+              repoType === 'github' ? 'github/issues-raw' : 'gitlab/issues/open-raw'
+            }/${parsedRepo.user}/${parsedRepo.repo_name}?label=Open%20Issues`"
+          />
+        </li>
+        <li>
+          <img
+            alt="Open PRs"
+            :src="`https://img.shields.io/${
+              repoType === 'github' ? 'github/issues-pr-raw' : 'gitlab/merge-requests/open'
+            }/${parsedRepo.user}/${parsedRepo.repo_name}?label=Open%20Pull%20Requests`"
+          />
+        </li>
+        <li>
+          <img
+            alt="Contributors"
+            :src="`https://img.shields.io/${repoType}/contributors/${parsedRepo.user}/${parsedRepo.repo_name}?label=Contributors`"
+          />
+        </li>
+        <li>
+          <img
+            alt="License"
+            :src="`https://img.shields.io/${repoType}/license/${parsedRepo.user}/${parsedRepo.repo_name}?color=c0c0c4&label=License&style=flat-square`"
+          />
+        </li>
+      </ul>
+    </div>
+
+    <div><p class="text-lg">Maintainer</p></div>
+
     <div v-if="metrics">
       <p class="text-lg">Meltano Stats</p>
-      <ul class="shields">
+      <ul class="list-disc list-inside shields">
         <li v-if="metrics.ALL_EXECS">
           <img
             alt="Total Executions (Last 3 Months)"
@@ -101,8 +113,10 @@
         </li>
       </ul>
     </div>
-    <p class="text-lg">Keywords</p>
-    <p>{{ (keywords ?? []).join(", ") }}</p>
+    <div>
+      <p class="text-lg">Keywords</p>
+      <p>{{ (keywords ?? []).join(", ") }}</p>
+    </div>
   </div>
 </template>
 

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="single-plugin-aside">
-    <h4>Install</h4>
+    <p class="text-lg">Install</p>
     <pre><code>meltano add {{plugin_type}} {{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code></pre>
-    <h4>Homepage</h4>
+    <p class="text-lg">Homepage</p>
     <div class="link-box">
       <img class="aside-icon" src="../assets/images/link-solid.svg" /><a :href="domain_url">{{
         domain_url
       }}</a>
     </div>
-    <h4>Maintenance Status</h4>
+    <p class="text-lg">Maintenance Status</p>
     <img
       v-if="maintenance_status === 'active'"
       alt="Maintenance Status"
@@ -34,7 +34,7 @@
       alt="Maintenance Status"
       src="https://img.shields.io/badge/Maintenance%20Status-Inactive%20or%20Stale-red"
     />
-    <h4>Repo</h4>
+    <p class="text-lg">Repo</p>
     <div class="link-box">
       <img class="aside-icon" src="../assets/images/git-alt-brands.svg" /><a :href="repo">{{
         repo
@@ -83,9 +83,9 @@
         />
       </li>
     </ul>
-    <h4>Maintainer</h4>
+    <p class="text-lg">Maintainer</p>
     <div v-if="metrics">
-      <h4>Meltano Stats</h4>
+      <p class="text-lg">Meltano Stats</p>
       <ul class="shields">
         <li v-if="metrics.ALL_EXECS">
           <img
@@ -101,7 +101,7 @@
         </li>
       </ul>
     </div>
-    <h4>Keywords</h4>
+    <p class="text-lg">Keywords</p>
     <p>{{ (keywords ?? []).join(", ") }}</p>
   </div>
 </template>

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -27,7 +27,7 @@
                   )}`)
                 "
               />
-              <p class="text-3xl">
+              <p class="text-3xl py-4">
                 {{ plugin.node.label }}
               </p>
               <span>{{ plugin.node.description || "No description" }}</span>

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -5,7 +5,7 @@
       name="search"
       id="search"
       placeholder="Search 300+ connectors and tools that work with Meltano…"
-      class="search-bar"
+      class="search-bar text-black"
       ref="searchBar"
       v-model="search"
       @focus="searchFocused = true"

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -27,9 +27,9 @@
                   )}`)
                 "
               />
-              <h1>
+              <p class="text-3xl">
                 {{ plugin.node.label }}
-              </h1>
+              </p>
               <span>{{ plugin.node.description || "No description" }}</span>
             </div>
 

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="file-not-found">
-      <p class="text-3xl">Whoops. Nothing to see here!</p>
+      <p class="text-3xl py-4">Whoops. Nothing to see here!</p>
     </div>
   </Layout>
 </template>

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="file-not-found">
-      <h1>Whoops. Nothing to see here!</h1>
+      <p class="text-3xl">Whoops. Nothing to see here!</p>
     </div>
   </Layout>
 </template>

--- a/src/pages/Extractors.vue
+++ b/src/pages/Extractors.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Extractors</h1>
+      <p class="text-3xl">Extractors</p>
       <p>
         Meltano lets you easily extract data out of arbitrary sources (databases, SaaS APIs, and
         file formats) using Singer taps, which take the role of your project’s extractor plugins. To
@@ -20,7 +20,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Extractors.vue
+++ b/src/pages/Extractors.vue
@@ -10,7 +10,7 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path.split('--')[0]">
+          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Extractors.vue
+++ b/src/pages/Extractors.vue
@@ -10,7 +10,10 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
+          <g-link
+            class="items-center flex flex-auto flex-col justify-around"
+            :to="edge.node.path.split('--')[0]"
+          >
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Extractors.vue
+++ b/src/pages/Extractors.vue
@@ -24,7 +24,6 @@
               "
             />
             <p class="text-2xl">{{ edge.node.label }}</p>
-            <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>
         <Pager

--- a/src/pages/Extractors.vue
+++ b/src/pages/Extractors.vue
@@ -1,14 +1,14 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <p class="text-3xl">Extractors</p>
+      <p class="text-3xl py-4">Extractors</p>
       <p>
         Meltano lets you easily extract data out of arbitrary sources (databases, SaaS APIs, and
         file formats) using Singer taps, which take the role of your project’s extractor plugins. To
         learn more about extracting and loading data using Meltano, refer to the Data Integration
         (EL) guide.
       </p>
-      <ul class="plugins-list">
+      <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
           <g-link :to="edge.node.path.split('--')[0]">
             <g-image

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Files</h1>
+      <p class="text-3xl">Files</p>
       <p>
         Meltano file plugins allow you to easily add new file resources to your data project. For
         example, Meltano utilities and other plugins can define file plugins that provide
@@ -19,7 +19,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -23,7 +23,6 @@
               "
             />
             <p class="text-2xl">{{ edge.node.label }}</p>
-            <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>
         <Pager

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -1,13 +1,13 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <p class="text-3xl">Files</p>
+      <p class="text-3xl py-4">Files</p>
       <p>
         Meltano file plugins allow you to easily add new file resources to your data project. For
         example, Meltano utilities and other plugins can define file plugins that provide
         tool-specific scaffolding, templates, and applicable readme resources.
       </p>
-      <ul class="plugins-list">
+      <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
           <g-link :to="edge.node.path.split('--')[0]">
             <g-image

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -9,7 +9,10 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
+          <g-link
+            class="items-center flex flex-auto flex-col justify-around"
+            :to="edge.node.path.split('--')[0]"
+          >
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -9,7 +9,7 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path.split('--')[0]">
+          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -1,11 +1,11 @@
 <template>
   <Layout>
     <div class="home-details">
-      <h1>Welcome to Meltano Hub</h1>
-      <h2>
+      <p class="text-3xl">Welcome to Meltano Hub</p>
+      <p class="text-2xl">
         Meltano Hub is a central place to find any Meltano plugin as well as Singer taps and
         targets. The Hub is lovingly curated by Meltano and the wider Singer community.
-      </h2>
+      </p>
     </div>
   </Layout>
 </template>
@@ -28,13 +28,13 @@ export default {
   padding: 20px;
   text-align: center;
 
-  h1 {
+  p {
     font-size: 3rem;
     line-height: 1.25;
     margin: 25px auto;
   }
 
-  h2 {
+  p {
     margin: 25px auto;
   }
 }
@@ -48,7 +48,7 @@ export default {
     padding: 50px 20%;
     text-align: center;
 
-    h1 {
+    p {
       font-size: 4.7rem;
     }
   }

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -1,8 +1,8 @@
 <template>
   <Layout>
     <div class="home-details">
-      <p class="text-3xl">Welcome to Meltano Hub</p>
-      <p class="text-2xl">
+      <p class="text-5xl tracking-wide mb-3">Welcome to Meltano Hub</p>
+      <p class="text-xl">
         Meltano Hub is a central place to find any Meltano plugin as well as Singer taps and
         targets. The Hub is lovingly curated by Meltano and the wider Singer community.
       </p>
@@ -27,16 +27,6 @@ export default {
   align-items: center;
   padding: 20px;
   text-align: center;
-
-  p {
-    font-size: 3rem;
-    line-height: 1.25;
-    margin: 25px auto;
-  }
-
-  p {
-    margin: 25px auto;
-  }
 }
 
 @media (min-width: 1000px) {
@@ -47,10 +37,6 @@ export default {
     align-items: center;
     padding: 50px 20%;
     text-align: center;
-
-    p {
-      font-size: 4.7rem;
-    }
   }
 }
 </style>

--- a/src/pages/Loaders.vue
+++ b/src/pages/Loaders.vue
@@ -10,7 +10,7 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path.split('--')[0]">
+          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Loaders.vue
+++ b/src/pages/Loaders.vue
@@ -10,7 +10,10 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
+          <g-link
+            class="items-center flex flex-auto flex-col justify-around"
+            :to="edge.node.path.split('--')[0]"
+          >
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Loaders.vue
+++ b/src/pages/Loaders.vue
@@ -24,7 +24,6 @@
               "
             />
             <p class="text-2xl">{{ edge.node.label }}</p>
-            <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>
         <Pager

--- a/src/pages/Loaders.vue
+++ b/src/pages/Loaders.vue
@@ -1,14 +1,14 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <p class="text-3xl">Loaders</p>
+      <p class="text-3xl py-4">Loaders</p>
       <p>
         Meltano lets you easily load extracted data into arbitrary destinations (databases, SaaS
         APIs, and file formats) using Singer targets, which take the role of your project’s loader
         plugins. To learn more about extracting and loading data using Meltano, refer to the Data
         Integration (EL) guide.
       </p>
-      <ul class="plugins-list">
+      <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
           <g-link :to="edge.node.path.split('--')[0]">
             <g-image

--- a/src/pages/Loaders.vue
+++ b/src/pages/Loaders.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Loaders</h1>
+      <p class="text-3xl">Loaders</p>
       <p>
         Meltano lets you easily load extracted data into arbitrary destinations (databases, SaaS
         APIs, and file formats) using Singer targets, which take the role of your project’s loader
@@ -20,7 +20,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Maintainers.vue
+++ b/src/pages/Maintainers.vue
@@ -1,8 +1,8 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <p class="text-3xl">Plugin Maintainers</p>
-      <ul class="plugins-list">
+      <p class="text-3xl py-4">Plugin Maintainers</p>
+      <ul class="list-disc list-inside plugins-list">
         <li
           v-for="(edge, index) in $page.allMaintainers.edges"
           :key="index"

--- a/src/pages/Maintainers.vue
+++ b/src/pages/Maintainers.vue
@@ -1,16 +1,16 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Plugin Maintainers</h1>
+      <p class="text-3xl">Plugin Maintainers</p>
       <ul class="plugins-list">
         <li
           v-for="(edge, index) in $page.allMaintainers.edges"
           :key="index"
           class="page-single-plugin"
         >
-          <h2>
+          <p class="text-2xl">
             <a :href="`${edge.node.url}`">{{ edge.node.label }}</a>
-          </h2>
+          </p>
         </li>
         <Pager
           :info="$page.allMaintainers.pageInfo"

--- a/src/pages/Orchestrators.vue
+++ b/src/pages/Orchestrators.vue
@@ -8,7 +8,10 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
+          <g-link
+            class="items-center flex flex-auto flex-col justify-around"
+            :to="edge.node.path.split('--')[0]"
+          >
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Orchestrators.vue
+++ b/src/pages/Orchestrators.vue
@@ -1,12 +1,12 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <p class="text-3xl">Orchestrators</p>
+      <p class="text-3xl py-4">Orchestrators</p>
       <p>
         Meltano orchestrator plugins provide advanced scheduling and workflow execution
         capabilities.
       </p>
-      <ul class="plugins-list">
+      <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
           <g-link :to="edge.node.path.split('--')[0]">
             <g-image

--- a/src/pages/Orchestrators.vue
+++ b/src/pages/Orchestrators.vue
@@ -8,7 +8,7 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path.split('--')[0]">
+          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Orchestrators.vue
+++ b/src/pages/Orchestrators.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Orchestrators</h1>
+      <p class="text-3xl">Orchestrators</p>
       <p>
         Meltano orchestrator plugins provide advanced scheduling and workflow execution
         capabilities.
@@ -18,7 +18,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Orchestrators.vue
+++ b/src/pages/Orchestrators.vue
@@ -22,7 +22,6 @@
               "
             />
             <p class="text-2xl">{{ edge.node.label }}</p>
-            <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>
         <Pager

--- a/src/pages/Singer.vue
+++ b/src/pages/Singer.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Welcome to MeltanoHub for Singer</h1>
+      <p class="text-3xl">Welcome to MeltanoHub for Singer</p>
       <p>
         MeltanoHub for Singer is the leading destination for the Singer Community to discover taps,
         targets, and other valuable resources. Read the
@@ -19,7 +19,7 @@
         <li class="page-single-plugin">spec</li>
       </ul>
 
-      <h1>API Resources</h1>
+      <p class="text-3xl">API Resources</p>
       <p>
         MeltanoHub for Singer is built for the entire Singer community. We have several resources
         available at a versioned endpoint that can be used by other organizations to build a catalog

--- a/src/pages/Singer.vue
+++ b/src/pages/Singer.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <p class="text-3xl">Welcome to MeltanoHub for Singer</p>
+      <p class="text-3xl py-4">Welcome to MeltanoHub for Singer</p>
       <p>
         MeltanoHub for Singer is the leading destination for the Singer Community to discover taps,
         targets, and other valuable resources. Read the
@@ -14,19 +14,19 @@
         Singer community and the architecture behind the Hub.
       </p>
 
-      <ul class="plugins-list">
+      <ul class="list-disc list-inside plugins-list">
         <li class="page-single-plugin">sdk</li>
         <li class="page-single-plugin">spec</li>
       </ul>
 
-      <p class="text-3xl">API Resources</p>
+      <p class="text-3xl py-4">API Resources</p>
       <p>
         MeltanoHub for Singer is built for the entire Singer community. We have several resources
         available at a versioned endpoint that can be used by other organizations to build a catalog
         of taps and targets within their products. You can view the latest version of each resource
         below:
       </p>
-      <ul class="plugins-list">
+      <ul class="list-disc list-inside plugins-list">
         <li class="page-single-plugin">tap json</li>
         <li class="page-single-plugin">target json</li>
         <li class="page-single-plugin">json schema</li>

--- a/src/pages/Transformers.vue
+++ b/src/pages/Transformers.vue
@@ -1,12 +1,12 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <p class="text-3xl">Transformers</p>
+      <p class="text-3xl py-4">Transformers</p>
       <p>
         Meltano transformer plugins allow you to create new derived transformations from raw data
         sources.
       </p>
-      <ul class="plugins-list">
+      <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
           <g-link :to="edge.node.path.split('--')[0]">
             <g-image

--- a/src/pages/Transformers.vue
+++ b/src/pages/Transformers.vue
@@ -8,7 +8,10 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
+          <g-link
+            class="items-center flex flex-auto flex-col justify-around"
+            :to="edge.node.path.split('--')[0]"
+          >
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Transformers.vue
+++ b/src/pages/Transformers.vue
@@ -8,7 +8,7 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path.split('--')[0]">
+          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Transformers.vue
+++ b/src/pages/Transformers.vue
@@ -22,7 +22,6 @@
               "
             />
             <p class="text-2xl">{{ edge.node.label }}</p>
-            <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>
         <Pager

--- a/src/pages/Transformers.vue
+++ b/src/pages/Transformers.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Transformers</h1>
+      <p class="text-3xl">Transformers</p>
       <p>
         Meltano transformer plugins allow you to create new derived transformations from raw data
         sources.
@@ -18,7 +18,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Utilities.vue
+++ b/src/pages/Utilities.vue
@@ -8,7 +8,10 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
+          <g-link
+            class="items-center flex flex-auto flex-col justify-around"
+            :to="edge.node.path.split('--')[0]"
+          >
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Utilities.vue
+++ b/src/pages/Utilities.vue
@@ -8,7 +8,7 @@
       </p>
       <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
-          <g-link :to="edge.node.path.split('--')[0]">
+          <g-link class="items-center flex flex-auto flex-col" :to="edge.node.path.split('--')[0]">
             <g-image
               v-if="edge.node.logo_url"
               :src="

--- a/src/pages/Utilities.vue
+++ b/src/pages/Utilities.vue
@@ -1,12 +1,12 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <p class="text-3xl">Utilities</p>
+      <p class="text-3xl py-4">Utilities</p>
       <p>
         Meltano utilities plugins allow virtually any open source data tool to be integrated with
         your data project.
       </p>
-      <ul class="plugins-list">
+      <ul class="list-disc list-inside plugins-list">
         <li v-for="edge in $page.allPlugins.edges" :key="edge.node.id" class="page-single-plugin">
           <g-link :to="edge.node.path.split('--')[0]">
             <g-image

--- a/src/pages/Utilities.vue
+++ b/src/pages/Utilities.vue
@@ -22,7 +22,6 @@
               "
             />
             <p class="text-2xl">{{ edge.node.label }}</p>
-            <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>
         <Pager

--- a/src/pages/Utilities.vue
+++ b/src/pages/Utilities.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Utilities</h1>
+      <p class="text-3xl">Utilities</p>
       <p>
         Meltano utilities plugins allow virtually any open source data tool to be integrated with
         your data project.
@@ -18,7 +18,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/singer/Docs.vue
+++ b/src/pages/singer/Docs.vue
@@ -42,7 +42,7 @@
       </p>
 
       <p class="text-2xl">API</p>
-      <ul>
+      <ul class="list-disc list-inside">
         <li>API Directory</li>
       </ul>
 
@@ -51,7 +51,7 @@
         these files will always be available at these endpoints:
       </p>
 
-      <ul>
+      <ul class="list-disc list-inside">
         <li>Tap JSON</li>
         <li>Target JSON</li>
       </ul>
@@ -233,7 +233,7 @@
         or target side but will soon be supported in Meltano itself. This includes things like:
       </p>
 
-      <ul>
+      <ul class="list-disc list-inside">
         <li>stream and property aliasing</li>
         <li>duplication and bifurcation of streams</li>
         <li>hashing or anonymizing PII/PHI</li>
@@ -324,7 +324,7 @@
         overall quality of Singer connectors.
       </p>
       <p>Current Metrics:</p>
-      <ul>
+      <ul class="list-disc list-inside">
         <li>
           Executions (Last 3 Months): The sum of executions via meltano elt or meltano invoke) that
           used the plugin.

--- a/src/pages/singer/Docs.vue
+++ b/src/pages/singer/Docs.vue
@@ -1,20 +1,20 @@
 <template>
   <Layout>
     <div class="docs-layout">
-      <h2>Commitment to the Singer Community</h2>
+      <p class="text-2xl">Commitment to the Singer Community</p>
       <p>
         The Meltano team aims to make MeltanoHub a fantastic resource for members of the Singer
         Community. We’re fully embracing Singer and MeltanoHub for Singer is a large part of those
         efforts.
       </p>
 
-      <h2>Development</h2>
+      <p class="text-2xl">Development</p>
       <p>
         MeltanoHub is under active development by Meltano. Check out our issue tracker to understand
         progress on a specific feature.
       </p>
 
-      <h2>Standardized Connectors</h2>
+      <p class="text-2xl">Standardized Connectors</p>
       <p>
         All taps and targets are pulled from external sources, such as GitHub and GitLab, and are
         organized into a clean YAML format that has no references to external tools. Learn more
@@ -41,7 +41,7 @@
         GitHub. These are useful proxy metrics for the quality of a given connector.
       </p>
 
-      <h2>API</h2>
+      <p class="text-2xl">API</p>
       <ul>
         <li>API Directory</li>
       </ul>
@@ -66,7 +66,7 @@
         Our expectation is that other tools, including Meltano, will utilize the data available via
         the API to build their own library of Singer taps and targets.
       </p>
-      <h2>Tap and Target SDKs</h2>
+      <p class="text-2xl">Tap and Target SDKs</p>
       <p>
         We’ve also created an SDK for Taps and Targets that is the best way to build and maintain
         Singer Taps and Targets.
@@ -74,13 +74,13 @@
 
       <p>Read more about the launch of the SDK on the Meltano blog.</p>
 
-      <h2>Singer Spec</h2>
+      <p class="text-2xl">Singer Spec</p>
       <p>
         We’ve created a simplified version of the Singer Specification with the goal of making it
         easier for people new to the Singer ecosystem to understand the spec.
       </p>
 
-      <h2>Singer Connector Capabilities</h2>
+      <p class="text-2xl">Singer Connector Capabilities</p>
       <p>
         The Singer Specification does a great job defining how taps and targets should communicate
         with each other at a high level but there’s an additional layer of commonly used patterns
@@ -90,33 +90,33 @@
       </p>
 
       <h3>Tap Specific</h3>
-      <h4>Catalog</h4>
+      <p class="text-lg">Catalog</p>
       <p>
         The tap accepts a --catalog argument referencing a file that defines the structure of one or
         many data streams. For more details see the Catalog Files section in our Singer Spec
         interpretation.
       </p>
 
-      <h4>Properties</h4>
+      <p class="text-lg">Properties</p>
       <p>
         The tap accepts the legacy --properties argument referencing a file that defines the
         structure of one or many data streams. For more details see the Catalog Files section in our
         Singer Spec interpretation.
       </p>
 
-      <h4>Discover</h4>
+      <p class="text-lg">Discover</p>
       <p>
         The tap accepts a --discover argument that is used to generate a catalog files. For more
         details see the Discovery mode section section in our Singer Spec interpretation.
       </p>
 
-      <h4>State</h4>
+      <p class="text-lg">State</p>
       <p>
         The tap accepts a --state argument and uses the input in order to run incremental syncs. For
         more details see the State Files section section in our Singer Spec interpretation.
       </p>
 
-      <h4>Log Based</h4>
+      <p class="text-lg">Log Based</p>
       This is a database source specific capability which supports reading the transaction logs of a
       database in order to identify incrementally changed data. The two common replication
       techniques are key-based or log-based replication. Key-based uses a timestamp or incrementing
@@ -125,14 +125,14 @@
       Supporting this capability, where applicable, means that targets have the information it needs
       to delete records in the destination.
 
-      <h4>Test</h4>
+      <p class="text-lg">Test</p>
       This capability is still in development, but the goal is to make it easy for connector
       developers to test locally without having to make a connection to the source systems. This
       might be accomplished by implementing utilities that can generate and save test data or make
       saving and moving real HTTP requests for tests easier. Join the issue conversation here!
 
       <h3>Target Specific</h3>
-      <h4>Soft Delete</h4>
+      <p class="text-lg">Soft Delete</p>
       <p>
         Targets that support this capability implement logic that soft deletes records in the
         destination, usually by populating a deleted_at timestamp field. The two common techniques
@@ -141,7 +141,7 @@
         deletes, in which case the behavior is configurable in the target’s config settings.
       </p>
 
-      <h4>Hard Delete</h4>
+      <p class="text-lg">Hard Delete</p>
       <p>
         Similar to the Soft Deletes capability, targets that support the hard delete capability
         implement logic that removes records from the destination when they receive a notification
@@ -150,7 +150,7 @@
         configurable in the target’s config settings.
       </p>
 
-      <h4>Datatype Failsafe</h4>
+      <p class="text-lg">Datatype Failsafe</p>
       <p>
         This capability means that the target has a failsafe data type (e.g. string) to ensure safe
         handling of unparsable or unforseen types. It’s common to find targets in the Singer
@@ -159,7 +159,7 @@
         exceptions will not be raised for unsupported types.
       </p>
 
-      <h4>Record Flattening</h4>
+      <p class="text-lg">Record Flattening</p>
       <p>
         It’s common for taps to output nested json data which needs to be flattened by the target in
         order to be loaded into a columnar format destinations. For example, the following is a
@@ -186,7 +186,7 @@
       </p>
 
       <h3>Either Tap or Target</h3>
-      <h4>Activate Version</h4>
+      <p class="text-lg">Activate Version</p>
       <p>
         Managing hard deletes in the source system is difficult but the Singer community has
         developed a technique using a message type called ACTIVATE_VERSION. This isnt a standardized
@@ -226,7 +226,7 @@
         destination.
       </p>
 
-      <h4>Stream Maps</h4>
+      <p class="text-lg">Stream Maps</p>
       <p>
         The ability to accept a mapping configuration can be used to do minor transformations to the
         data between the tap and target. The capability can be currently be implemented on the tap
@@ -249,7 +249,7 @@
         details and use cases.
       </p>
 
-      <h4>About</h4>
+      <p class="text-lg">About</p>
       <p>
         The tap or target accepts an --about argument which outputs details about the connector
         including its capabilities and settings which can be used in programmatically generate UI
@@ -282,7 +282,7 @@
 }
 </code></pre>
 
-      <h4>Batch</h4>
+      <p class="text-lg">Batch</p>
       <p>
         This capability is currently in development by the Singer Working Group to align on a
         consistent approach for supporting batch sync messages in the Spec or as part of its
@@ -311,7 +311,7 @@
       <p>We’re using Singer taps and targets to extract and load into a Snowflake warehouse.</p>
       <p>We’re using dbt to manage transformations with Athena to aid in curating the data.</p>
 
-      <h2>Meltano Usage Metrics</h2>
+      <p class="text-2xl">Meltano Usage Metrics</p>
       <p>
         Meltano collects anonymous usage stats using Google Analytics. We use this data to learn
         about the size of our user base and overal feature usage. This helps us determine the

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -17,7 +17,7 @@
                 />
               </td>
               <td>
-                <p class="text-3xl">
+                <p class="text-3xl py-8">
                   {{ $page.plugins.label }}
                 </p>
                 <p class="text-2xl">
@@ -30,7 +30,7 @@
             </tr>
           </table>
         </div>
-        <div class="single-plugin-main">
+        <div class="single-plugin-main p-5 space-y-4">
           <p>
             The {{ $page.plugins.name }}
             <a :href="'https://docs.meltano.com/concepts/plugins#' + $page.plugins.pluginTypePlural"
@@ -41,7 +41,7 @@
             to a destination using a <g-link to="/loaders">loader</g-link>.
           </p>
           <p class="text-2xl">Other Available Variants</p>
-          <ul>
+          <ul class="list-disc list-inside pl-4">
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link :to="variant.node.path" v-if="variant.node.path !== $page.plugins.path">{{
                 variant.node.variant
@@ -50,10 +50,10 @@
               <span v-if="variant.node.isDefault"> (default)</span>
             </li>
           </ul>
-          <p class="text-3xl" id="getting-started">Getting Started</p>
+          <p class="text-3xl py-4" id="getting-started">Getting Started</p>
           <PluginPrereqSection :plugin="$page.plugins" :plugin_type="$page.plugins.pluginType" />
-          <p class="text-2xl" id="installation">Installation and configuration</p>
-          <ol>
+          <p class="text-xl py-3" id="installation">Installation and configuration</p>
+          <ol class="list-decimal list-inside pl-4">
             <li>
               Add the {{ $page.plugins.name }} {{ $page.plugins.pluginType }} to your project using
               <pre class="inline-code-block"><code>meltano add</code></pre>
@@ -61,12 +61,12 @@
             </li>
             <pre><code>meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
           </ol>
-          <p class="text-2xl">Next steps</p>
+          <p class="text-xl py-3">Next steps</p>
           <p>
             Follow the remaining steps of the
             <a href="https://docs.meltano.com/getting-started.html">Getting Started guide</a>:
           </p>
-          <ol>
+          <ol class="list-decimal list-inside pl-4">
             <li>
               <a
                 href="https://docs.meltano.com/getting-started.html#select-entities-and-attributes-to-extract"

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -17,12 +17,12 @@
                 />
               </td>
               <td>
-                <h1>
+                <p class="text-3xl">
                   {{ $page.plugins.label }}
-                </h1>
-                <h2>
+                </p>
+                <p class="text-2xl">
                   <code>{{ $page.plugins.name }} from {{ $page.plugins.variant }}</code>
-                </h2>
+                </p>
                 <p>
                   <b>{{ $page.plugins.description }}</b>
                 </p>
@@ -40,7 +40,7 @@
             <a :href="$page.plugins.domain_url">{{ $page.plugins.label }}</a> that can then be sent
             to a destination using a <g-link to="/loaders">loader</g-link>.
           </p>
-          <h3>Other Available Variants</h3>
+          <p class="text-2xl">Other Available Variants</p>
           <ul>
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link :to="variant.node.path" v-if="variant.node.path !== $page.plugins.path">{{
@@ -50,9 +50,9 @@
               <span v-if="variant.node.isDefault"> (default)</span>
             </li>
           </ul>
-          <h2 id="getting-started">Getting Started</h2>
+          <p class="text-3xl" id="getting-started">Getting Started</p>
           <PluginPrereqSection :plugin="$page.plugins" :plugin_type="$page.plugins.pluginType" />
-          <h3 id="installation">Installation and configuration</h3>
+          <p class="text-2xl" id="installation">Installation and configuration</p>
           <ol>
             <li>
               Add the {{ $page.plugins.name }} {{ $page.plugins.pluginType }} to your project using
@@ -61,7 +61,7 @@
             </li>
             <pre><code>meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
           </ol>
-          <h3>Next steps</h3>
+          <p class="text-2xl">Next steps</p>
           <p>
             Follow the remaining steps of the
             <a href="https://docs.meltano.com/getting-started.html">Getting Started guide</a>:

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -87,7 +87,11 @@
             </li>
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
-          <span v-if="$page.plugins.usage" v-html="$page.plugins.usage_rendered"></span>
+          <div
+            class="prose bg-slate-100 mt-3"
+            v-if="$page.plugins.usage"
+            v-html="$page.plugins.usage_rendered"
+          ></div>
           <PluginCapabilitiesSection
             :capabilities="$page.plugins.capabilities"
             :name="$page.plugins.name"

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -88,7 +88,7 @@
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
           <div
-            class="prose bg-slate-100 mt-3"
+            class="prose bg-slate-100 mt-3 p-2"
             v-if="$page.plugins.usage"
             v-html="$page.plugins.usage_rendered"
           ></div>

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -88,7 +88,7 @@
           </ol>
           <p>If you run into any issues, learn how to get help.</p>
           <div
-            class="prose bg-slate-100 mt-3 p-2"
+            class="prose mt-3 p-2"
             v-if="$page.plugins.usage"
             v-html="$page.plugins.usage_rendered"
           ></div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,5 +13,6 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  // eslint-disable-next-line global-require
+  plugins: [require("@tailwindcss/typography")],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,15 @@
+const plugin = require("tailwindcss/plugin");
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/components/**/*.{js,vue,ts}",
+    "./src/layouts/**/*.vue",
+    "./src/pages/**/*.vue",
+    "./src/layouts/**/*.vue",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,3 @@
-const plugin = require("tailwindcss/plugin");
-
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
     "./src/components/**/*.{js,vue,ts}",
     "./src/layouts/**/*.vue",
     "./src/pages/**/*.vue",
-    "./src/layouts/**/*.vue",
+    "./src/templates/**/*.vue",
   ],
   theme: {
     extend: {},

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,10 @@ module.exports = {
     "./src/pages/**/*.vue",
     "./src/templates/**/*.vue",
   ],
+  // Safelist is a brute force method to get tailwind to work with `gridsome develop`
+  // https://tailwindcss.com/docs/content-configuration#safelisting-classes
+  // Only enable during local dev
+  // safelist: [{ pattern: /.*/ }],
   theme: {
     extend: {},
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,6 +1140,16 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tailwindcss/typography@^0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.7.tgz#e0b95bea787ee14c5a34a74fc824e6fe86ea8855"
+  integrity sha512-JTTSTrgZfp6Ki4svhPA4mkd9nmQ/j9EfE7SbHJ1cLtthKkpW2OxsFXzSmxbhYbEkfNIyAyhle5p4SYyKRbz/jg==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
+
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -6037,6 +6047,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -6046,6 +6061,11 @@ lodash.deburr@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
   integrity sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
@@ -7531,6 +7551,14 @@ postcss-reduce-transforms@^4.0.2:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
+postcss-selector-parser@6.0.10, postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-selector-parser@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz#b310f5c4c0fdaf76f94902bbaa30db6aa84f5270"
@@ -7548,14 +7576,6 @@ postcss-selector-parser@^5.0.0:
     cssesc "^2.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
-
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
-  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
-  dependencies:
-    cssesc "^3.0.0"
-    util-deprecate "^1.0.2"
 
 postcss-svgo@^4.0.3:
   version "4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,10 +1522,29 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-node@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
+  integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
+  dependencies:
+    acorn "^7.0.0"
+    acorn-walk "^7.0.0"
+    xtend "^4.0.2"
+
+acorn-walk@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
+  integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+
+acorn@^7.0.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.8.0:
   version "8.8.0"
@@ -1662,6 +1681,11 @@ archive-type@^4.0.0:
   integrity sha512-zV4Ky0v1F8dBrdYElwTvQhweQ0P7Kwc1aluqJsYtOBP01jXcWCyW2IEfI1YiqsG+Iy7ZR+o5LF1N+PGECBxHWA==
   dependencies:
     file-type "^4.2.0"
+
+arg@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2346,6 +2370,11 @@ camel-case@3.0.x:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
+camelcase-css@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
+  integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -2440,7 +2469,7 @@ chalk@^4.0.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -2581,7 +2610,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -3252,6 +3281,11 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -3300,6 +3334,20 @@ detect-newline@3.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detective@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-5.2.1.tgz#6af01eeda11015acb0e73f933242b70f24f91034"
+  integrity sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==
+  dependencies:
+    acorn-node "^1.8.2"
+    defined "^1.0.0"
+    minimist "^1.2.6"
+
+didyoumean@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
+  integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -3330,6 +3378,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+dlv@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -4063,6 +4116,17 @@ fast-glob@^3.0.3, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.2.11:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4509,7 +4573,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
+glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -4715,6 +4779,11 @@ graphql@^14.4.2:
   integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
   dependencies:
     iterall "^1.2.2"
+
+gridsome-plugin-tailwindcss@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/gridsome-plugin-tailwindcss/-/gridsome-plugin-tailwindcss-4.1.1.tgz#fd167f6f4ffec6c2400b5a3011200761b72f4ec4"
+  integrity sha512-PlCY1oSdfrQ/DpLN8xK0oz4KYOA1Be6x34BiemhpF1X1JZ9FjnpR4bmQtv1HCvRQZM/UbZPso836UNTqKh/yCw==
 
 gridsome@^0.7.0:
   version "0.7.23"
@@ -5891,6 +5960,11 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lilconfig@^2.0.5, lilconfig@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
+  integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -6635,6 +6709,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
+  integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
+
 object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
@@ -7199,6 +7278,22 @@ postcss-discard-overridden@^4.0.1:
   dependencies:
     postcss "^7.0.0"
 
+postcss-import@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-14.1.0.tgz#a7333ffe32f0b8795303ee9e40215dac922781f0"
+  integrity sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==
+  dependencies:
+    postcss-value-parser "^4.0.0"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
+postcss-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.0.tgz#31db79889531b80dc7bc9b0ad283e418dce0ac00"
+  integrity sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==
+  dependencies:
+    camelcase-css "^2.0.1"
+
 postcss-load-config@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.1.2.tgz#c5ea504f2c4aef33c7359a34de3573772ad7502a"
@@ -7206,6 +7301,14 @@ postcss-load-config@^2.0.0:
   dependencies:
     cosmiconfig "^5.0.0"
     import-cwd "^2.0.0"
+
+postcss-load-config@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.4.tgz#1ab2571faf84bb078877e1d07905eabe9ebda855"
+  integrity sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==
+  dependencies:
+    lilconfig "^2.0.5"
+    yaml "^1.10.2"
 
 postcss-loader@^3.0.0:
   version "3.0.0"
@@ -7310,6 +7413,13 @@ postcss-modules-values@^2.0.0:
   dependencies:
     icss-replace-symbols "^1.1.0"
     postcss "^7.0.6"
+
+postcss-nested@5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-5.0.6.tgz#466343f7fc8d3d46af3e7dba3fcd47d052a945bc"
+  integrity sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==
+  dependencies:
+    postcss-selector-parser "^6.0.6"
 
 postcss-normalize-charset@^4.0.1:
   version "4.0.1"
@@ -7439,7 +7549,7 @@ postcss-selector-parser@^5.0.0:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.9:
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
   version "6.0.10"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
   integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
@@ -7470,7 +7580,7 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -7703,6 +7813,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -7742,6 +7857,13 @@ rc@1.2.8, rc@^1.2.7, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  integrity sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==
+  dependencies:
+    pify "^2.3.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -7986,7 +8108,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
 
-resolve@^1.10.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.0:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -8802,6 +8924,34 @@ svgo@^1.0.0:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+tailwindcss@^3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.1.8.tgz#4f8520550d67a835d32f2f4021580f9fddb7b741"
+  integrity sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==
+  dependencies:
+    arg "^5.0.2"
+    chokidar "^3.5.3"
+    color-name "^1.1.4"
+    detective "^5.2.1"
+    didyoumean "^1.2.2"
+    dlv "^1.1.3"
+    fast-glob "^3.2.11"
+    glob-parent "^6.0.2"
+    is-glob "^4.0.3"
+    lilconfig "^2.0.6"
+    normalize-path "^3.0.0"
+    object-hash "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.4.14"
+    postcss-import "^14.1.0"
+    postcss-js "^4.0.0"
+    postcss-load-config "^3.1.4"
+    postcss-nested "5.0.6"
+    postcss-selector-parser "^6.0.10"
+    postcss-value-parser "^4.2.0"
+    quick-lru "^5.1.1"
+    resolve "^1.22.1"
 
 tapable@2.0.0-beta.5:
   version "2.0.0-beta.5"
@@ -9694,7 +9844,7 @@ xss@^1.0.6:
     commander "^2.20.3"
     cssfilter "0.0.10"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
@@ -9725,6 +9875,11 @@ yaml-loader@^0.5.0:
   integrity sha512-p9QIzcFSNm4mCw/m5NdyMfN4RE4aFZJWRRb01ERVNGCym8VNbKtw3OYZXnvUIkim6U/EjqE/2yIh9F/msShH9A==
   dependencies:
     js-yaml "^3.5.2"
+
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yauzl@^2.4.2:
   version "2.10.0"


### PR DESCRIPTION
This enables us to use tailwind utility classes in our components.

There is a downside however to adding tailwind to a project this far along. We might struggle to use tailwindcss' default (opinionated) mode: [Preflight](https://tailwindcss.com/docs/preflight)

To see what I mean, all you need to do is [browse the preview build](https://deploy-preview-786--meltano-hub-gridsome.netlify.app/) for this branch.

Preflight itself is pretty cool, and it would be a great base layer for us to build on if we managed to wrangle the current design to fit it. It plays really well with modern design systems, smooths over the rougher parts of the browser ecosystem, and would make it a lot easier to create a consistent look and feel across meltano's web front ends.

I see 2 approaches (or maybe two phases):

- [Disable Preflight](https://tailwindcss.com/docs/preflight#disabling-preflight), keeping our current setup intact while still letting us incrementally adopt utility classes where we need them. (#788 )
- Keep Prefilght and begin updating our existing styles and elements with utility classes (#787)

I've created two additional PR's that demonstrate each of the approaches so that anyone can check the Netlify previews. 