### PR TITLE
add null check for pip url

### DIFF
--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -223,7 +223,7 @@ export default {
       //   - multiple packages are listed space-delimited
       //   - packages have version specifiers (==, ~=)
       //   - packages specify optional dependencies in []
-      return !(
+      return this.pip_url && !(
         this.pip_url.includes("git+") ||
         this.pip_url.includes("//") ||
         this.pip_url.includes("=") ||

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -223,12 +223,15 @@ export default {
       //   - multiple packages are listed space-delimited
       //   - packages have version specifiers (==, ~=)
       //   - packages specify optional dependencies in []
-      return this.pip_url && !(
-        this.pip_url.includes("git+") ||
-        this.pip_url.includes("//") ||
-        this.pip_url.includes("=") ||
-        this.pip_url.includes(" ") ||
-        this.pip_url.includes("[")
+      return (
+        this.pip_url &&
+        !(
+          this.pip_url.includes("git+") ||
+          this.pip_url.includes("//") ||
+          this.pip_url.includes("=") ||
+          this.pip_url.includes(" ") ||
+          this.pip_url.includes("[")
+        )
       );
     },
   },


### PR DESCRIPTION
Metabase https://hub.meltano.com/utilities/metabase doesnt have a pip_url and we removed the requirement in the JSON schemas in https://github.com/meltano/hub/pull/865. The pypi badges were trying to render for null pip_urls and rendering 404s. This fixes that by adding a null check.

<img width="294" alt="Screen Shot 2022-10-06 at 1 34 55 PM" src="https://user-images.githubusercontent.com/27376735/194380805-28e5678b-f890-414a-982e-4dab24f3beb0.png">
