### PR TITLE
exclude tap-slack new admin stream by default

### DIFF
--- a/_data/meltano/extractors/tap-slack/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-slack/meltanolabs.yml
@@ -55,6 +55,9 @@ prereq: |
   curl -X GET -H 'Authorization: Bearer <Your Token>' https://slack.com/api/conversations.list?exclude_archived=False
   ```
 repo: https://github.com/MeltanoLabs/tap-slack
+select:
+- '*.*'
+- '!integration_logs.*'
 settings:
 - description: Your Slack App API key. See the Prerequisites section above for more
     details on obtaining it.


### PR DESCRIPTION
Related to https://github.com/MeltanoLabs/tap-slack/pull/14

Theres a new stream that requires admin credentials where as the existing streams do not. My thought was that we could allow that stream to be added to the tap but by default exclude it from syncs. If a user wants to add it they can override the default select criteria but it wont affect normal users.

If we like this idea I can also add a blurb to one of the free text sections like `usage` to describe that the stream is available for admin users.

@tayloramurphy @edgarrmondragon what do you think?