### PR TITLE
Add singer redirects to new endpoints

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,10 +5,10 @@
 
 [[redirects]]
   from = "/taps/*"
-  to = "/extractors/:splat"
+  to = "/extractors/tap-:splat"
   force = true
 
 [[redirects]]
   from = "/targets/*"
-  to = "/loaders/:splat"
+  to = "/loaders/target-:splat"
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,13 @@
   base = "."
   command = "./utility_scripts/build/build_with_metrics.sh"
   publish = "dist"
+
+[[redirects]]
+  from = "/taps/*"
+  to = "/extractors/:splat"
+  force = true
+
+[[redirects]]
+  from = "/targets/*"
+  to = "/loaders/:splat"
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,13 @@
   from = "/targets/*"
   to = "/loaders/target-:splat"
   force = true
+
+[[redirects]]
+  from = "/singer/taps"
+  to = "/extractors"
+  force = true
+
+[[redirects]]
+  from = "/singer/targets"
+  to = "/loaders"
+  force = true


### PR DESCRIPTION
Closes #795 

This uses netlify redirect rules to replace the `/taps/*` and `/targets/*` endpoints with their meltano plugin equivalents