### PR TITLE
skip ci dispatcher for executable plugin name mismatch

### DIFF
--- a/.github/workflows/test_dispatcher.yml
+++ b/.github/workflows/test_dispatcher.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Filter changed files
         id: filter_files
-        run: echo "filtered_files=$(echo ${{ steps.changed_files.outputs.all_changed_files }} | jq -c 'map(select(startswith("_data/meltano/") and endswith(".yml")))' | sed 's/"/\\"/g')" >> "$GITHUB_OUTPUT"
+        run: echo "filtered_files=$(echo ${{ steps.changed_files.outputs.all_changed_files }} | jq -c 'map(select(startswith("_data/meltano/") and endswith(".yml") and not endswith("airbyte.yml")))' | sed 's/"/\\"/g')" >> "$GITHUB_OUTPUT"
 
       - id: set-matrix
         run: echo "matrix={\"changed_file\":${{ steps.filter_files.outputs.filtered_files }}}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Related to https://github.com/meltano/hub/pull/1101

@tayloramurphy we can also fix the fact that its having issues with plugin name and executable when they dont match but this will help for now.