### PR TITLE
fix: broken pip-url arg in slash command

### DIFF
--- a/.github/workflows/test-plugin-command.yml
+++ b/.github/workflows/test-plugin-command.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
     - name: Handle missing pip_url
-      if: github.event.inputs.from-slash-command == 'true'
+      if: github.event.inputs.from-slash-command == 'true' && github.event.inputs.pip-url == ''
       run: echo 'PIP_URL=${{ github.event.inputs.name }}' >> "$GITHUB_ENV"
 
     - name: Add 👀 reaction


### PR DESCRIPTION
This resolves an issue introduced when we started auto-executing from the git diff.

https://github.com/meltano/hub/commit/4b23af5e8179ca2b3c8e3f55c287d0def3d94981#diff-44877f17959acc8ff695de1b624f690461a4cd55f8263cadda6328a96d8fc3e3L38

Tested successfully via manual invocation here:

[meltano/hub/actions/runs/3824661063/jobs/6506995341](https://github.com/meltano/hub/actions/runs/3824661063/jobs/6506995341)