### PR TITLE
bugfix: maintainer script not raising error

### DIFF
--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -278,6 +278,9 @@ einartg:
   label: Einar Gudmundsson
   url: https://github.com/einartg
   name: einartg
+elementary:
+  label: Elementary Data
+  url: https://github.com/elementary-data
 eltonarodrigues:
   label: Elton de Andrade Rodrigues
   url: https://github.com/eltonarodrigues
@@ -630,6 +633,9 @@ meshcloud:
   label: meshcloud
   url: https://github.com/meshcloud
   name: meshcloud
+metabase:
+  label: Metabase
+  url: https://github.com/metabase
 mighty-digital:
   label: mighty-digital
   url: https://github.com/mighty-digital
@@ -762,6 +768,9 @@ polar-analytics:
   label: polar-analytics
   url: https://github.com/polar-analytics
   name: polar-analytics
+postgres:
+  label: Postgres
+  url: https://github.com/postgres
 potloc:
   label: Potloc
   url: https://www.potloc.com/
@@ -786,6 +795,9 @@ pys933:
   label: Jack Park
   url: https://github.com/pys933
   name: pys933
+quantile-development:
+  label: Quantile Development
+  url: https://github.com/dagster-io
 quickbi:
   label: QuickBI Oy
   url: https://github.com/quickbi

--- a/utility_scripts/plugin_definitions/maintainers_validate.py
+++ b/utility_scripts/plugin_definitions/maintainers_validate.py
@@ -23,6 +23,7 @@ def write_updated_maintainers(data):
 
 def build_maintainers():
     maintainers_set = set()
+    missing = set()
     updated_maintainers = read_yaml(f"{data_dir}/maintainers.yml")
 
     for plugin_type in os.listdir(directory):
@@ -35,12 +36,13 @@ def build_maintainers():
                 )
                 maintainers_set.add(plugin_data.get("variant"))  # different casings will return as distinct items
                 if plugin_data.get("variant").lower() not in updated_maintainers:
+                    missing.add(plugin_data.get("variant"))
                     updated_maintainers[plugin_data.get("variant").lower()] = {
                         "label": "TODO: ADD LABEL",
                         "url": "/".join(plugin_data.get("repo").split("/")[:-1]),
                     }
 
-    return maintainers_set, updated_maintainers
+    return maintainers_set, updated_maintainers, missing
 
 
 def remove_extras(updated_maintainers, extras):
@@ -56,10 +58,9 @@ if __name__ == "__main__":
     to accelerate updates. It also exits with code 1 if there are extra or missing
     maintainers so CICD can use it to validate.
     """
-    maintainers_set, updated_maintainers = build_maintainers()
+    maintainers_set, updated_maintainers, missing = build_maintainers()
 
     extras = updated_maintainers.keys() - maintainers_set
-    missing = maintainers_set - updated_maintainers.keys()
 
     remove_extras(updated_maintainers, extras)
     write_updated_maintainers(updated_maintainers)


### PR DESCRIPTION
Related to https://github.com/meltano/hub/pull/1016#issuecomment-1319993010

The maintainer script had a bug where it wasnt raising the proper exit code if there were extra or missing maintainers. Now it should be fixed and all the maintainers that were missing are added.