### PR TITLE
Add generic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a potential bug in the MeltanoHub
+title: "\U0001F41B BUG: `Brief description of the problem` "
+labels: 
+assignees: taylormurphy,pnadolny13
+---
+
+**Note:** This issue template is for issues related to the MeltanoHub or plugin definitions. 
+If you're having a problem with a tap or target, please open an issue on that repository so the maintainers can address it.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information if applicable):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information if applicable):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
@tayloramurphy @pnadolny13 We didn't have a generic bug report issue template so I figured it would be good to make one so that we can collect the right info from folks. Will this work?

@rwfeather @cjohnhanson Would love to get your thoughts on this to make sure this captures info you might need as well.

See https://meltano.slack.com/archives/C01UGBSJNG5/p1668779438979179 for context on this proposal.