### PR TITLE
fix: update installation instructions for non-python tap-mssql

### DIFF
--- a/_data/meltano/extractors/tap-mssql/singer-io.yml
+++ b/_data/meltano/extractors/tap-mssql/singer-io.yml
@@ -7,7 +7,7 @@ variant: singer-io
 prereqs: |
   ## Required Pre-Installation
   
-  This edition of the SQL Server tap is built in [Clojure](https://clojure.org/) and requires a JVM
+  This edition of the SQL Server tap is built in [Clojure](https://en.wikipedia.org/wiki/Clojure) and requires a JVM
   preinstalled. For this reason, you will need to perform custom installation steps before you will
   be able to use this with Meltano.
   

--- a/_data/meltano/extractors/tap-mssql/singer-io.yml
+++ b/_data/meltano/extractors/tap-mssql/singer-io.yml
@@ -5,7 +5,7 @@ logo_url: /assets/logos/extractors/mssql.png
 namespace: tap_mssql
 variant: singer-io
 prereq: |
-  ## Required Pre-Installation
+  ### Required Pre-Installation
   
   This edition of the SQL Server tap is built in [Clojure](https://en.wikipedia.org/wiki/Clojure) and requires a JVM
   preinstalled. For this reason, you will need to perform custom installation steps before you will

--- a/_data/meltano/extractors/tap-mssql/singer-io.yml
+++ b/_data/meltano/extractors/tap-mssql/singer-io.yml
@@ -4,7 +4,7 @@ name: tap-mssql
 logo_url: /assets/logos/extractors/mssql.png
 namespace: tap_mssql
 variant: singer-io
-prereqs: |
+prereq: |
   ## Required Pre-Installation
   
   This edition of the SQL Server tap is built in [Clojure](https://en.wikipedia.org/wiki/Clojure) and requires a JVM

--- a/_data/meltano/extractors/tap-mssql/singer-io.yml
+++ b/_data/meltano/extractors/tap-mssql/singer-io.yml
@@ -4,7 +4,14 @@ name: tap-mssql
 logo_url: /assets/logos/extractors/mssql.png
 namespace: tap_mssql
 variant: singer-io
-pip_url: git+https://github.com/singer-io/tap-mssql.git
+prereqs: |
+  ## Required Pre-Installation
+  
+  This edition of the SQL Server tap is built in [Clojure](https://clojure.org/) and requires a JVM
+  preinstalled. For this reason, you will need to perform custom installation steps before you will
+  be able to use this with Meltano.
+  
+  For more information, please see the `tap-mssql` readme: https://github.com/singer-io/tap-mssql#requirements
 repo: https://github.com/singer-io/tap-mssql
 settings: []
 capabilities:
@@ -15,3 +22,4 @@ domain_url: https://www.microsoft.com/en-us/sql-server/sql-server-2019
 maintenance_status: unknown
 keywords:
 - database
+- clojure


### PR DESCRIPTION
Discovered during this slack convo that our installation instructions are incorrect/incomplete: https://meltano.slack.com/archives/C013EKWA2Q1/p1666366768437239?thread_ts=1666305849.947129&cid=C013EKWA2Q1

I've confirmed the preview render looks correct.