### PR TITLE
Do not render `Commands` section for plugins that do not define any `commands`

### DIFF
--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="commands">
+  <div v-if="commands?.length">
     <p class="text-3xl py-4" id="commands">Commands</p>
     <span
       >The {{ name }} {{ plugin_type }} supports the following commands that can be used with


### PR DESCRIPTION
Small QOL change for plugins like [`tap-auth0`](https://hub.meltano.com/extractors/tap-auth0/):

![image](https://user-images.githubusercontent.com/60552974/203876685-3577580e-be45-4066-b73e-37fedc621209.png)
