### PR TITLE
Duckdb Default target schema

### DIFF
--- a/_data/meltano/loaders/target-duckdb/jwills.yml
+++ b/_data/meltano/loaders/target-duckdb/jwills.yml
@@ -31,6 +31,7 @@ settings:
   kind: string
   label: Default Target Schema
   name: default_target_schema
+  value: $MELTANO_EXTRACT__LOAD_SCHEMA
 - description: |
     Useful if you want to load multiple streams from one tap to multiple DuckDB schemas.
 


### PR DESCRIPTION
Default Target Schema for DuckDB. Should probably be linted for all loaders? But that's probably too much :D 