### PR TITLE
Adds loaders target-s3-parquet (jkausti)

### DIFF
--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -533,6 +533,10 @@ jjbarberio2:
   label: Jeff Barberio
   name: jjbarberio2
   url: https://github.com/jjbarberio2
+jkausti:
+  label: jkausti
+  name: jkausti
+  url: https://github.com/jkausti
 jmriego:
   label: jmriego
   url: https://github.com/jmriego

--- a/_data/meltano/loaders/target-s3-parquet/jkausti.yml
+++ b/_data/meltano/loaders/target-s3-parquet/jkausti.yml
@@ -1,0 +1,65 @@
+capabilities:
+- about
+- stream-maps
+- schema-flattening
+description: AWS S3 - Apache Parquet File Format
+domain_url: https://aws.amazon.com/s3/
+executable: target-s3
+keywords:
+- meltano_sdk
+label: S3 Parquet
+logo_url: /assets/logos/loaders/s3-parquet.png
+maintenance_status: active
+name: target-s3-parquet
+namespace: target_s3_parquet
+next_steps: ''
+pip_url: git+https://github.com/jkausti/target-s3.git
+repo: https://github.com/jkausti/target-s3
+settings:
+- description: AWS Access Key ID used to authenticate programmatically to S3.
+  kind: password
+  label: Aws Access Key Id
+  name: AWS_ACCESS_KEY_ID
+- description: AWS Secret Access Key used to authenticate programmatically to S3.
+  kind: password
+  label: Aws Secret Access Key
+  name: AWS_SECRET_ACCESS_KEY
+- description: The path to where the data should be stored. *REQUIRED*
+  kind: string
+  label: Path
+  name: path
+- description: "Determines the folder-structure. Alternatives are: 'simple', 'date_hierarchy'\
+    \ and 'both'."
+  kind: string
+  label: Folder Structure
+  name: folder_structure
+- description: Specifies the filetype to store the data as. Only parquet supported
+    atm. *REQUIRED*
+  kind: string
+  label: Filetype
+  name: filetype
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: "'True' to enable schema flattening and automatically expand nested\
+    \ properties."
+  kind: boolean
+  label: Flattening Enabled
+  name: flattening_enabled
+- description: The max depth to flatten schemas.
+  kind: integer
+  label: Flattening Max Depth
+  name: flattening_max_depth
+settings_group_validation:
+- - folder_structure
+  - filetype
+  - path
+settings_preamble: ''
+usage: ''
+variant: jkausti


### PR DESCRIPTION
From slack https://meltano.slack.com/archives/C013Z450LCD/p1673469356899909 this is a new variant that doesnt require the athena/glue dependency like the default variant does. The tap itself is actually generically named target-s3 but only supports parquet right now so I appended `-parquet` to match the pattern we have already on the hub. In the future if this gets more file type support we can also list it as a generic `target-s3`.