### PR TITLE
Add more tap/target maintenance content

### DIFF
--- a/static/markdown/add-a-tap.md
+++ b/static/markdown/add-a-tap.md
@@ -3,27 +3,21 @@ title: "Add a Tap or Target to Meltano Hub"
 description: "Find out how to get your plugins on the MeltanoHub"
 ---
 
-# Add a Tap to the MeltanoHub
+# Add a Plugin to the MeltanoHub
 
-1. Clone the MeltanoHub Repo & Create YAML File
+1. Clone the MeltanoHub Repo
 
 ```
 git clone git@github.com:meltano/hub.git
 ```
 
-All Singer definitions are stored in `/_data/meltano/extractors/` or `/_data/meltano/loaders/` and logo images are in /assets/logos/<extractors or loaders>. Add/update the file in the appropriate folder (`/taps` or `/targets`). The name of the file should match the name of the tap. If there is already one, add a descriptor to the name such as `-search`.
+2. Add or Update Plugin Definition
+
+All Singer definitions are stored in `/_data/meltano/extractors/` or `/_data/meltano/loaders/` and logo images are in /assets/logos/<extractors or loaders>. Each variant of a plugin is stored under a directory named after the plugin (e.g.`/_data/meltano/extractors/tap-github/meltanolabs.yml`).
 
 Use the following template to create your YAML file.
 
 ```yaml
-description: General description of what the company behind the API does
-label: Properly formatted label of the connector e.g. GitLab
-name: The unique name of the connector
-logo_url: /assets/logos/extractors/gitlab.png
-namespace: The namespace e.g. tap_gitlab
-variant: Name of the GitHub/GitLab namespace
-pip_url: git+<git_url>.git or pip install name
-repo: repo URL
 capabilities:
   # Chose the capabilities that the connector supports
   # Checkout for a list and details - https://hub.meltano.com/singer/docs#singer-connector-capabilities
@@ -49,34 +43,65 @@ capabilities:
   - hard-delete
   - datatype-failsafe
   - record-flattening
-settings_group_validation:
-  # The set of required settings.
-  - api_key
-  - start_date
-settings:
-  - name: api_key
-    label: API Key
-    kind: password
-    description: The API key for this source.
-  - name: start_date
-    label: Start date
-    description: Start date of when to start retrieve data from.
-  - name: my_other_setting
-    label: My Other Setting
-    description: Some other setting
+description: Code hosting platform # General description of what the company behind the API does
 domain_url: URL of the developer documentation or website
-maintenance_status: "Options: active, beta, development, inactive, unknown"
 keywords:
   # Attributes about the plugin for easier searching. Include `meltano_sdk` here if built using the SDK.
   # Other examples could be source type: `api`, `file`, `database`, etc. or cloud name `aws`, `gcp`, etc.
   - api
   - meltano_sdk
+label: GitHub
+logo_url: /assets/logos/extractors/github.png
+maintenance_status: active # Options: active, beta, development, inactive, unknown
+name: tap-github # The unique name of the connector
+namespace: tap_github # The namespace e.g. tap_github
+pip_url: git+<git_url>.git or pip install name
+repo: https://github.com/MeltanoLabs/tap-github
+settings:
+- name: api_key
+  label: API Key
+  kind: password
+  description: The API key for this source.
+- name: start_date
+  label: Start date
+  description: Start date of when to start retrieve data from.
+- name: my_other_setting
+  label: My Other Setting
+  description: Some other setting
+settings_group_validation:
+  # The set of required settings.
+  - api_key
+  - start_date
+variant: meltanolabs # the github namespace
 ```
 
-1. Add a Logo
+3. Add a Logo
 
-Add/update the PNG logo image in `/assets/logos/<taps or targets>`. The image name must match the YAML file name.
+Add or update the logo image in `/assets/logos/<extractors or loaders>`.
 
-1. Open a PR and Get your PR Reviewed
+4. Add or Update default_variants.yml
+
+If the plugin is new or if the default variant is changing then update the `/_data/default_variants.yml` file with the plugin name and its associated default variant name.
+
+5. Add or Update maintainers.yml
+
+The plugin variant name is usually the github namespaces that the plugin lives in.
+If its not already listed in `/_data/maintainers.yml` then they should be added along with a link and label.
+
+6. Lint Your Changes
+
+Optionally run the yaml_lint_fix.py script over the files you updated to make them conform with the yamlint settings for this repo.
+
+```
+poetry install
+poetry run python utility_scripts/plugin_definitions/yaml_lint_fix.py _data/meltano/extractors/tap-github/meltanolabs.yml
+poetry run python utility_scripts/plugin_definitions/yaml_lint_fix.py _data/default_variants.yml
+poetry run python utility_scripts/plugin_definitions/yaml_lint_fix.py _data/maintainers.yml
+```
+
+See the [CONTRIBUTING.md](https://github.com/meltano/hub/blob/main/CONTRIBUTING.md#linters) for more details.
+
+
+7. Open a PR and Get Your PR Reviewed
 
 [Open a pull request](https://github.com/meltano/hub/pulls) on the MeltanoHub repo and tag `@tayloramurphy` or `@pnadolny13` to flag it for review. You can optionally post to the [#hub](https://meltano.slack.com/archives/C01UGBSJNG5) channel on Meltano's [Slack](https://meltano.com/slack) workspace.

--- a/static/markdown/add-a-tap.md
+++ b/static/markdown/add-a-tap.md
@@ -58,16 +58,16 @@ namespace: tap_github # The namespace e.g. tap_github
 pip_url: git+<git_url>.git or pip install name
 repo: https://github.com/MeltanoLabs/tap-github
 settings:
-- name: api_key
-  label: API Key
-  kind: password
-  description: The API key for this source.
-- name: start_date
-  label: Start date
-  description: Start date of when to start retrieve data from.
-- name: my_other_setting
-  label: My Other Setting
-  description: Some other setting
+  - name: api_key
+    label: API Key
+    kind: password
+    description: The API key for this source.
+  - name: start_date
+    label: Start date
+    description: Start date of when to start retrieve data from.
+  - name: my_other_setting
+    label: My Other Setting
+    description: Some other setting
 settings_group_validation:
   # The set of required settings.
   - api_key
@@ -100,7 +100,6 @@ poetry run python utility_scripts/plugin_definitions/yaml_lint_fix.py _data/main
 ```
 
 See the [CONTRIBUTING.md](https://github.com/meltano/hub/blob/main/CONTRIBUTING.md#linters) for more details.
-
 
 7. Open a PR and Get Your PR Reviewed
 

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -92,7 +92,7 @@ None of these attributes alone will tell you what the best connectors are, so lo
 
 - <u>Organization backed connectors</u>: If its in the namespace of `meltano`/`meltanolabs`/`transferwise`/`singer-io`/ etc. its usually a good bet that the connector is maintained because one of the organizations is invested in it's success. Although this isn't always the case, especially with some of the older singer-io variants.
 - <u>MeltanoHub default</u>: The Meltano community does it's best to label the most active variant as the default on MeltanoHub. Although it's still possible that the best option is unmaintained.
-- <u>Meltano SDK</u>: If it uses the Meltano SDK then its a good sign that its relatively recent and has good support for common features. If there are many TODOs still in the repo that came with the cookiecutter it might indicate that the connector was never finished or is a hobby project.
+- <u>Meltano Singer SDK</u>: If it uses the Meltano Singer SDK then its a good sign that its relatively recent and has good support for common features. If there are many TODOs still in the repo that came with the cookiecutter it might indicate that the connector was never finished or is a hobby project.
 - <u>Stream coverage</u>: You can evaluate 2 variants against each other based on stream coverage. Sometimes a new variant is written that has more features but is only supporting a small number of streams.
 - <u>Latest commit timestamp</u>: If there are commits in the last couple months then its probably decently maintained.
 - <u>Total amount of commits</u>: If it only has a few commits it could still be in development, but if the latest timestamp is also a while ago it might indicate that it was a hobby project or never completed.

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -44,7 +44,7 @@ More users means more contributors and maintainers for your code base!
 
 ### Use the Meltano Singer SDK
 
-We might be a little biased on this one but using an SDK allows you to reduce code, increase reliability, comply with the Singer Spec, gain features with an SDK version upgrade, and work well within the Meltano community.
+Using the SDK allows you to reduce code, increase reliability, comply with the Singer Spec, gain features with an SDK version upgrade, and work well within the Meltano community. The SDK is maintained by Meltano and receives regular updates. Upgrading a tap built on the SDK is much easier than one that isn't.
 
 ## Common Patterns
 

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -32,14 +32,15 @@ Sometimes it's tempting to build a connector with only your exact needs baked in
 The most challenging part of using a community maintained connector is configuring it properly.
 Always make sure to document your configurations well.
 
-SDK based connectors have a [--about command option](https://sdk.meltano.com/en/latest/implementation/cli.html#about) that prints out the documented settings and descriptions from `tap.py`. MeltanoHub scrapes these settings and descriptions for building documentation so you should make sure to keep them up to date.
+SDK based connectors have a [--about command option](https://sdk.meltano.com/en/latest/implementation/cli.html#about) that prints out the documented settings and descriptions from `tap.py`. 
+Meltano Hub uses these settings and descriptions for documentation, so ensuring they're up to date makes it more useful for everyone.
 
 For non-SDK based connectors you will commonly find an example config.json in the repo.
 The Meltano community has also invested in documenting these on MeltanoHub for your convenience.
 
 ### Advertise It On Meltano Hub
 
-Once your connector is functioning and ready to go, make sure you get it listed on MeltanoHub (see [docs](/add-a-tap)) so others can find it.
+Once your connector is functioning and ready to go, make sure you get it listed on Meltano Hub (see [docs](/add-a-tap)) so others can find it.
 More users means more contributors and maintainers for your code base!
 
 ### Use the Meltano Singer SDK
@@ -48,30 +49,32 @@ Using the SDK allows you to reduce code, increase reliability, comply with the S
 
 ## Common Patterns
 
-Since Singer is only a spec (see Meltano's [Singer Spec docs](http://localhost:8080/singer/docs#singer-spec)) for how data should be formatted and passed between connectors there have become many common patterns, tools, and SDKs to help speed the process up.
+Since Singer is a primarily a specification for data formatting and transfer(see Meltano's [Singer Spec docs](http://localhost:8080/singer/docs#singer-spec)) there have become many common patterns, tools, and SDKs to help build connectors and pipelines more efficiently.
 
 #### [singer-io](https://github.com/singer-io)
 
 - Mostly from scratch implementations, using the [singer-python](https://github.com/singer-io/singer-python) library for some shared methods
 - Commonly have most of the code in the module's `__init__.py` file with a `main` method
-- Logic for parsing cli inputs uses argparse and is required by every connector
+- Logic for parsing CLI inputs uses argparse and is required by every connector
 - A `REQUIRED_CONFIG_KEYS` list to validate required config values
 - Dependencies are usually in the setup.py vs in requirements.txt
 - Very few target examples because they we're originally built to always send data to the [Stitch](https://www.stitchdata.com/) service with [target-stitch](https://github.com/singer-io/target-stitch)
 - Usually unit tests are limited
-- The developer needs to know internal rules like when its safe to write state messages or how to handle ACTIVATE_VERSION messages
+- The developer needs to know internal rules like when its safe to write state messages or how to handle advanced features like `ACTIVATE_VERSION` messages
 - The `catalog` input file was originally called `properties` so some will accept either
 - [Getting started guide](https://github.com/singer-io/getting-started)
 - [tap template](https://github.com/singer-io/singer-tap-template)
 
 #### [Meltano Singer SDK](https://sdk.meltano.com/en/latest/) Based Connectors
 
-A software development kit that abstracts many of the challenges of building Singer connectors so the developer doesn't need to know about them and also provides accelerators to speed up the process of writing a new connector. See the [Meltano SDK](https://sdk.meltano.com/en/latest/) docs for more details. Example of some features:
+A software development kit that abstracts many of the challenges of building Singer connectors so the developer doesn't need to know about them and also provides accelerators to speed up the process of writing a new connector. 
+See the [Meltano SDK](https://sdk.meltano.com/en/latest/) docs for more details. Example of some features:
 
 - cookiecutter templates to seed a connector repo
 - manages translating records into Singer spec compliant messages
 - methods for common API functionality (i.e. parent child relationships, pagination, retry, post processing, etc.)
 - methods for common SQL functionality
+- native support for advanced features such as BATCH messaging and the ACTIVATE_VERSION sync strategy
 - default unit tests
 - additional features for testing, printing config metadata,
 

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -42,7 +42,7 @@ The Meltano community has also invested in documenting these on MeltanoHub for y
 Once your connector is functioning and ready to go, make sure you get it listed on MeltanoHub (see [docs](/add-a-tap)) so others can find it.
 More users means more contributors and maintainers for your code base!
 
-### Use Meltano SDK
+### Use the Meltano Singer SDK
 
 We might be a little biased on this one but using an SDK allows you to reduce code, increase reliability, comply with the Singer Spec, gain features with an SDK version upgrade, and work well within the Meltano community.
 

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -37,12 +37,10 @@ SDK based connectors have a [--about command option](https://sdk.meltano.com/en/
 For non-SDK based connectors you will commonly find an example config.json in the repo.
 The Meltano community has also invested in documenting these on MeltanoHub for your convenience.
 
-
 ### Advertise It On Meltano Hub
 
 Once your connector is functioning and ready to go, make sure you get it listed on MeltanoHub (see [docs](/add-a-tap)) so others can find it.
 More users means more contributors and maintainers for your code base!
-
 
 ### Use Meltano SDK
 
@@ -75,13 +73,13 @@ A software development kit that abstracts many of the challenges of building Sin
 - methods for common API functionality (i.e. parent child relationships, pagination, retry, post processing, etc.)
 - methods for common SQL functionality
 - default unit tests
-- additional features for testing, printing config metadata, 
+- additional features for testing, printing config metadata,
 
 #### [Pipelinewise](https://github.com/transferwise/pipelinewise)
+
 - An open source tool created in 2019 that helps configure and run Singer connectors, similar to Meltano
 - Maintains its own list of connectors that it supports. You can also run all of these with Meltano!
 - Well documented patterns around [metadata columns](https://transferwise.github.io/pipelinewise/user_guide/metadata_columns.html), [replication methods](https://transferwise.github.io/pipelinewise/concept/replication_methods.html), and [schema changes](https://transferwise.github.io/pipelinewise/user_guide/schema_changes).
-
 
 ## Evaluating a tap or target
 
@@ -140,6 +138,7 @@ Please see the [MeltanoLabs Meta repo](https://github.com/MeltanoLabs/Meta) for 
 Taps will occasionally become dormant as maintainers change jobs, companies shift priorities, or individual maintainers don't have enough time.
 
 ## FAQs
+
 ### What is considered an unmaintained tap?
 
 Here are some signs that a tap or target has been abandoned:
@@ -158,18 +157,20 @@ Open an issue on the [Singer Most Wanted repository](https://github.com/MeltanoL
 Usually the Meltano community can help determine the best path forward but the options are usually:
 
 1. Fork it to your personal or organization's GitHub namespace:
+
 - Create a fork of the project
 - Make your changes
 - Add your fork to Meltano Hub and make it the new default
 
 2. Communicate with the current owner:
+
 - If the maintainer prefers you can become a maintainer on their repo
 
 3. Migrate it to MeltanoLabs:
+
 - See [MeltanoLabs README](https://github.com/MeltanoLabs/Meta#adding-a-new-connector) for details on transferring the repo
 - Make your changes
 - Update Meltano Hub and make it the new default
-
 
 ### What if I want to update a tap but don't want to maintain it long term?
 

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -3,16 +3,116 @@ title: "Maintaining Taps & Targets"
 description: "Find out how to maintain Singer taps and targets using the Meltano Singer SDK and Meltano Hub"
 ---
 
-## Tap & Target Maintenance
+# Tap & Target Maintenance
 
 Thanks for your interest in maintaining a tap or target! Here are some best practices and FAQs for contributing to and maintaining these projects.
+
+The Singer community was started by Stitch in 2017 and since then many conventions and best practices have been adopted but are commonly unspoken or not explicitly documented which can be intimidating to newcomers.
+This document is meant to memorialize some of the ways that the Singer community operates to make it easier to join, contribute, and benefit from.
+
+## Best Practices
+
+### Avoid Creating a New Variant When Possible
+
+It's not uncommon in the Singer community (and the open source ecosystem in general) to see people fork a repo in order to add a single feature or bug fix but never get it merged to the upstream repo.
+This approach may solve the short term problem but requires you to take on the burden of maintaining the repo moving forward.
+By contributing back to the upstream you benefit the community and you can free yourself from maintaining your variant moving forward.
+If everyone in our community puts their effort into maintaining the same connectors then we all benefit from less work and better quality.
+
+### Favor Generically Useful vs Custom or Hardcoded Logic
+
+Sometimes it's tempting to build a connector with only your exact needs baked in. For example only adding the streams you need or hard coding organization specific logic like account names, how credentials are sourced, etc. But with a little extra effort you can make it generically useful enough to attract other community members to use and help maintain your code.
+
+- Add as much stream coverage as you can
+- All configs should flow through the config.json input file
+- No hardcoded values and logic, or at least not by default
+
+### Document Settings Well
+
+The most challenging part of using a community maintained connector is configuring it properly.
+Always make sure to document your configurations well.
+
+SDK based connectors have a [--about command option](https://sdk.meltano.com/en/latest/implementation/cli.html#about) that prints out the documented settings and descriptions from `tap.py`. MeltanoHub scrapes these settings and descriptions for building documentation so you should make sure to keep them up to date.
+
+For non-SDK based connectors you will commonly find an example config.json in the repo.
+The Meltano community has also invested in documenting these on MeltanoHub for your convenience.
+
+
+### Advertise It On Meltano Hub
+
+Once your connector is functioning and ready to go, make sure you get it listed on MeltanoHub (see [docs](/add-a-tap)) so others can find it.
+More users means more contributors and maintainers for your code base!
+
+
+### Use Meltano SDK
+
+We might be a little biased on this one but using an SDK allows you to reduce code, increase reliability, comply with the Singer Spec, gain features with an SDK version upgrade, and work well within the Meltano community.
+
+## Common Patterns
+
+Since Singer is only a spec (see Meltano's [Singer Spec docs](http://localhost:8080/singer/docs#singer-spec)) for how data should be formatted and passed between connectors there have become many common patterns, tools, and SDKs to help speed the process up.
+
+#### [singer-io](https://github.com/singer-io)
+
+- Mostly from scratch implementations, using the [singer-python](https://github.com/singer-io/singer-python) library for some shared methods
+- Commonly have most of the code in the module's `__init__.py` file with a `main` method
+- Logic for parsing cli inputs uses argparse and is required by every connector
+- A `REQUIRED_CONFIG_KEYS` list to validate required config values
+- Dependencies are usually in the setup.py vs in requirements.txt
+- Very few target examples because they we're originally built to always send data to the [Stitch](https://www.stitchdata.com/) service with [target-stitch](https://github.com/singer-io/target-stitch)
+- Usually unit tests are limited
+- The developer needs to know internal rules like when its safe to write state messages or how to handle ACTIVATE_VERSION messages
+- The `catalog` input file was originally called `properties` so some will accept either
+- [Getting started guide](https://github.com/singer-io/getting-started)
+- [tap template](https://github.com/singer-io/singer-tap-template)
+
+#### [Meltano SDK](https://sdk.meltano.com/en/latest/) Based Connectors
+
+A software development kit that abstracts many of the challenges of building Singer connectors so the developer doesn't need to know about them and also provides accelerators to speed up the process of writing a new connector. See the [Meltano SDK](https://sdk.meltano.com/en/latest/) docs for more details. Example of some features:
+
+- cookiecutter templates to seed a connector repo
+- manages translating records into Singer spec compliant messages
+- methods for common API functionality (i.e. parent child relationships, pagination, retry, post processing, etc.)
+- methods for common SQL functionality
+- default unit tests
+- additional features for testing, printing config metadata, 
+
+#### [Pipelinewise](https://github.com/transferwise/pipelinewise)
+- An open source tool created in 2019 that helps configure and run Singer connectors, similar to Meltano
+- Maintains its own list of connectors that it supports. You can also run all of these with Meltano!
+- Well documented patterns around [metadata columns](https://transferwise.github.io/pipelinewise/user_guide/metadata_columns.html), [replication methods](https://transferwise.github.io/pipelinewise/concept/replication_methods.html), and [schema changes](https://transferwise.github.io/pipelinewise/user_guide/schema_changes).
+
+
+## Evaluating a tap or target
+
+These are things you can look for when evaluating a tap or target.
+Many of these recommendations can be used for evaluating open source projects in general.
+
+You should start by looking on MeltanoHub to find and evaluate connectors.
+Although a connector can still be listed if its not well maintained so click through to the repo to inspect it closer if you're unsure.
+None of these attributes alone will tell you what the best connectors are, so look at many of them to make a holistic evaluation.
+
+- <u>Organization backed connectors</u>: If its in the namespace of `meltano`/`meltanolabs`/`transferwise`/`singer-io`/ etc. its usually a good bet that the connector is maintained because one of the organizations is invested in it's success. Although this isn't always the case, especially with some of the older singer-io variants.
+- <u>MeltanoHub default</u>: The Meltano community does it's best to label the most active variant as the default on MeltanoHub. Although it's still possible that the best option is unmaintained.
+- <u>Meltano SDK</u>: If it uses the Meltano SDK then its a good sign that its relatively recent and has good support for common features. If there are many TODOs still in the repo that came with the cookiecutter it might indicate that the connector was never finished or is a hobby project.
+- <u>Stream coverage</u>: You can evaluate 2 variants against each other based on stream coverage. Sometimes a new variant is written that has more features but is only supporting a small number of streams.
+- <u>Latest commit timestamp</u>: If there are commits in the last couple months then its probably decently maintained.
+- <u>Total amount of commits</u>: If it only has a few commits it could still be in development, but if the latest timestamp is also a while ago it might indicate that it was a hobby project or never completed.
+- <u>Open Pull Requests</u>: Are there pending PRs that aren't being addressed?
+- <u>Open Issues</u>: Are there many open issues that aren't being addressed? Lots of issues could also mean that it has high traffic and many feature requests so look closely at what the issues are for.
+- <u>Forks</u>: How many forks are there? It could indicate that people need to fork it to fix bugs or update dependencies before they got it working.
+- <u>Network Insights</u>: GitHub has a [network insights](https://docs.github.com/en/repositories/viewing-activity-and-data-for-your-repository/understanding-connections-between-repositories) feature that allows you to see forks of the repo and recent commits. Sometimes this reveals a fork that is more active than the main repo, potentially indicating that the fork is the new best variant.
+
+## FAQs
 
 ### How are targets marked as "maintained" and "unmaintained"? What does a well-maintained tap or target look like?
 
 There are no hard requirements for maintainership, but well-maintained taps typically follow these guidelines:
 
 - Issues and PRs/MRs responded to within a week.
-- All settings documented, with additional documentation containing useage examples.
+- All settings documented, with additional documentation containing usage examples.
+- Dependencies regularly updated
+- Support for the recent Python versions
 
 ### How do I add my tap or target to the Meltano Hub?
 
@@ -28,14 +128,17 @@ If you'd like to port your tap or target to the Meltano Singer SDK, please see t
 
 If you're taking over maintanership of a tap that hasn't yet been ported, it's best to get the existing tap working again before porting it over to the SDK. If you're not ready to port it just yet, please open an issue on your repo and tell us in `#contributing` on [Slack](https://meltano.com/slack). We may be able to find someone to help you.
 
-#### How do I flag a tap that should be migrated to the SDK for community prioritization?
+### How do I flag a tap that should be migrated to the SDK for community prioritization?
 
 Please open an issue on the [Singer Most Wanted repo](https://github.com/MeltanoLabs/Singer-Most-Wanted/issues) to let the community know that a tap or target needs porting. We can try to find someone to port it.
 
-## Unmaintained Taps and Targets
+# Unmaintained Taps and Targets
 
-Taps will occasionally become dormant as maintainers change jobs or companies shift priorities.
+Taps will occasionally become dormant as maintainers change jobs, companies shift priorities, or individual maintainers don't have enough time.
 
+
+
+## FAQs
 ### What is considered an unmaintained tap?
 
 Here are some signs that a tap or target has been abandoned:
@@ -51,17 +154,25 @@ Open an issue on the [Singer Most Wanted repository](https://github.com/MeltanoL
 
 ### How do I take over maintenance of a tap or target?
 
-- Create a fork of the project and make your changes
-- Add to Meltano Hub
+Usually the Meltano community can help determine the best path forward but the options are usually:
+
+Fork it to your personal or organization's GitHub namespace:
+- Create a fork of the project
+- Make your changes
+- Add your fork to Meltano Hub and make it the new default
+
+Communicate with the current owner:
+- If the maintainer prefers you can become a maintainer on their repo
+
 
 ### What if I want to update a tap but don't want to maintain it long term?
 
 Not a problem! Please open an issue on the [Singer Most Wanted repo](https://github.com/MeltanoLabs/Singer-Most-Wanted/issues) to let the Meltano Community know that a tap needs a maintainer. We can help find someone to maintain it.
 
-## Where do I go if I want to pay someone to build a tap or add a feature?
+### Where do I go if I want to pay someone to build a tap or add a feature?
 
 Please reach out to one of our [Partners](https://meltano.com/partners/) to discuss custom taps and targets.
 
-## How do I escalate an issue if it’s not being recognized by the maintainer?
+### How do I escalate an issue if it’s not being recognized by the maintainer?
 
 Please join the #contributing channel on [Slack](https://meltano.com/slack) and tag `@Amanda Folson` along with a link to the issue.

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -32,7 +32,7 @@ Sometimes it's tempting to build a connector with only your exact needs baked in
 The most challenging part of using a community maintained connector is configuring it properly.
 Always make sure to document your configurations well.
 
-SDK based connectors have a [--about command option](https://sdk.meltano.com/en/latest/implementation/cli.html#about) that prints out the documented settings and descriptions from `tap.py`. 
+SDK based connectors have a [--about command option](https://sdk.meltano.com/en/latest/implementation/cli.html#about) that prints out the documented settings and descriptions from `tap.py`.
 Meltano Hub uses these settings and descriptions for documentation, so ensuring they're up to date makes it more useful for everyone.
 
 For non-SDK based connectors you will commonly find an example config.json in the repo.
@@ -49,7 +49,7 @@ Using the SDK allows you to reduce code, increase reliability, comply with the S
 
 ## Common Patterns
 
-Since Singer is a primarily a specification for data formatting and transfer(see Meltano's [Singer Spec docs](http://localhost:8080/singer/docs#singer-spec)) there have become many common patterns, tools, and SDKs to help build connectors and pipelines more efficiently.
+Since Singer is a primarily a specification for data formatting and transfer(see Meltano's [Singer Spec docs](/singer/docs#singer-spec)) there have become many common patterns, tools, and SDKs to help build connectors and pipelines more efficiently.
 
 #### [singer-io](https://github.com/singer-io)
 
@@ -67,7 +67,7 @@ Since Singer is a primarily a specification for data formatting and transfer(see
 
 #### [Meltano Singer SDK](https://sdk.meltano.com/en/latest/) Based Connectors
 
-A software development kit that abstracts many of the challenges of building Singer connectors so the developer doesn't need to know about them and also provides accelerators to speed up the process of writing a new connector. 
+A software development kit that abstracts many of the challenges of building Singer connectors so the developer doesn't need to know about them and also provides accelerators to speed up the process of writing a new connector.
 See the [Meltano SDK](https://sdk.meltano.com/en/latest/) docs for more details. Example of some features:
 
 - cookiecutter templates to seed a connector repo

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -64,7 +64,7 @@ Since Singer is only a spec (see Meltano's [Singer Spec docs](http://localhost:8
 - [Getting started guide](https://github.com/singer-io/getting-started)
 - [tap template](https://github.com/singer-io/singer-tap-template)
 
-#### [Meltano SDK](https://sdk.meltano.com/en/latest/) Based Connectors
+#### [Meltano Singer SDK](https://sdk.meltano.com/en/latest/) Based Connectors
 
 A software development kit that abstracts many of the challenges of building Singer connectors so the developer doesn't need to know about them and also provides accelerators to speed up the process of writing a new connector. See the [Meltano SDK](https://sdk.meltano.com/en/latest/) docs for more details. Example of some features:
 

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -157,13 +157,18 @@ Open an issue on the [Singer Most Wanted repository](https://github.com/MeltanoL
 
 Usually the Meltano community can help determine the best path forward but the options are usually:
 
-Fork it to your personal or organization's GitHub namespace:
+1. Fork it to your personal or organization's GitHub namespace:
 - Create a fork of the project
 - Make your changes
 - Add your fork to Meltano Hub and make it the new default
 
-Communicate with the current owner:
+2. Communicate with the current owner:
 - If the maintainer prefers you can become a maintainer on their repo
+
+3. Migrate it to MeltanoLabs:
+- See [MeltanoLabs README](https://github.com/MeltanoLabs/Meta#adding-a-new-connector) for details on transferring the repo
+- Make your changes
+- Update Meltano Hub and make it the new default
 
 
 ### What if I want to update a tap but don't want to maintain it long term?

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -114,13 +114,12 @@ There are no hard requirements for maintainership, but well-maintained taps typi
 - Dependencies regularly updated
 - Support for the recent Python versions
 
+The Meltano community does it's best to mark the best connectors as the default variant on Meltano Hub.
+If you think the default should be different, open an issue!
+
 ### How do I add my tap or target to the Meltano Hub?
 
 Please follow the steps outlined in [this guide](/add-a-tap) and the PR request template.
-
-### How can I become a maintainer in MeltanoLabs? How do I stop being a maintainer?
-
-Please see the [MeltanoLabs Meta repo](https://github.com/MeltanoLabs/Meta) for more information on how we manage this organization.
 
 ### Porting Singer Taps to the Meltano Singer SDK for Taps and Targets
 
@@ -132,11 +131,13 @@ If you're taking over maintanership of a tap that hasn't yet been ported, it's b
 
 Please open an issue on the [Singer Most Wanted repo](https://github.com/MeltanoLabs/Singer-Most-Wanted/issues) to let the community know that a tap or target needs porting. We can try to find someone to port it.
 
+### How can I become a maintainer in MeltanoLabs? How do I stop being a maintainer?
+
+Please see the [MeltanoLabs Meta repo](https://github.com/MeltanoLabs/Meta) for more information on how we manage this organization.
+
 # Unmaintained Taps and Targets
 
 Taps will occasionally become dormant as maintainers change jobs, companies shift priorities, or individual maintainers don't have enough time.
-
-
 
 ## FAQs
 ### What is considered an unmaintained tap?

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -45,7 +45,7 @@ More users means more contributors and maintainers for your code base!
 
 ### Use the Meltano Singer SDK
 
-Using the SDK allows you to reduce code, increase reliability, comply with the Singer Spec, gain features with an SDK version upgrade, and work well within the Meltano community. The SDK is maintained by Meltano and receives regular updates. Upgrading a tap built on the SDK is much easier than one that isn't.
+Using the SDK allows you to reduce code, increase reliability, comply with the Singer Spec, gain features with an SDK version upgrade, and work well within the Meltano community. The SDK is maintained by Meltano and receives regular updates. The SDK also has tons of [valuable pre-written tests](https://sdk.meltano.com/en/latest/testing.html) that you can take advantage of with only a few lines of code, allowing you to maintain and upgrade your tap or target with more confidence and less manual testing effort.
 
 ## Common Patterns
 

--- a/static/markdown/tap-target-maintenance.md
+++ b/static/markdown/tap-target-maintenance.md
@@ -94,7 +94,7 @@ None of these attributes alone will tell you what the best connectors are, so lo
 - <u>MeltanoHub default</u>: The Meltano community does it's best to label the most active variant as the default on MeltanoHub. Although it's still possible that the best option is unmaintained.
 - <u>Meltano Singer SDK</u>: If it uses the Meltano Singer SDK then its a good sign that its relatively recent and has good support for common features. If there are many TODOs still in the repo that came with the cookiecutter it might indicate that the connector was never finished or is a hobby project.
 - <u>Stream coverage</u>: You can evaluate 2 variants against each other based on stream coverage. Sometimes a new variant is written that has more features but is only supporting a small number of streams.
-- <u>Latest commit timestamp</u>: If there are commits in the last couple months then its probably decently maintained.
+- <u>Latest commit timestamp</u>: If there are commits in the last couple months then its probably decently maintained. However, many APIs can be quite stable, so a lack of commits does not mean the connector does not work.
 - <u>Total amount of commits</u>: If it only has a few commits it could still be in development, but if the latest timestamp is also a while ago it might indicate that it was a hobby project or never completed.
 - <u>Open Pull Requests</u>: Are there pending PRs that aren't being addressed?
 - <u>Open Issues</u>: Are there many open issues that aren't being addressed? Lots of issues could also mean that it has high traffic and many feature requests so look closely at what the issues are for.


### PR DESCRIPTION
- add best practices section to encourage more collaborating vs always forking, general features, well documented settings, etc.
- add common patterns section to explain the state of the community and different singer connector styles
- add evaluating a connector sections to be explicit about what they should look for. We know these things from being in the community but theyre learned over time and never documented anywhere
- some slight reformatting of headers to make the page a little more readable. Our styling is a little funky on the hub so its hard to read.