### PR TITLE
Add missing capabilities and setting labels for `tap-spotify`

### DIFF
--- a/_data/meltano/extractors/tap-spotify/matatika.yml
+++ b/_data/meltano/extractors/tap-spotify/matatika.yml
@@ -18,16 +18,16 @@ pip_url: git+https://github.com/Matatika/tap-spotify.git
 repo: https://github.com/Matatika/tap-spotify
 settings:
 - description: App client ID
-  label: Client ID
   kind: password
+  label: Client ID
   name: client_id
 - description: App client secret
-  label: Client secret
   kind: password
+  label: Client secret
   name: client_secret
 - description: Refresh token
-  label: Refresh token
   kind: password
+  label: Refresh token
   name: refresh_token
 settings_group_validation:
 - - client_id

--- a/_data/meltano/extractors/tap-spotify/matatika.yml
+++ b/_data/meltano/extractors/tap-spotify/matatika.yml
@@ -2,6 +2,8 @@ capabilities:
 - catalog
 - discover
 - state
+- about
+- stream-maps
 description: Audio Streaming and Media Services
 domain_url: https://developer.spotify.com/documentation/web-api/
 keywords:
@@ -16,12 +18,15 @@ pip_url: git+https://github.com/Matatika/tap-spotify.git
 repo: https://github.com/Matatika/tap-spotify
 settings:
 - description: App client ID
+  label: Client ID
   kind: password
   name: client_id
 - description: App client secret
+  label: Client secret
   kind: password
   name: client_secret
 - description: Refresh token
+  label: Refresh token
   kind: password
   name: refresh_token
 settings_group_validation:


### PR DESCRIPTION
[tap-spotify](https://hub.meltano.com/extractors/tap-spotify/) settings had no labels, causing them to be displayed in an odd way.

![image](https://user-images.githubusercontent.com/60552974/203877827-2ab50bbd-020a-4269-a5c8-5f19b77ba761.png)

Also updated `capabilities` for good measure.