### PR TITLE
feat: Make logos link to homepages

### DIFF
--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -8,7 +8,7 @@
               <td style="padding: 25px">
                 <a
                   v-if="$page.plugins.domain_url"
-                  href="$page.plugins.domain_url"
+                  :href="$page.plugins.domain_url"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -6,7 +6,7 @@
           <table>
             <tr>
               <td style="padding: 25px">
-                <a v-if="domain_url" href="domain_url" target="_blank" rel="noopener noreferrer">
+                <a v-if="$page.plugins.domain_url" href="$page.plugins.domain_url" target="_blank" rel="noopener noreferrer">
                   <g-image
                     v-if="$page.plugins.logo_url"
                     :src="

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -6,28 +6,28 @@
           <table>
             <tr>
               <td style="padding: 25px">
-              <a v-if="domain_url" href="domain_url" target="_blank" rel="noopener noreferrer">
-                <g-image
-                  v-if="$page.plugins.logo_url"
-                  :src="
-                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.plugins.logo_url.replace(
-                      '/assets/logos/',
-                      ''
-                    )}`)
-                  "
-                />
-              </a>
-              <div v-else>
-                <g-image
-                  v-if="$page.plugins.logo_url"
-                  :src="
-                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.plugins.logo_url.replace(
-                      '/assets/logos/',
-                      ''
-                    )}`)
-                  "
-                />
-              </div>
+                <a v-if="domain_url" href="domain_url" target="_blank" rel="noopener noreferrer">
+                  <g-image
+                    v-if="$page.plugins.logo_url"
+                    :src="
+                      require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.plugins.logo_url.replace(
+                        '/assets/logos/',
+                        ''
+                      )}`)
+                    "
+                  />
+                </a>
+                <div v-else>
+                  <g-image
+                    v-if="$page.plugins.logo_url"
+                    :src="
+                      require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.plugins.logo_url.replace(
+                        '/assets/logos/',
+                        ''
+                      )}`)
+                    "
+                  />
+                </div>
               </td>
               <td>
                 <p class="text-3xl py-8">

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -6,7 +6,12 @@
           <table>
             <tr>
               <td style="padding: 25px">
-                <a v-if="$page.plugins.domain_url" href="$page.plugins.domain_url" target="_blank" rel="noopener noreferrer">
+                <a
+                  v-if="$page.plugins.domain_url"
+                  href="$page.plugins.domain_url"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <g-image
                     v-if="$page.plugins.logo_url"
                     :src="

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -6,6 +6,7 @@
           <table>
             <tr>
               <td style="padding: 25px">
+              <a v-if="domain_url" href="domain_url" target="_blank" rel="noopener noreferrer">
                 <g-image
                   v-if="$page.plugins.logo_url"
                   :src="
@@ -15,6 +16,18 @@
                     )}`)
                   "
                 />
+              </a>
+              <div v-else>
+                <g-image
+                  v-if="$page.plugins.logo_url"
+                  :src="
+                    require(`!!assets-loader?width=250&height=200&fit=inside!@logos/${$page.plugins.logo_url.replace(
+                      '/assets/logos/',
+                      ''
+                    )}`)
+                  "
+                />
+              </div>
               </td>
               <td>
                 <p class="text-3xl py-8">


### PR DESCRIPTION
Example of a plugin with a homepage: https://deploy-preview-908--meltano-hub.netlify.app/extractors/tap-mysql
Example of a plugin without a homepage: https://deploy-preview-908--meltano-hub.netlify.app/transformers/dbt-snowflake/

Closes #903