### PR TITLE
add executable for mismatch names

### DIFF
--- a/_data/meltano/extractors/tap-tableau/tailsdotcom.yml
+++ b/_data/meltano/extractors/tap-tableau/tailsdotcom.yml
@@ -3,6 +3,7 @@ capabilities:
 - state
 - discover
 domain_url: https://www.tableau.com/
+executable: tap-tableau-server
 keywords:
 - meltano_sdk
 label: Tableau

--- a/_data/meltano/loaders/target-iomete/iomete.yml
+++ b/_data/meltano/loaders/target-iomete/iomete.yml
@@ -3,6 +3,7 @@ capabilities:
 - hard-delete
 description: Serverless lakehouse platform.
 domain_url: https://iomete.com/
+executable: singer-target-iomete
 keywords:
 - 'lakehouse'
 label: IOMETE

--- a/src/pages/Extractors.vue
+++ b/src/pages/Extractors.vue
@@ -8,7 +8,9 @@
       </p>
       <p>
         To learn more about extracting and loading data using Meltano, refer to the
-        <a href="https://docs.meltano.com/getting-started/part1" target="_blank">Getting Started guide</a>.
+        <a href="https://docs.meltano.com/getting-started/part1" target="_blank"
+          >Getting Started guide</a
+        >.
       </p>
       <div
         class="grid grid-cols-2 md:grid-cols-4 bg-slate-200 rounded-lg p-4 mt-4 md:m-4 gap-4 w-full place-items-stretch"

--- a/src/pages/Loaders.vue
+++ b/src/pages/Loaders.vue
@@ -9,7 +9,9 @@
       </p>
       <p>
         To learn more about extracting and loading data using Meltano, refer to the
-        <a href="https://docs.meltano.com/getting-started/part1" target="_blank">Getting Started guide</a>.
+        <a href="https://docs.meltano.com/getting-started/part1" target="_blank"
+          >Getting Started guide</a
+        >.
       </p>
       <div
         class="grid grid-cols-2 md:grid-cols-4 bg-slate-200 rounded-lg p-4 mt-4 md:m-4 gap-4 w-full place-items-stretch"


### PR DESCRIPTION
I noticed a couple plugins that I renamed but the executable was never added so I dont think they'd work properly.