### PR TITLE
add meltanolabs sftp variant and make default

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -266,7 +266,7 @@ extractors:
   tap-sentry: valulucchesi
   tap-servicem8: fostersdata
   tap-sevenrooms: uptilab2
-  tap-sftp: singer-io
+  tap-sftp: meltanolabs
   tap-shiphero: singer-io
   tap-shipstation: mashey
   tap-shopify: singer-io

--- a/_data/meltano/extractors/tap-sftp/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-sftp/meltanolabs.yml
@@ -1,0 +1,61 @@
+description: File Transfer Protocl
+label: SFTP
+name: tap-sftp
+logo_url: /assets/logos/extractors/sftp.png
+namespace: tap_sftp
+variant: meltanolabs
+pip_url: git+https://github.com/MeltanoLabs/tap-sftp.git
+repo: https://github.com/MeltanoLabs/tap-sftp
+settings_group_validation:
+- - username
+  - port
+  - host
+  - tables
+  - start_date
+settings:
+- name: host
+  label: Host
+  description: The SFTP server hostname.
+- name: port
+  kind: integer
+  label: Port
+  description: The SFTP server port.
+- name: username
+  label: Username
+  description: The username for connecting the the SFTP server.
+- name: password
+  kind: password
+  label: Password
+  description: The pass for connecting the the SFTP server.
+- name: private_key_file
+  label: Private Key File
+  description: A path to the private key file for connecting the the SFTP server.
+- name: tables
+  kind: array
+  label: Tables
+  description: An array that consists of one or more objects that describe how to
+    find files and emit records. Required in each table object - `table_name`, `search_pattern`,`search_prefix`,
+    `key_properties`, `delimiter`.
+- name: start_date
+  kind: date_iso8601
+  label: Start Date
+  description: Determines how much historical data will be extracted. Please be aware
+    that the larger the time period and amount of data, the longer the initial extraction
+    can be expected to take.
+- name: request_timeout
+  kind: integer
+  label: Request Timeout
+  description: The SFTP connection timeout in seconds. Defaults to 300.
+- name: decryption_configs
+  kind: object
+  label: Decryption Configs
+  description: A configuration for using AWS SSM Parameter Store as the source for the private key file.
+    The tap will download the private key from SSM and use it to authenticate. The keys required are - `SSM_key_name`, `gnupghome`, `passphrase`.
+capabilities:
+- catalog
+- discover
+- state
+domain_url: https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol
+maintenance_status: active
+keywords:
+- file


### PR DESCRIPTION
Singer-io looks like it actually is somewhat active but still doesnt have any documentation in their readme and the bonobos variant hasnt been touched in a while.