### PR TITLE
target-bigquery: Add placeholder for the Location

### DIFF
--- a/_data/meltano/loaders/target-bigquery/adswerve.yml
+++ b/_data/meltano/loaders/target-bigquery/adswerve.yml
@@ -26,8 +26,8 @@ settings:
 - description: Dataset Location. See https://cloud.google.com/bigquery/docs/locations.
   label: Region
   name: location
-  value: us-central1
   placeholder: us-central1
+  value: us-central1
 - description: |
     Fully qualified path to `client_secrets.json` for your service account.
 

--- a/_data/meltano/loaders/target-bigquery/adswerve.yml
+++ b/_data/meltano/loaders/target-bigquery/adswerve.yml
@@ -24,9 +24,10 @@ settings:
   name: dataset_id
   value: $MELTANO_EXTRACT__LOAD_SCHEMA
 - description: Dataset Location. See https://cloud.google.com/bigquery/docs/locations.
-  label: Location
+  label: Region
   name: location
-  value: US
+  value: us-central1
+  placeholder: us-central1
 - description: |
     Fully qualified path to `client_secrets.json` for your service account.
 


### PR DESCRIPTION
Having tried both US and EU as values with corresponding BigQuery datasets, I found that neither worked and should point to the `region` as linked to. Without setting the value to a good region the target requests an API endpoint that returns a 404 status code not making clear the region/location might be misconfigured.

All Singer definitions are stored in `/_data/taps/` or `/_data/targets`. The minimal requirement for adding a tap or target will match the following format:

## Checklist

- [X] Add/update the file in the appropriate folder (`/taps` or `/targets`). The name of the file should match the name of the tap. If there is already one, add a descriptor to the name such as `-search`.
- [-] Add/update the PNG logo image in `/assets/logos/<taps or targets>`. The image name must match the YAML file name.
- [x] Tag `@tayloramurphy` or `@pnadolny13` to flag it for review. Or post to the [#hub](https://meltano.slack.com/archives/C01UGBSJNG5) channel on Meltano slack.

## Reviewer Checklist

- [ ] Validate file against JSON Schema. https://www.jsonschema.net/home is an option.
- [ ] Build website locally and validate everything works.

Closes: https://github.com/meltano/hub/issues/1116