### PR TITLE
Add variants to safelist workaround

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,7 @@ module.exports = {
   // Safelist is a brute force method to get tailwind to work with `gridsome develop`
   // https://tailwindcss.com/docs/content-configuration#safelisting-classes
   // Only enable during local dev
-  // safelist: [{ pattern: /.*/ }],
+  // safelist: [{ pattern: /.*/, variants: ["lg", "md", "sm", "hover"] }],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
The workaround for hot-reloading tailwind classes hasn't been respecting variants like `md:`, `sm:`, `hover:`.

Adding this option will generate those when we are in safelist mode