### PR TITLE
read metrics from new aws account s3 bucket

### DIFF
--- a/utility_scripts/build/build_with_metrics.sh
+++ b/utility_scripts/build/build_with_metrics.sh
@@ -20,7 +20,7 @@ aws_access_key_id = $ENV_ACCESS_KEY_ID
 EOL
 
 # Grab files
-~/aws-cli/bin/aws s3 cp s3://prod-meltano-bucket-01/hub_metrics/variant_metrics.yml ./_data/variant_metrics.yml 
-~/aws-cli/bin/aws s3 cp s3://prod-meltano-bucket-01/hub_metrics/audit.yml ./_data/audit.yml
+~/aws-cli/bin/aws s3 cp s3://hub-metrics-b8ba2d5/prod/hub_metrics/variant_metrics.yml ./_data/variant_metrics.yml 
+~/aws-cli/bin/aws s3 cp s3://hub-metrics-b8ba2d5/prod/hub_metrics/audit.yml ./_data/audit.yml
 
 gridsome build


### PR DESCRIPTION
Related to https://github.com/meltano/squared/issues/247

- Squared is now writing to the new AWS account/bucket
- This makes the update to read from that bucket

Melissa created `Hub Metrics Bucket Read Access` in the 1Pass vault that is able to read the metrics files from the new S3 bucket. 

@rwfeather @cjohnhanson could one of you review this and also update the settings in this repo to use those new AWS credentials from 1Pass? I don't have access to do that.

cc @magreenbaum @tayloramurphy 