### PR TITLE
For settings blocks, add the environment variable information and default values

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -104,6 +104,22 @@ function buildData(dataPath, collections) {
       readPlugin.pluginTypePlural = path.basename(dataPath);
       readPlugin.pluginType = pluginTypeSingulars[readPlugin.pluginTypePlural];
 
+      // Need to stringify default setting values due to limited gql type system
+      readPlugin.settings =
+        readPlugin.settings &&
+        readPlugin.settings.map((setting) => ({
+          ...setting,
+          value: (function parseValue(s) {
+            if (s.value === undefined) {
+              return undefined;
+            }
+            if (typeof s.value === "string") {
+              return s.value;
+            }
+            return JSON.stringify(s.value);
+          })(setting),
+        }));
+
       // Include additional fields
       readPlugin.metrics = pluginMetricsData[readPlugin.repo];
       readPlugin.maintainer = readMaintainers[readPlugin.variant];

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -33,12 +33,25 @@
         >
         that defines the settings for this plugin.
       </p>
-      <span v-for="(setting, index) in settings" v-bind:key="index">
-        <p class="text-xl mt-3" :id="setting.name + '-setting'">
+      <span class="mt-6" v-for="(setting, index) in settings" v-bind:key="index">
+        <p class="mt-3 text-xl" :id="setting.name + '-setting'">
           <code>{{ setting.label }} ({{ setting.name }})</code>
         </p>
+        <ul class="list-inside list-disc pl-4 text-sm">
+          <li>
+            Environment variable:
+            <code>{{
+              `${name.replaceAll("-", "_").toUpperCase()}_${setting.name
+                .replaceAll(".", "_")
+                .toUpperCase()}`
+            }}</code>
+          </li>
+          <li v-if="setting.value">
+            Default Value: <code class="overflow-x-scroll">{{ setting.value }}</code>
+          </li>
+        </ul>
         <div
-          class="prose bg-slate-100 p-2"
+          class="prose mt-3 bg-slate-100 p-2"
           v-if="setting.description"
           v-html="setting.description_rendered"
         ></div>

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -47,7 +47,7 @@
             }}</code>
           </li>
           <li v-if="setting.value">
-            Default Value: <code class="overflow-x-scroll">{{ setting.value }}</code>
+            Default Value: <code>{{ setting.value }}</code>
           </li>
         </ul>
         <div

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -248,6 +248,7 @@ query Plugins($path: String!, $name: String!) {
       description_rendered
       kind
       placeholder
+      value
     }
     prereq
     prereq_rendered


### PR DESCRIPTION
Adding more information to the settings section

<img width="907" alt="Screen Shot 2022-09-28 at 7 33 06 PM" src="https://user-images.githubusercontent.com/6589528/192912245-8c684c75-dadd-4be6-ba0f-88666f249775.png">

<img width="907" alt="Screen Shot 2022-09-28 at 7 36 41 PM" src="https://user-images.githubusercontent.com/6589528/192912593-7109ece1-f9a1-46d4-8b7a-de74cddc511f.png">


For the default values, because they can be anything (string, int, array, object) in the yaml, the graphql based build system had a hard time handling them in a consistent manner. In order for this to work, I've just stringified all default values for display purposes.