### PR TITLE
Disable Tailwind Preflight

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  corePlugins: {
+    preflight: false,
+  },
   content: [
     "./src/components/**/*.{js,vue,ts}",
     "./src/layouts/**/*.vue",


### PR DESCRIPTION
This demonstrates what the site would look like if we add tailwind but can't invest the time into using their base layer, [Preflight](https://tailwindcss.com/docs/preflight#disabling-preflight).