### PR TITLE
Tap twitter variants

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -356,7 +356,7 @@ extractors:
   tap-twinfield: yoast
   tap-twitter-ads: singer-io
   tap-twitter-streams: pbegle
-  tap-twitter: bernietai
+  tap-twitter: voxmedia
   tap-typeform: albert-marrero
   tap-typo: typo-ai
   tap-udemy-for-business: immuta

--- a/_data/meltano/extractors/tap-twitter/bernietai.yml
+++ b/_data/meltano/extractors/tap-twitter/bernietai.yml
@@ -6,12 +6,52 @@ namespace: tap_twitter
 variant: bernietai
 pip_url: git+https://github.com/bernietai/tap-twitter.git
 repo: https://github.com/bernietai/tap-twitter
-settings: []
+settings:
+- name: consumer_key
+  label: Consumer Key
+  description: See your Twitter App setup.
+  kind: password
+- name: access_token_url
+  label: Access Token Url
+  description: The access token URL. Default, https://api.twitter.com/oauth/access_token.
+  value: https://api.twitter.com/oauth/access_token
+- name: start_date
+  label: Start Date
+  description: "Determines how much historical data will be extracted. Please be aware\n\
+    that the larger the time period and amount of data, the longer the initial extraction\n\
+    can be expected to take."
+  kind: date_iso8601
+- name: request_token_url
+  label: Request Token Url
+  description: The request token URL. Default, https://api.twitter.com/oauth/request_token.
+  value: https://api.twitter.com/oauth/request_token
+- name: consumer_secret
+  label: Consumer Secret
+  description: Your consumer secret.
+  kind: password
+- name: count
+  label: Count
+  description: The number of records to retrieve. Applies to all streams. Default
+    10.
+  kind: integer
+  value: 10
+- name: authorize_url
+  label: Authorize Url
+  description: The authorize url. Default https://api.twitter.com/oauth/authorize.
+  value: https://api.twitter.com/oauth/authorize
 capabilities:
 - catalog
 - discover
 - state
 domain_url: https://developer.twitter.com
-maintenance_status: unknown
+maintenance_status: inactive
 keywords:
 - api
+settings_group_validation:
+- - consumer_key
+  - access_token_url
+  - start_date
+  - request_token_url
+  - consumer_secret
+  - count
+  - authorize_url

--- a/_data/meltano/extractors/tap-twitter/bernietai.yml
+++ b/_data/meltano/extractors/tap-twitter/bernietai.yml
@@ -6,52 +6,13 @@ namespace: tap_twitter
 variant: bernietai
 pip_url: git+https://github.com/bernietai/tap-twitter.git
 repo: https://github.com/bernietai/tap-twitter
-settings:
-- name: consumer_key
-  label: Consumer Key
-  description: See your Twitter App setup.
-  kind: password
-- name: access_token_url
-  label: Access Token Url
-  description: The access token URL. Default, https://api.twitter.com/oauth/access_token.
-  value: https://api.twitter.com/oauth/access_token
-- name: start_date
-  label: Start Date
-  description: "Determines how much historical data will be extracted. Please be aware\n\
-    that the larger the time period and amount of data, the longer the initial extraction\n\
-    can be expected to take."
-  kind: date_iso8601
-- name: request_token_url
-  label: Request Token Url
-  description: The request token URL. Default, https://api.twitter.com/oauth/request_token.
-  value: https://api.twitter.com/oauth/request_token
-- name: consumer_secret
-  label: Consumer Secret
-  description: Your consumer secret.
-  kind: password
-- name: count
-  label: Count
-  description: The number of records to retrieve. Applies to all streams. Default
-    10.
-  kind: integer
-  value: 10
-- name: authorize_url
-  label: Authorize Url
-  description: The authorize url. Default https://api.twitter.com/oauth/authorize.
-  value: https://api.twitter.com/oauth/authorize
+settings: []
+hidden: true
 capabilities:
 - catalog
 - discover
 - state
 domain_url: https://developer.twitter.com
-maintenance_status: inactive
+maintenance_status: unknown
 keywords:
 - api
-settings_group_validation:
-- - consumer_key
-  - access_token_url
-  - start_date
-  - request_token_url
-  - consumer_secret
-  - count
-  - authorize_url

--- a/_data/meltano/extractors/tap-twitter/voxmedia.yml
+++ b/_data/meltano/extractors/tap-twitter/voxmedia.yml
@@ -1,0 +1,43 @@
+name: tap-twitter
+variant: voxmedia
+label: Twitter
+logo_url: /assets/logos/extractors/twitter.png
+capabilities:
+- catalog
+- state
+- discover
+- about
+- stream-maps
+description: Social Networking Website
+domain_url: https://developer.twitter.com/en
+keywords:
+- meltano_sdk
+- api
+maintenance_status: active
+namespace: tap_twitter
+next_steps: ''
+pip_url: git+https://github.com/voxmedia/tap-twitter.git
+repo: https://github.com/voxmedia/tap-twitter
+settings:
+- name: bearer_token
+  label: Bearer Token
+  description: 'The bearer token to authenticate against the Twitter API using the
+    OAuth 2.0 flow outlined here - https://developer.twitter.com/en/docs/authentication/oauth-2-0/application-only '
+  kind: password
+- name: user_ids
+  label: User Ids
+  description: List of user IDs of Twitter accounts for which to fetch data
+  kind: array
+- name: url_patterns
+  label: Url Patterns
+  description: List of URL patterns for which to fetch tweets
+  kind: array
+- name: start_date
+  label: Start Date
+  description: The earliest record date to sync
+  kind: date_iso8601
+settings_group_validation:
+- - bearer_token
+  - user_ids
+settings_preamble: ''
+usage: ''


### PR DESCRIPTION
- the existing tap variant is 5 years old and fails to install see https://github.com/bernietai/tap-twitter/issues/1. The auth flow is pretty confusing too.
- theres a new SDK based variant that exists to I made that the default. It doesnt pull as much data but it worked for me and I think we'd rather have someone succeed and need to contribute more streams to fit their use case than fail and give up.