### PR TITLE
fix: Dispatch PR plugin tests for forks

### DIFF
--- a/.github/workflows/test_dispatcher.yml
+++ b/.github/workflows/test_dispatcher.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Get changed files
         id: changed_files
@@ -47,7 +49,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
         with:
-          ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install yq
         env:


### PR DESCRIPTION
Example of it working with a PR from MeltyBot's fork to my fork: https://github.com/WillDaSilva/meltano-hub/pull/2

Closes #969