### PR TITLE
Add default codeowners to repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rwfeather @cjohnhanson


### PR DESCRIPTION
Discussion with @aaronsteers, we'll have myself and @cjohnhanson as codeowners for the repository.

Do we want to set it up differently for PRs that touch `_data`?