### PR TITLE
Updates extractors tap-mailchimp (singer-io), and make default

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -222,7 +222,7 @@ extractors:
   tap-loopreturns: loopreturns
   tap-lotr: mattarderne
   tap-maestroqa: pathlight
-  tap-mailchimp: lovepopcards
+  tap-mailchimp: singer-io
   tap-mailgun: streetteam
   tap-mailjet: Somtom
   tap-mailshake: singer-io

--- a/_data/meltano/extractors/tap-mailchimp/singer-io.yml
+++ b/_data/meltano/extractors/tap-mailchimp/singer-io.yml
@@ -6,11 +6,46 @@ namespace: tap_mailchimp
 variant: singer-io
 pip_url: tap-mailchimp
 repo: https://github.com/singer-io/tap-mailchimp
-settings: []
+settings:
+- name: request_timeout
+  label: Request Timeout
+  description: Time for which request should wait to get response. Default, 300.
+  kind: integer
+- name: dc
+  label: Data Center
+  description: The Mailchimp data center, only requried when using API key auth. E.g. "us14".
+- name: page_size
+  label: Page Size
+  description: The request page size, default 1000.
+  kind: integer
+- name: user_agent
+  label: User Agent
+  description: The user agent to send on every request.
+- name: start_date
+  label: Start Date
+  description: "Determines how much historical data will be extracted. Please be aware\n\
+    that the larger the time period and amount of data, the longer the initial extraction\n\
+    can be expected to take."
+  kind: date_iso8601
+- name: access_token
+  label: Access Token
+  description: The access token from the OAuth2 flow.
+  kind: password
+- name: api_key
+  label: API Key
+  description: The Mailchimp API key, if using API key auth instead of OAuth.
+  kind: password
 capabilities:
 - catalog
 - discover
+- state
 domain_url: https://mailchimp.com/developer/marketing/api/
-maintenance_status: unknown
+maintenance_status: active
 keywords:
 - api
+settings_group_validation:
+- - start_date
+  - api_key
+  - dc
+- - start_date
+  - access_token


### PR DESCRIPTION
Adds settings to singer-io variant and makes it the default. The [singer-io variant](https://github.com/singer-io/tap-mailchimp) has had updates in the last 12 months and I see a bunch of new PRs so its active vs the [lovepopcards variant](https://github.com/lovepopcards/tap-mailchimp) (currently default) that hasnt had a commit since 2017. 

@tayloramurphy any idea why we might have chosen to make lovepopcards the default over singer-io? 