### PR TITLE
Replace existing styles/elements with idiomatic Tailwind approaches

### DIFF
--- a/src/components/PluginCapabilitiesSection.vue
+++ b/src/components/PluginCapabilitiesSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h2 id="capabilities">Capabilities</h2>
+    <p class="text-3xl" id="capabilities">Capabilities</p>
     <span v-if="capabilities">
       <span
         >The current capabilities for

--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="commands">
-    <h2 id="commands">Commands</h2>
+    <p class="text-3xl" id="commands">Commands</p>
     <span
       >The {{ name }} {{ plugin_type }} supports the following commands that can be used with
       <pre><code>meltano invoke</code></pre>

--- a/src/components/PluginHelpSection.vue
+++ b/src/components/PluginHelpSection.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="help-module">
-    <h2 id="contribute">Something missing?</h2>
+    <p class="text-3xl" id="contribute">Something missing?</p>
     <p>This page is generated from a YAML file that you can contribute changes to.</p>
     <a
       v-if="name"
       :href="`https://github.com/meltano/hub/blob/main/_data/meltano/${plugin_type}/${name}/${variant}.yml`"
       >Edit it on GitHub!</a
     >
-    <h2 id="looking-for-help">Looking for help?</h2>
+    <p class="text-2xl" id="looking-for-help">Looking for help?</p>
     <div>
       If you're having trouble getting the
       {{ name }} extractor to work, look for an

--- a/src/components/PluginPrereqSection.vue
+++ b/src/components/PluginPrereqSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h3 id="prereqs">Prerequisites</h3>
+    <p class="text-3xl" id="prereqs">Prerequisites</p>
     <p>
       If you haven't already, follow the initial steps of the
       <a href="https://docs.meltano.com/getting-started.html">Getting Started guide</a>:

--- a/src/components/PluginRequiresSection.vue
+++ b/src/components/PluginRequiresSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="requires">
-    <h3>Requires</h3>
+    <p class="text-3xl">Requires</p>
     <p>This {{ plugin_type }} requires the following plugins and variants to work:</p>
     <ul>
       <li v-for="(file, index) in requires.files" v-bind:key="index">

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h2 id="settings">Settings</h2>
+    <p class="text-3xl" id="settings">Settings</p>
     <span v-if="settings">
       <span v-if="preamble" v-html="preamble"></span>
       <p>
@@ -29,9 +29,9 @@
         <a href="#contributing">pull request to the YAML file</a>.
       </p>
       <span v-for="(setting, index) in settings" v-bind:key="index">
-        <h3 :id="setting.name + '-setting'">
+        <p class="text-2xl" :id="setting.name + '-setting'">
           <code>{{ setting.label }} ({{ setting.name }})</code>
-        </h3>
+        </p>
         <p>
           <span v-if="setting.description" v-html="setting.description_rendered"></span>
           <span v-else><a href="#contribute">[No description provided.]</a></span>

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="single-plugin-aside">
-    <h4>Install</h4>
+    <p class="text-lg">Install</p>
     <pre><code>meltano add {{plugin_type}} {{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code></pre>
-    <h4>Homepage</h4>
+    <p class="text-lg">Homepage</p>
     <div class="link-box">
       <img class="aside-icon" src="../assets/images/link-solid.svg" /><a :href="domain_url">{{
         domain_url
       }}</a>
     </div>
-    <h4>Maintenance Status</h4>
+    <p class="text-lg">Maintenance Status</p>
     <img
       v-if="maintenance_status === 'active'"
       alt="Maintenance Status"
@@ -34,7 +34,7 @@
       alt="Maintenance Status"
       src="https://img.shields.io/badge/Maintenance%20Status-Inactive%20or%20Stale-red"
     />
-    <h4>Repo</h4>
+    <p class="text-lg">Repo</p>
     <div class="link-box">
       <img class="aside-icon" src="../assets/images/git-alt-brands.svg" /><a :href="repo">{{
         repo
@@ -83,9 +83,9 @@
         />
       </li>
     </ul>
-    <h4>Maintainer</h4>
+    <p class="text-lg">Maintainer</p>
     <div v-if="metrics">
-      <h4>Meltano Stats</h4>
+      <p class="text-lg">Meltano Stats</p>
       <ul class="shields">
         <li v-if="metrics.ALL_EXECS">
           <img
@@ -101,7 +101,7 @@
         </li>
       </ul>
     </div>
-    <h4>Keywords</h4>
+    <p class="text-lg">Keywords</p>
     <p>{{ (keywords ?? []).join(", ") }}</p>
   </div>
 </template>

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -27,9 +27,9 @@
                   )}`)
                 "
               />
-              <h1>
+              <p class="text-3xl">
                 {{ plugin.node.label }}
-              </h1>
+              </p>
               <span>{{ plugin.node.description || "No description" }}</span>
             </div>
 

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="file-not-found">
-      <h1>Whoops. Nothing to see here!</h1>
+      <p class="text-3xl">Whoops. Nothing to see here!</p>
     </div>
   </Layout>
 </template>

--- a/src/pages/Extractors.vue
+++ b/src/pages/Extractors.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Extractors</h1>
+      <p class="text-3xl">Extractors</p>
       <p>
         Meltano lets you easily extract data out of arbitrary sources (databases, SaaS APIs, and
         file formats) using Singer taps, which take the role of your project’s extractor plugins. To
@@ -20,7 +20,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Files</h1>
+      <p class="text-3xl">Files</p>
       <p>
         Meltano file plugins allow you to easily add new file resources to your data project. For
         example, Meltano utilities and other plugins can define file plugins that provide
@@ -19,7 +19,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -1,11 +1,11 @@
 <template>
   <Layout>
     <div class="home-details">
-      <h1>Welcome to Meltano Hub</h1>
-      <h2>
+      <p class="text-3xl">Welcome to Meltano Hub</p>
+      <p class="text-2xl">
         Meltano Hub is a central place to find any Meltano plugin as well as Singer taps and
         targets. The Hub is lovingly curated by Meltano and the wider Singer community.
-      </h2>
+      </p>
     </div>
   </Layout>
 </template>
@@ -28,13 +28,13 @@ export default {
   padding: 20px;
   text-align: center;
 
-  h1 {
+  p {
     font-size: 3rem;
     line-height: 1.25;
     margin: 25px auto;
   }
 
-  h2 {
+  p {
     margin: 25px auto;
   }
 }
@@ -48,7 +48,7 @@ export default {
     padding: 50px 20%;
     text-align: center;
 
-    h1 {
+    p {
       font-size: 4.7rem;
     }
   }

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -1,8 +1,8 @@
 <template>
   <Layout>
     <div class="home-details">
-      <p class="text-3xl">Welcome to Meltano Hub</p>
-      <p class="text-2xl">
+      <p class="text-5xl tracking-wide mb-3">Welcome to Meltano Hub</p>
+      <p class="text-xl">
         Meltano Hub is a central place to find any Meltano plugin as well as Singer taps and
         targets. The Hub is lovingly curated by Meltano and the wider Singer community.
       </p>
@@ -27,16 +27,6 @@ export default {
   align-items: center;
   padding: 20px;
   text-align: center;
-
-  p {
-    font-size: 3rem;
-    line-height: 1.25;
-    margin: 25px auto;
-  }
-
-  p {
-    margin: 25px auto;
-  }
 }
 
 @media (min-width: 1000px) {
@@ -47,10 +37,6 @@ export default {
     align-items: center;
     padding: 50px 20%;
     text-align: center;
-
-    p {
-      font-size: 4.7rem;
-    }
   }
 }
 </style>

--- a/src/pages/Loaders.vue
+++ b/src/pages/Loaders.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Loaders</h1>
+      <p class="text-3xl">Loaders</p>
       <p>
         Meltano lets you easily load extracted data into arbitrary destinations (databases, SaaS
         APIs, and file formats) using Singer targets, which take the role of your project’s loader
@@ -20,7 +20,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Maintainers.vue
+++ b/src/pages/Maintainers.vue
@@ -1,16 +1,16 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Plugin Maintainers</h1>
+      <p class="text-3xl">Plugin Maintainers</p>
       <ul class="plugins-list">
         <li
           v-for="(edge, index) in $page.allMaintainers.edges"
           :key="index"
           class="page-single-plugin"
         >
-          <h2>
+          <p class="text-2xl">
             <a :href="`${edge.node.url}`">{{ edge.node.label }}</a>
-          </h2>
+          </p>
         </li>
         <Pager
           :info="$page.allMaintainers.pageInfo"

--- a/src/pages/Orchestrators.vue
+++ b/src/pages/Orchestrators.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Orchestrators</h1>
+      <p class="text-3xl">Orchestrators</p>
       <p>
         Meltano orchestrator plugins provide advanced scheduling and workflow execution
         capabilities.
@@ -18,7 +18,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Singer.vue
+++ b/src/pages/Singer.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Welcome to MeltanoHub for Singer</h1>
+      <p class="text-3xl">Welcome to MeltanoHub for Singer</p>
       <p>
         MeltanoHub for Singer is the leading destination for the Singer Community to discover taps,
         targets, and other valuable resources. Read the
@@ -21,7 +21,7 @@
         <li class="page-single-plugin">spec</li>
       </ul>
 
-      <h1>API Resources</h1>
+      <p class="text-3xl">API Resources</p>
       <p>
         MeltanoHub for Singer is built for the entire Singer community. We have several resources
         available at a versioned endpoint that can be used by other organizations to build a catalog

--- a/src/pages/Transformers.vue
+++ b/src/pages/Transformers.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Transformers</h1>
+      <p class="text-3xl">Transformers</p>
       <p>
         Meltano transformer plugins allow you to create new derived transformations from raw data
         sources.
@@ -18,7 +18,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/Utilities.vue
+++ b/src/pages/Utilities.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout>
     <div class="plugins-overview">
-      <h1>Utilities</h1>
+      <p class="text-3xl">Utilities</p>
       <p>
         Meltano utilities plugins allow virtually any open source data tool to be integrated with
         your data project.
@@ -18,7 +18,7 @@
                 )}`)
               "
             />
-            <h2>{{ edge.node.label }}</h2>
+            <p class="text-2xl">{{ edge.node.label }}</p>
             <p>{{ edge.node.pluginType }}</p>
           </g-link>
         </li>

--- a/src/pages/singer/API.vue
+++ b/src/pages/singer/API.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout>
-    <h1>API</h1>
+    <p class="text-3xl">API</p>
   </Layout>
 </template>
 

--- a/src/pages/singer/Docs.vue
+++ b/src/pages/singer/Docs.vue
@@ -1,20 +1,20 @@
 <template>
   <Layout>
     <div class="docs-layout">
-      <h2>Commitment to the Singer Community</h2>
+      <p class="text-2xl">Commitment to the Singer Community</p>
       <p>
         The Meltano team aims to make MeltanoHub a fantastic resource for members of the Singer
         Community. We’re fully embracing Singer and MeltanoHub for Singer is a large part of those
         efforts.
       </p>
 
-      <h2>Development</h2>
+      <p class="text-2xl">Development</p>
       <p>
         MeltanoHub is under active development by Meltano. Check out our issue tracker to understand
         progress on a specific feature.
       </p>
 
-      <h2>Standardized Connectors</h2>
+      <p class="text-2xl">Standardized Connectors</p>
       <p>
         All taps and targets are pulled from external sources, such as GitHub and GitLab, and are
         organized into a clean YAML format that has no references to external tools. Learn more
@@ -41,7 +41,7 @@
         GitHub. These are useful proxy metrics for the quality of a given connector.
       </p>
 
-      <h2>API</h2>
+      <p class="text-2xl">API</p>
       <ul>
         <li>API Directory</li>
       </ul>
@@ -66,7 +66,7 @@
         Our expectation is that other tools, including Meltano, will utilize the data available via
         the API to build their own library of Singer taps and targets.
       </p>
-      <h2>Tap and Target SDKs</h2>
+      <p class="text-2xl">Tap and Target SDKs</p>
       <p>
         We’ve also created an SDK for Taps and Targets that is the best way to build and maintain
         Singer Taps and Targets.
@@ -74,13 +74,13 @@
 
       <p>Read more about the launch of the SDK on the Meltano blog.</p>
 
-      <h2>Singer Spec</h2>
+      <p class="text-2xl">Singer Spec</p>
       <p>
         We’ve created a simplified version of the Singer Specification with the goal of making it
         easier for people new to the Singer ecosystem to understand the spec.
       </p>
 
-      <h2>Singer Connector Capabilities</h2>
+      <p class="text-2xl">Singer Connector Capabilities</p>
       <p>
         The Singer Specification does a great job defining how taps and targets should communicate
         with each other at a high level but there’s an additional layer of commonly used patterns
@@ -90,33 +90,33 @@
       </p>
 
       <h3>Tap Specific</h3>
-      <h4>Catalog</h4>
+      <p class="text-lg">Catalog</p>
       <p>
         The tap accepts a --catalog argument referencing a file that defines the structure of one or
         many data streams. For more details see the Catalog Files section in our Singer Spec
         interpretation.
       </p>
 
-      <h4>Properties</h4>
+      <p class="text-lg">Properties</p>
       <p>
         The tap accepts the legacy --properties argument referencing a file that defines the
         structure of one or many data streams. For more details see the Catalog Files section in our
         Singer Spec interpretation.
       </p>
 
-      <h4>Discover</h4>
+      <p class="text-lg">Discover</p>
       <p>
         The tap accepts a --discover argument that is used to generate a catalog files. For more
         details see the Discovery mode section section in our Singer Spec interpretation.
       </p>
 
-      <h4>State</h4>
+      <p class="text-lg">State</p>
       <p>
         The tap accepts a --state argument and uses the input in order to run incremental syncs. For
         more details see the State Files section section in our Singer Spec interpretation.
       </p>
 
-      <h4>Log Based</h4>
+      <p class="text-lg">Log Based</p>
       This is a database source specific capability which supports reading the transaction logs of a
       database in order to identify incrementally changed data. The two common replication
       techniques are key-based or log-based replication. Key-based uses a timestamp or incrementing
@@ -125,14 +125,14 @@
       Supporting this capability, where applicable, means that targets have the information it needs
       to delete records in the destination.
 
-      <h4>Test</h4>
+      <p class="text-lg">Test</p>
       This capability is still in development, but the goal is to make it easy for connector
       developers to test locally without having to make a connection to the source systems. This
       might be accomplished by implementing utilities that can generate and save test data or make
       saving and moving real HTTP requests for tests easier. Join the issue conversation here!
 
       <h3>Target Specific</h3>
-      <h4>Soft Delete</h4>
+      <p class="text-lg">Soft Delete</p>
       <p>
         Targets that support this capability implement logic that soft deletes records in the
         destination, usually by populating a deleted_at timestamp field. The two common techniques
@@ -141,7 +141,7 @@
         deletes, in which case the behavior is configurable in the target’s config settings.
       </p>
 
-      <h4>Hard Delete</h4>
+      <p class="text-lg">Hard Delete</p>
       <p>
         Similar to the Soft Deletes capability, targets that support the hard delete capability
         implement logic that removes records from the destination when they receive a notification
@@ -150,7 +150,7 @@
         configurable in the target’s config settings.
       </p>
 
-      <h4>Datatype Failsafe</h4>
+      <p class="text-lg">Datatype Failsafe</p>
       <p>
         This capability means that the target has a failsafe data type (e.g. string) to ensure safe
         handling of unparsable or unforseen types. It’s common to find targets in the Singer
@@ -159,7 +159,7 @@
         exceptions will not be raised for unsupported types.
       </p>
 
-      <h4>Record Flattening</h4>
+      <p class="text-lg">Record Flattening</p>
       <p>
         It’s common for taps to output nested json data which needs to be flattened by the target in
         order to be loaded into a columnar format destinations. For example, the following is a
@@ -186,7 +186,7 @@
       </p>
 
       <h3>Either Tap or Target</h3>
-      <h4>Activate Version</h4>
+      <p class="text-lg">Activate Version</p>
       <p>
         Managing hard deletes in the source system is difficult but the Singer community has
         developed a technique using a message type called ACTIVATE_VERSION. This isnt a standardized
@@ -226,7 +226,7 @@
         destination.
       </p>
 
-      <h4>Stream Maps</h4>
+      <p class="text-lg">Stream Maps</p>
       <p>
         The ability to accept a mapping configuration can be used to do minor transformations to the
         data between the tap and target. The capability can be currently be implemented on the tap
@@ -249,7 +249,7 @@
         details and use cases.
       </p>
 
-      <h4>About</h4>
+      <p class="text-lg">About</p>
       <p>
         The tap or target accepts an --about argument which outputs details about the connector
         including its capabilities and settings which can be used in programmatically generate UI
@@ -282,7 +282,7 @@
 }
 </code></pre>
 
-      <h4>Batch</h4>
+      <p class="text-lg">Batch</p>
       <p>
         This capability is currently in development by the Singer Working Group to align on a
         consistent approach for supporting batch sync messages in the Spec or as part of its
@@ -311,7 +311,7 @@
       <p>We’re using Singer taps and targets to extract and load into a Snowflake warehouse.</p>
       <p>We’re using dbt to manage transformations with Athena to aid in curating the data.</p>
 
-      <h2>Meltano Usage Metrics</h2>
+      <p class="text-2xl">Meltano Usage Metrics</p>
       <p>
         Meltano collects anonymous usage stats using Google Analytics. We use this data to learn
         about the size of our user base and overal feature usage. This helps us determine the

--- a/src/pages/singer/Taps.vue
+++ b/src/pages/singer/Taps.vue
@@ -1,5 +1,5 @@
 <template>
-  <Layout><h1>Taps</h1></Layout>
+  <Layout><p class="text-3xl">Taps</p></Layout>
 </template>
 
 <script>

--- a/src/pages/singer/Targets.vue
+++ b/src/pages/singer/Targets.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout>
-    <h1>targets</h1>
+    <p class="text-3xl">targets</p>
   </Layout>
 </template>
 

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -17,12 +17,12 @@
                 />
               </td>
               <td>
-                <h1>
+                <p class="text-3xl">
                   {{ $page.plugins.label }}
-                </h1>
-                <h2>
+                </p>
+                <p class="text-2xl">
                   <code>{{ $page.plugins.name }} from {{ $page.plugins.variant }}</code>
-                </h2>
+                </p>
                 <p>
                   <b>{{ $page.plugins.description }}</b>
                 </p>
@@ -40,7 +40,7 @@
             <a :href="$page.plugins.domain_url">{{ $page.plugins.label }}</a> that can then be sent
             to a destination using a <g-link to="/loaders">loader</g-link>.
           </p>
-          <h3>Other Available Variants</h3>
+          <p class="text-2xl">Other Available Variants</p>
           <ul>
             <li v-for="(variant, index) in $page.variants.edges" v-bind:key="index">
               <g-link :to="variant.node.path" v-if="variant.node.path !== $page.plugins.path">{{
@@ -50,9 +50,9 @@
               <span v-if="variant.node.isDefault"> (default)</span>
             </li>
           </ul>
-          <h2 id="getting-started">Getting Started</h2>
+          <p class="text-3xl" id="getting-started">Getting Started</p>
           <PluginPrereqSection :plugin="$page.plugins" :plugin_type="$page.plugins.pluginType" />
-          <h3 id="installation">Installation and configuration</h3>
+          <p class="text-2xl" id="installation">Installation and configuration</p>
           <ol>
             <li>
               Add the {{ $page.plugins.name }} {{ $page.plugins.pluginType }} to your project using
@@ -61,7 +61,7 @@
             </li>
             <pre><code>meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
           </ol>
-          <h3>Next steps</h3>
+          <p class="text-2xl">Next steps</p>
           <p>
             Follow the remaining steps of the
             <a href="https://docs.meltano.com/getting-started.html">Getting Started guide</a>:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
     "./src/components/**/*.{js,vue,ts}",
     "./src/layouts/**/*.vue",
     "./src/pages/**/*.vue",
-    "./src/layouts/**/*.vue",
+    "./src/templates/**/*.vue",
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
If we want to get to the point where we can use Prefight (I argue that we should, eventually) it would start to look like this.

- Addressing each of the items in the Preflight doc (https://tailwindcss.com/docs/preflight) such as no longer using `<h1234>`, explicitly styling lists, specifying margins, etc.
- Yanking out the parts of `main.css` that conflict with the above, and I ran into quite a few of them while exploring this
- Using https://tailwindcss.com/docs/typography-plugin for styling rendered markdown sections