### PR TITLE
fix: Don't include transforms in search results

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -122,7 +122,9 @@ export default {
 
 <static-query lang="graphql">
 query {
-  allPlugins(filter: { isDefault: { eq: true }, hidden: { ne: true } }) {
+  allPlugins(
+    filter: { isDefault: { eq: true }, hidden: { ne: true }, pluginType: { ne: "transform" } }
+  ) {
     edges {
       node {
         id


### PR DESCRIPTION
Turns out that any tap which had an associated transform was trying to display the transform plugin within search results, which meant it was doing a `require(`!!assets-loader?width=75!@logos/transforms/${plugin.node.name}.png)` and since we don't have logos for transforms, that require was failing and preventing any search results for the tap being displayed.

@aaronsteers -- should we be including transforms within search results in the hub? If so, I'll update this to add logos for each.

Closes #860 