### PR TITLE
fix: Remove default value for `cursorclass` in tap-mysql (transferwise)

### DIFF
--- a/_data/meltano/extractors/tap-mysql/transferwise.yml
+++ b/_data/meltano/extractors/tap-mysql/transferwise.yml
@@ -37,7 +37,6 @@ settings:
   description: The MySQL/MariaDB database name.
 - name: cursorclass
   label: Cursor Class
-  value: pymysql.cursors.SSCursor
   description: Cursor class used by PyMYSQL.
 - name: server_id
   label: Server ID


### PR DESCRIPTION
The tap can't resolve string values of `cursorclass`, so for the moment it'd be better for Meltano not to use a default value.

See https://github.com/transferwise/pipelinewise-tap-mysql/issues/129