### PR TITLE
fix: Fix built API urls and document new script

### DIFF
--- a/utility_scripts/README.md
+++ b/utility_scripts/README.md
@@ -1,0 +1,31 @@
+# Meltano Hub - Utility Scripts
+
+## API
+
+### `make_files.py`
+
+This script generates the JSON files for the Meltano Hub API.
+
+#### Options
+
+| Option               | Description                               | Example                                                      |
+| -------------------- | ----------------------------------------- | ------------------------------------------------------------ |
+| `-o`, `--output-dir` | The directory to write the JSON files to. | `./_hub_api`                                                 |
+| `--hub-url`          | The URL of the Meltano Hub.               | `https://meltano.com`                                        |
+| `--api-url`          | The URL of the API Gateway stage.         | `https://ty9g0lccp8.execute-api.us-west-2.amazonaws.com/dev` |
+
+#### Usage
+
+After activating the Poetry environment, run the following command:
+
+```bash
+HUB_URL='https://hub.meltano.com' \
+API_URL='https://ty9g0lccp8.execute-api.us-west-2.amazonaws.com/dev' \
+python utility_scripts/api/make_files.py -o _hub_api --hub-url $HUB_URL --api-url $API_URL
+```
+
+To sync the files with the target S3 bucket, run the following command:
+
+```bash
+aws s3 sync _hub_api s3://<s3-bucket>/hub-api
+```

--- a/utility_scripts/api/make_files.py
+++ b/utility_scripts/api/make_files.py
@@ -96,15 +96,17 @@ class ApiBuilder:
             output_dir: Path to output directory.
             create: Whether to create the output directory if it doesn't exist.
         """
-        if not output_dir.exists() and create:
-            output_dir.mkdir(parents=True)
+        plugins_dir = output_dir.joinpath("plugins")
+
+        if not plugins_dir.exists() and create:
+            plugins_dir.mkdir(parents=True)
 
         default_variants = self.get_default_variants()
         global_index = {}
 
         for plugin_type in PluginType:
             source_type_path = self.data_path.joinpath("meltano", plugin_type.value)
-            output_type_path = output_dir.joinpath(plugin_type.value)
+            output_type_path = plugins_dir.joinpath(plugin_type.value)
             plugin_type_index = {}
 
             if not output_type_path.exists() and create:
@@ -143,7 +145,10 @@ class ApiBuilder:
 
                     # Add to plugin variants
                     variants[variant] = {
-                        "ref": f"{self.base_api_url}/{plugin_type}/{plugin_full_name}",
+                        "ref": (
+                            f"{self.base_api_url}/plugins"
+                            f"/{plugin_type}/{plugin_full_name}"
+                        ),
                     }
 
                     # Set default variant logo
@@ -166,7 +171,7 @@ class ApiBuilder:
             logger.info("Wrote %s", plugin_index_path)
 
         # Write global index
-        global_index_path = output_dir.joinpath("index")
+        global_index_path = plugins_dir.joinpath("index")
         with global_index_path.open("w") as f:
             json.dump(global_index, f, separators=(",", ":"))
 


### PR DESCRIPTION
- Ensures the `/plugins/` part of the URL is set.
- Writes files to the `<output-dir>/plugins` directory.
- Documents the script usage