### PR TITLE
bump connector count 350->400+

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -4,7 +4,7 @@
       type="text"
       name="search"
       id="search"
-      placeholder="Search 350+ connectors and tools that work with Meltano…"
+      placeholder="Search 400+ connectors and tools that work with Meltano…"
       class="text-black col-span-1 bg-slate-100 pl-4 border-solid border-black border-2 w-10/12 place-self-center"
       ref="searchBar"
       :value="search"


### PR DESCRIPTION
A recent [plugin definition validation job](https://github.com/meltano/hub/actions/runs/3566816399/jobs/5993735379#step:6:19) showed 400+ distinct plugins (excluding file bundles and transforms) so we can bump this count!

```json
{
    "extractors": "Plugins: 351, Variants: 613",
    "files": "Plugins: 12, Variants: 12",
    "loaders": "Plugins: 30, Variants: 51",
    "mappers": "Plugins: 2, Variants: 2",
    "orchestrators": "Plugins: 1, Variants: 1",
    "transformers": "Plugins: 6, Variants: 6",
    "transforms": "Plugins: 9, Variants: 9",
    "utilities": "Plugins: 17, Variants: 18"
}
```