### PR TITLE
yamllint - enable trailing spaces rule

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -14,4 +14,3 @@ rules:
   key-ordering: enable
   line-length: disable
       # max: 160
-  trailing-spaces: disable

--- a/_data/meltano/extractors/tap-looker/singer-io.yml
+++ b/_data/meltano/extractors/tap-looker/singer-io.yml
@@ -53,7 +53,7 @@ settings_group_validation:
   - client_id
 usage: |
   ### Additional Notes
-  This tap uses Looker's API v3.1 https://developers.looker.com/api/explorer/3.1. 
+  This tap uses Looker's API v3.1 https://developers.looker.com/api/explorer/3.1.
 
   - All endpoints replicate FULL_TABLE (ALL records, every time). Currently, the Looker API does not support paginating, sorting, filtering, or providing audit fields (like created/modified datetimes).
   - Primary Key field(s): Almost all endpoint have an id primary key

--- a/_data/meltano/extractors/tap-stripe/singer-io.yml
+++ b/_data/meltano/extractors/tap-stripe/singer-io.yml
@@ -47,7 +47,7 @@ settings:
     2. Under the `Standard keys` section, click on the button to `Create secret key`
 
     > **Tip: No button?**
-    > 
+    >
     > If the "Create secret key" button is not available, a secret key may already have been generated before.
     > In this case, use the "Reveal live key token" button under "Token" and to the right of "Secret key". The token that appears is the secret key you can copy and paste into the data source configuration.
 

--- a/_data/meltano/extractors/tap-zendesk/twilio-labs.yml
+++ b/_data/meltano/extractors/tap-zendesk/twilio-labs.yml
@@ -108,7 +108,7 @@ usage: |
     *  slas
 
   To sideload an object a list can be passed in the [metadata extra](https://docs.meltano.com/concepts/plugins#metadata-extra) under `sideload-objects``:
-    
+
   ```
   extractors:
   - name: tap-zendesk

--- a/_data/meltano/loaders/target-yaml/meltanolabs.yml
+++ b/_data/meltano/loaders/target-yaml/meltanolabs.yml
@@ -55,9 +55,9 @@ settings:
 - description: |
     Determines the overwrite behavior if destination file already exists.
     Must be one of the following string values:
-      - `append_records` (default): append records at the insertion point 
-      - `replace_records`: replace all records at the insertion point 
-      - `replace_file`: replace entire file using `default_yaml_template` 
+      - `append_records` (default): append records at the insertion point
+      - `replace_records`: replace all records at the insertion point
+      - `replace_file`: replace entire file using `default_yaml_template`
   label: Overwrite Behavior
   name: overwrite_behavior
 - description: Text string to use for a yaml template file. This text will be used

--- a/_data/meltano/utilities/dbt-osmosis/z3z1ma.yml
+++ b/_data/meltano/utilities/dbt-osmosis/z3z1ma.yml
@@ -10,7 +10,7 @@ commands:
     args: diff --project-dir ${MELTANO_PROJECT_ROOT}/transform --profiles-dir ${MELTANO_PROJECT_ROOT}/transform/profiles/${ADAPTER}
       --temp-table
     description: |
-      Diff a query from git HEAD to inspect changes as you develop caching the HEAD rev of the model 
+      Diff a query from git HEAD to inspect changes as you develop caching the HEAD rev of the model
       to a schema called `dbt_diff`, requires -m [MODEL]
   run:
     args: run --project-dir ${MELTANO_PROJECT_ROOT}/transform --profiles-dir ${MELTANO_PROJECT_ROOT}/transform/profiles/${ADAPTER}
@@ -21,8 +21,8 @@ commands:
       --profiles-dir ${MELTANO_PROJECT_ROOT}/transform/profiles/${ADAPTER}
     description: |
       Start a server exposing two primary endpoints. /compile and /run which receive POST
-      requests and compile or run dbt SQL against your dbt profile. It is significantly faster 
-      and simpler than dbt RPC and internally does not rely on it. This server is compatible with 
+      requests and compile or run dbt SQL against your dbt profile. It is significantly faster
+      and simpler than dbt RPC and internally does not rely on it. This server is compatible with
       https://github.com/innoverio/vscode-dbt-power-user providing VS code users interactive
       query previews via a simple ▶️ button or Cmd+Enter.
   workbench:
@@ -38,7 +38,7 @@ definition: |
   2. The ability to diff model outputs across file revisions
   3. Automation which manages generating, updating, and propagating documentation for your
   `schema.yml` files.
-  4. A FastAPI dbt server which principally integrates with the 
+  4. A FastAPI dbt server which principally integrates with the
   [VSCode dbt power user extension](https://github.com/innoverio/vscode-dbt-power-user).
 domain_url: https://github.com/z3z1ma/dbt-osmosis
 executable: dbt-osmosis
@@ -69,7 +69,7 @@ repo: https://github.com/z3z1ma/dbt-osmosis
 settings:
 - description: |
     This should be set to the adapter you have installed as meltano will install
-    dbt and its profile directory into `transform/<adapter>` directory. We use this 
+    dbt and its profile directory into `transform/<adapter>` directory. We use this
     config option to resolve dbt profile directory.
   env: ADAPTER
   name: adapter

--- a/_data/meltano/utilities/notebook/matatika.yml
+++ b/_data/meltano/utilities/notebook/matatika.yml
@@ -44,7 +44,7 @@ settings:
 - description: |-
     [Configuration for the `nbconvert` exporter](https://nbconvert.readthedocs.io/en/latest/config_options.html#exporter-options) specified by `format` as a preset or raw JSON string.
 
-    [More information on configuration and available presets](https://github.com/Matatika/utility-notebook#supported-converting-formats) 
+    [More information on configuration and available presets](https://github.com/Matatika/utility-notebook#supported-converting-formats)
   label: Configuration
   name: config
   value: '""'

--- a/_data/meltano/utilities/sqlfluff/sqlfluff.yml
+++ b/_data/meltano/utilities/sqlfluff/sqlfluff.yml
@@ -46,7 +46,7 @@ next_steps: |
       ```
   1. Create a `.sqlfluffignore` in the root directory of your project using the sample content below.
     This makes sure SQLFluff ignores auto generated sql or installed packages.
-   
+
       ```
       .meltano/
       utilities/
@@ -58,7 +58,7 @@ next_steps: |
   1. Depending on your dbt adapter you will need to override your dbt environment variables using the `env` key so when SQLFluff calls dbt your
     [profile.yml env vars](https://github.com/meltano/files-dbt-snowflake/blob/c8ae6cde35716b6ada3ccf8f9b6f116ba37b95fe/bundle/transform/profiles/snowflake/profiles.yml#L15)
     are properly set.
-    Refer to the Meltano transformer [docs](https://hub.meltano.com/transformers/) for details on what variables are needed for your adapter. 
+    Refer to the Meltano transformer [docs](https://hub.meltano.com/transformers/) for details on what variables are needed for your adapter.
     An example for Snowflake is shown below.
 
       ```yaml

--- a/_data/meltano/utilities/superset/apache.yml
+++ b/_data/meltano/utilities/superset/apache.yml
@@ -148,7 +148,7 @@ usage: |
 
   ### Invalid decryption key
 
-  If you see a `ValueError: Invalid decryption key` warning or a message that `Superset default roles and permissions could not be created: 'superset init' failed` then it's likely that your encryption key is incorrect. 
+  If you see a `ValueError: Invalid decryption key` warning or a message that `Superset default roles and permissions could not be created: 'superset init' failed` then it's likely that your encryption key is incorrect.
 
   If you change your [`SECRET_KEY`](#secret-key), the metadata database containing your users and reports will become unreadable. If there was nothing valuable in there, you can delete it at `.meltano/utilities/superset/superset.db` inside your project. If you changed the secret key because the old one was leaked, you can [rotate the key](https://superset.apache.org/docs/installation/configuring-superset/#secret_key-rotation):
 

--- a/_data/meltano/utilities/superset/meltano.yml
+++ b/_data/meltano/utilities/superset/meltano.yml
@@ -62,7 +62,7 @@ next_steps: |
     ```
 
     This is equivalent to `superset load_examples` in the Superset documentation
-    
+
     **Note that you need a user named `admin` with the admin permissions to load these examples.**
 
   4. Launch the Superset UI and log in using the username/password you created:
@@ -146,7 +146,7 @@ usage: |
 
   ### Invalid decryption key
 
-  If you see a `ValueError: Invalid decryption key` warning or a message that `Superset default roles and permissions could not be created: 'superset init' failed` then it's likely that your encryption key is incorrect. 
+  If you see a `ValueError: Invalid decryption key` warning or a message that `Superset default roles and permissions could not be created: 'superset init' failed` then it's likely that your encryption key is incorrect.
 
   If you change your [`SECRET_KEY`](#secret-key), the metadata database containing your users and reports will become unreadable. If there was nothing valuable in there, you can delete it at `.meltano/utilities/superset/superset.db` inside your project. If you changed the secret key because the old one was leaked, you can [rotate the key](https://superset.apache.org/docs/installation/configuring-superset/#secret_key-rotation):
 


### PR DESCRIPTION
https://github.com/meltano/hub/pull/1023 disabled the trailing spaces lint rule so we could fix the larger key sorting errors first. This re-enables it and fixes all violations.