### PR TITLE
Improve content width on mobile screens

### DIFF
--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="single-plugin-aside bg-gray-100 space-y-3 pl-4 order-first lg:pr-4 lg:order-last lg:border-l-2 border-black"
+    class="single-plugin-aside bg-gray-100 space-y-3 pl-4 pb-4 order-first lg:pr-4 lg:order-last lg:border-l-2 border-black"
   >
     <div>
       <p class="text-lg py-2">Install</p>

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout>
-    <div class="single-plugin-overview mx-36">
+    <div class="single-plugin-overview md:mx-36 sm:mx-0">
       <div class="single-plugin-detail">
         <div class="single-plugin-top-bar">
           <table>
@@ -30,8 +30,8 @@
             </tr>
           </table>
         </div>
-        <div class="flex flex-col lg:flex-row">
-          <div class="p-5 overflow-x-scroll">
+        <div class="flex flex-col lg:flex-row w-screen sm:w-auto">
+          <div class="p-5">
             <p>
               The {{ $page.plugins.name }}
               <a


### PR DESCRIPTION
Layout was looking really bad on my phone. Now we completely 0 the margins and go full width on `sm` screen sizes.

Before:
![IMG_1625](https://user-images.githubusercontent.com/6589528/193664051-f6553f02-edf1-4714-8030-e11949c02a92.jpg)

After:
![IMG_1626](https://user-images.githubusercontent.com/6589528/193664042-7ab69714-fb66-4f28-9330-7c56155bea35.jpg)

And the code blocks are still successfully overflowing into a horizontal scrollbar rather than off the page
