### PR TITLE
feat: Add test dispatcher workflow

### DIFF
--- a/.github/workflows/slash_commands.yml
+++ b/.github/workflows/slash_commands.yml
@@ -31,6 +31,7 @@ jobs:
             repository=${{ github.repository }}
             comment-id=${{ github.event.comment.id }}
             issue-number=${{ github.event.issue.number }}
+            from-slash-command=true
 
       - name: Edit comment with error message
         if: steps.command-dispatch.outputs.error-message

--- a/.github/workflows/test-plugin-command.yml
+++ b/.github/workflows/test-plugin-command.yml
@@ -9,15 +9,23 @@ on:
         required: true
       comment-id:
         description: The comment ID of the originating slash command
-        required: true
+        required: false
       issue-number:
         description: The issue number containing the slash command comment
         required: true
+      from-slash-command:
+        description: Whether this workflow run was invoked by a slash command
+        required: true
+        default: 'false'
       name:
         description: The name of the plugin's executable
         required: true
       pip-url:
         description: The pip_url for the plugin
+        required: false
+        default: ''
+      prepend-text:
+        description: Text to be prepended to the command output
         required: false
         default: ''
 
@@ -35,10 +43,11 @@ jobs:
     steps:
 
     - name: Handle missing pip_url
-      if: github.event.inputs.pip-url == ''
+      if: github.event.inputs.from-slash-command == 'true'
       run: echo 'PIP_URL=${{ github.event.inputs.name }}' >> "$GITHUB_ENV"
 
     - name: Add 👀 reaction
+      if: github.event.inputs.from-slash-command == 'true'
       uses: peter-evans/create-or-update-comment@v2
       with:
         token: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}
@@ -46,11 +55,21 @@ jobs:
         comment-id: ${{ github.event.inputs.comment-id }}
         reaction-type: eyes
 
+    - name: Set initial edit mode (to conditionally clear previous comment)
+      id: initial-edit-mode
+      run: |
+        should_replace=${{ github.event.inputs.from-slash-command == 'false' && github.event.inputs.comment-id != '' }}
+        echo "edit-mode=$([ ${should_replace} == 'true' ] && echo 'replace' || echo 'append')" >> $GITHUB_OUTPUT
+
     - name: Append 'starting' notification to comment
+      id: create-or-update-comment
       uses: peter-evans/create-or-update-comment@v2
       with:
+        edit-mode: ${{ steps.initial-edit-mode.outputs.edit-mode }}
         comment-id: ${{ github.event.inputs.comment-id }}
+        issue-number: ${{ github.event.inputs.issue-number }}
         body: |
+          ${{ github.event.inputs.prepend-text }}
           > [Starting test job...](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
           > ...
 
@@ -184,13 +203,14 @@ jobs:
       uses: peter-evans/create-or-update-comment@v2
       if: always()
       with:
-        comment-id: ${{ github.event.inputs.comment-id }}
+        comment-id: ${{ steps.create-or-update-comment.outputs.comment-id }}
         body: |
           > Job completed.
 
           ${{ env.JOB_OUTPUT }}
 
     - name: Add reaction (success)
+      if: github.event.inputs.from-slash-command == 'true'
       uses: peter-evans/create-or-update-comment@v2
       with:
         token: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}
@@ -200,7 +220,7 @@ jobs:
 
     - name: Add reaction (failure)
       uses: peter-evans/create-or-update-comment@v2
-      if: failure()
+      if: failure() && (github.event.inputs.from-slash-command == 'true')
       with:
         token: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}
         repository: ${{ github.event.inputs.repository }}

--- a/.github/workflows/test_dispatcher.yml
+++ b/.github/workflows/test_dispatcher.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
 
       - name: Install yq
         env:

--- a/.github/workflows/test_dispatcher.yml
+++ b/.github/workflows/test_dispatcher.yml
@@ -1,0 +1,81 @@
+
+name: Plugin 'Test' Command Dispatcher
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - "_data/meltano/*/*/*.yml"
+
+jobs:
+  get_changed_files:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed_files
+        uses: tj-actions/changed-files@v32
+        with:
+          sha: ${{ github.event.pull_request.head.sha }}
+          json: "true"
+
+      - name: Filter changed files
+        id: filter_files
+        run: echo "filtered_files=$(echo ${{ steps.changed_files.outputs.all_changed_files }} | jq -c 'map(select(startswith("_data/meltano/") and endswith(".yml")))' | sed 's/"/\\"/g')" >> "$GITHUB_OUTPUT"
+
+      - id: set-matrix
+        run: echo "matrix={\"changed_file\":${{ steps.filter_files.outputs.filtered_files }}}" >> "$GITHUB_OUTPUT"
+
+  dispatch_tests:
+    runs-on: ubuntu-latest
+    needs:
+      - get_changed_files
+    strategy:
+      matrix: ${{ fromJson(needs.get_changed_files.outputs.matrix) }}
+      max-parallel: 4
+      fail-fast: false
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Install yq
+        env:
+          VERSION: v4.28.2
+          BINARY: yq_linux_amd64
+        run: >
+          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.gz -O - |
+          tar xz && mv ${BINARY} yq && chmod u+x yq
+
+      - name: Get the name and pip url
+        run: |
+          name="$(basename "$(dirname "${{ matrix.changed_file }}")")"
+          pip_url="$(./yq '.pip_url' "${{ matrix.changed_file }}")"
+          variant="$(./yq '.variant' "${{ matrix.changed_file }}")"
+          echo "name=${name}" >> $GITHUB_ENV
+          echo "pip_url=${pip_url}" >> $GITHUB_ENV
+          echo "prelude=Testing plugin \`${name}\` (\`${variant}\` variant):" >> $GITHUB_ENV
+
+      - name: Find the MeltyBot test-command comment if it exists
+        id: find_comment
+        uses: peter-evans/find-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: ${{ env.prelude }}
+
+      - uses: octokit/request-action@v2.x
+        with:
+          route: "POST /repos/${{ github.repository }}/actions/workflows/test-plugin-command.yml/dispatches"
+          ref: 'main'
+          inputs: "{\"repository\":\"${{ github.repository }}\",\"comment-id\":\"${{ steps.find_comment.outputs.comment-id }}\",\"issue-number\":\"${{ github.event.pull_request.number }}\",\"name\":\"${{ env.name }}\",\"pip-url\":\"${{ env.pip_url }}\",\"prepend-text\":\"${{ env.prelude }}\"}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}


### PR DESCRIPTION
Example usage: https://github.com/WillDaSilva/meltano-hub/pull/1/

It was tested on a fork because I had to use `pull_request_target`, which runs in the context of the main branch, and so won't have an effect until this PR is merged into `main`.

Note that if it had previously commented about a plugin (as identified by its name and variant).

The linked example shows it printing the pip url, but it no longer does this. The variant is printed instead.

Closes #917