### PR TITLE
Code block formatting, link clean up, text clean up, maintainer fix

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -106,6 +106,7 @@ function buildData(dataPath, collections) {
 
       // Include additional fields
       readPlugin.metrics = pluginMetricsData[readPlugin.repo];
+      readPlugin.maintainer = readMaintainers[readPlugin.variant];
 
       collections.forEach((collection) => {
         collection.addNode(readPlugin);

--- a/src/components/PluginHelpSection.vue
+++ b/src/components/PluginHelpSection.vue
@@ -10,7 +10,7 @@
     <p class="text-3xl py-4" id="looking-for-help">Looking for help?</p>
     <div>
       If you're having trouble getting the
-      {{ name }} extractor to work, look for an
+      {{ name }} {{ plugin_type }} to work, look for an
       <a :href="`${repo}/issues`">existing issue in its repository</a>, file a
       <a :href="`${repo}/issues/new`">new issue</a>, or
       <a href="https://meltano.com/slack">join the Meltano Slack community</a>

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -25,8 +25,13 @@
       </p>
       <p>
         Please consider adding any settings you have defined locally to this definition on
-        MeltanoHub by making a
-        <a href="#contributing">pull request to the YAML file</a>.
+        MeltanoHub by making a pull request to the
+        <a
+          :href="`https://github.com/meltano/hub/blob/main/_data/meltano/${plugin_type_plural}/${name}/${variant}.yml`"
+        >
+          YAML file</a
+        >
+        that defines the settings for this plugin.
       </p>
       <span v-for="(setting, index) in settings" v-bind:key="index">
         <p class="text-xl mt-3" :id="setting.name + '-setting'">
@@ -37,7 +42,7 @@
           v-if="setting.description"
           v-html="setting.description_rendered"
         ></div>
-        <span v-else><a href="#contribute">[No description provided.]</a></span>
+        <span v-else>[No description provided.]</span>
       </span>
     </span>
     <span v-else
@@ -50,7 +55,7 @@
 <script>
 export default {
   name: "PluginSettingsSection",
-  props: ["settings", "preamble", "name"],
+  props: ["settings", "plugin_type_plural", "preamble", "name", "variant"],
 };
 </script>
 

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -113,10 +113,11 @@
       <p class="text-lg">Maintainer</p>
       <ul class="list-disc list-inside shields">
         <li>
-          <img
-            :alt="variant"
-            :src="`https://img.shields.io/static/v1?label=&message=${variant}&color=grey`"
-          />
+          <a :href="maintainer.url"
+            ><img
+              :alt="variant"
+              :src="`https://img.shields.io/static/v1?label=&message=${maintainer.label}&color=grey`"
+          /></a>
         </li>
       </ul>
     </div>
@@ -177,6 +178,7 @@ export default {
     "variant",
     "plugin_type",
     "metrics",
+    "maintainer",
   ],
   computed: {
     parsedRepo() {

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -113,11 +113,16 @@
       <p class="text-lg">Maintainer</p>
       <ul class="list-disc list-inside shields">
         <li>
-          <a :href="maintainer.url"
+          <a v-if="maintainer" :href="maintainer.url"
             ><img
-              :alt="variant"
+              :alt="maintainer.label"
               :src="`https://img.shields.io/static/v1?label=&message=${maintainer.label}&color=grey`"
-          /></a>
+            /> </a
+          ><img
+            v-else
+            :alt="variant"
+            :src="`https://img.shields.io/static/v1?label=&message=${variant}&color=grey`"
+          />
         </li>
       </ul>
     </div>

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -187,6 +187,7 @@
             :is_default="$page.plugins.isDefault"
             :metrics="$page.plugins.metrics"
             :plugin_type="$page.plugins.pluginType"
+            :maintainer="$page.plugins.maintainer"
           />
         </div>
       </div>
@@ -255,6 +256,11 @@ query Plugins($path: String!, $name: String!) {
     metrics {
       ALL_PROJECTS
       ALL_EXECS
+    }
+    maintainer {
+      name
+      label
+      url
     }
   }
   variants: allPlugins(filter: { name: { eq: $name } }) {

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -75,7 +75,9 @@
                   <pre class="inline-code-block"><code>meltano add</code></pre>
                   :
                 </li>
-                <pre><code>meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
+                <pre
+                  class="prose language-bash rounded-md"
+                ><code >meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
               </ol>
               <p class="text-xl py-3">Next steps</p>
               <div

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -165,6 +165,8 @@
               <PluginSettingsSection
                 :settings="$page.plugins.settings"
                 :name="$page.plugins.name"
+                :plugin_type_plural="$page.plugins.pluginTypePlural"
+                :variant="$page.plugins.variant"
               />
               <PluginHelpSection
                 :name="$page.plugins.name"


### PR DESCRIPTION
Closes #850 

Addresses the following review comments from @tayloramurphy:

- The installation and config instructions on most plugins don’t have any code blocks https://deploy-preview-663--meltano-hub.netlify.app/utilities/great-expectations they seem to be formatted for code, but it doesn’t have the background I would expect.
- On GE - I’m seeing a couple of wrong URLs. “pull request to the YAML file” goes to a non-existent section and same for the setting “No description provided”
- Under looking for help “If you’re having trouble getting the great_expectations extractor to work” - looks like we need to update to the plugin type (s/extractor/utility)
- Under “Maintainer” in the sidebar - I’d like to see the clean label and not the raw key. So “Meltano Community” instead of meltanolabs