### PR TITLE
set new db2 default variant

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -122,7 +122,7 @@ extractors:
   tap-daisycon: horze-international
   tap-dash-hudson: gthesheep
   tap-dayforce: goodeggs
-  tap-db2: singer-io
+  tap-db2: mjsqu
   tap-dbf: edgarrmondragon
   tap-dbt-artifacts: prratek
   tap-dbt: meltanolabs

--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -646,6 +646,10 @@ misoai:
   label: Miso Technologies
   url: https://github.com/MisoAI
   name: misoai
+mjsqu:
+  label: mjsqu
+  url: https://github.com/mjsqu
+  name: mjsqu
 mmeyer:
   label: Markus Meyer
   url: https://github.com/mmeyer

--- a/_data/meltano/extractors/tap-db2/mjsqu.yml
+++ b/_data/meltano/extractors/tap-db2/mjsqu.yml
@@ -1,0 +1,62 @@
+name: tap-db2
+variant: mjsqu
+label: IBM DB2
+logo_url: /assets/logos/extractors/db2.png
+capabilities:
+- catalog
+- discover
+- state
+description: IBM DB2 Relational Database
+domain_url: https://www.ibm.com/products/db2
+keywords:
+- database
+maintenance_status: active
+namespace: tap_db2
+next_steps: ''
+pip_url: git+https://github.com/mjsqu/tap-db2.git
+repo: https://github.com/mjsqu/tap-db2
+settings:
+- name: database
+  label: Database
+  description: The database name.
+- name: port
+  label: Port
+  description: The database port.
+  kind: integer
+- name: offset_value
+  label: Offset Value
+  description: The offset to use for querying data. Only needed for development and
+    edge cases. The state bookmarks usually keep track of this.
+  kind: integer
+- name: use_date_datatype
+  label: Use Date Datatype
+  description: Whether to add date format to the schema when date strings are provided.
+    Default False.
+  kind: boolean
+- name: hostname
+  label: Hostname
+  description: Your DB2 hostname.
+- name: username
+  label: Username
+  description: Your DB2 username.
+- name: password
+  label: Password
+  description: Your DB2 password.
+  kind: password
+- name: use_singer_decimal
+  label: Use Singer Decimal
+  description: Whether to add decimal format to the schema when decimal strings are
+    provided. Default False.
+  kind: boolean
+- name: cursor_array_size
+  label: Cursor Array Size
+  description: The size of the cursor to use when querying data. Default 1.
+  kind: integer
+settings_group_validation:
+- - database
+  - port
+  - hostname
+  - username
+  - password
+settings_preamble: ''
+usage: ''

--- a/_data/meltano/extractors/tap-db2/singer-io.yml
+++ b/_data/meltano/extractors/tap-db2/singer-io.yml
@@ -1,4 +1,4 @@
-description: IMB Db2 Relational Database
+description: IBM Db2 Relational Database
 label: IBM Db2
 name: tap-db2
 logo_url: /assets/logos/extractors/db2.png


### PR DESCRIPTION
Discussed in https://github.com/MeltanoLabs/Singer-Most-Wanted/issues/33.

Replace the stale singer-io variant with this new fork variant.

cc @s7clarke10 @aaronsteers 