### PR TITLE
target-postgres has a default for port not obvious in meltano interac…

### DIFF
--- a/_data/meltano/loaders/target-postgres/meltanolabs.yml
+++ b/_data/meltano/loaders/target-postgres/meltanolabs.yml
@@ -23,7 +23,7 @@ settings:
   label: Host
   name: host
 - description: The port on which postgres is awaiting connection. Note if sqlalchemy_url
-    is set this will be ignored.
+    is set this will be ignored. Defaults to 5432
   kind: integer
   label: Port
   name: port


### PR DESCRIPTION
target-postgres has a default in target.py here https://github.com/MeltanoLabs/target-postgres/blob/main/target_postgres/target.py#L62 

This isn't reflected in the interactive window

![image](https://user-images.githubusercontent.com/8680264/206803548-02eae7b6-442c-4680-892a-ff7f7e72d3d6.png)

I could add a `value` here as well? Maybe the automation needs this added @pnadolny13  ? 