### PR TITLE
bugfix: empty command list

### DIFF
--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="commands">
+  <div v-if="commands && commands.length">
     <p class="text-3xl py-4" id="commands">Commands</p>
     <span
       >The {{ name }} {{ plugin_type }} supports the following commands that can be used with


### PR DESCRIPTION
This fixes a bug where the commands section is included even if the plugin doesnt have any:

<img width="941" alt="Screen Shot 2022-11-23 at 1 38 14 PM" src="https://user-images.githubusercontent.com/27376735/203625165-68f3fd5c-2a81-427a-879d-7ce140ba0243.png">

See "Commands" section of https://hub.meltano.com/extractors/tap-postgres. Now it makes sure that there are elements in the list before populating the sections header.

This works but let me know if theres a more javascripty way to do the "not null and not empty" conditional.