### PR TITLE
make meltanolabs the default for tap-slack

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -322,7 +322,7 @@ extractors:
   tap-simplifi: georgiyolovski
   tap-sklik: polar-analytics
   tap-skubana: singer-io
-  tap-slack: mashey
+  tap-slack: meltanolabs
   tap-sleeper: collinprather
   tap-sling: singer-io
   tap-smartsheet: brooklyn-data


### PR DESCRIPTION
- Its worked well for me
- Its on the SDK
- The current variant hasnt had updates in a while vs MeltanoLabs maintenance