### PR TITLE
fix freshdesk capabilities

### DIFF
--- a/_data/meltano/extractors/tap-freshdesk/singer-io.yml
+++ b/_data/meltano/extractors/tap-freshdesk/singer-io.yml
@@ -28,10 +28,8 @@ settings_group_validation:
   - api_key
   - start_date
 capabilities:
-- catalog
-- discover
 - state
 domain_url: https://developer.freshdesk.com/api/
-maintenance_status: unknown
+maintenance_status: active
 keywords:
 - api


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/1018

I've actually never seen a tap that doesnt support catalog/discover. I wonder if theres implications on the meltano side. I know selection rules wouldnt work in this case. @edgarrmondragon do you know?

cc @visch 