### PR TITLE
chore: declare `jsonl` support in ets/tap-spreadsheets-anywhere

### DIFF
--- a/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
+++ b/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
@@ -10,6 +10,7 @@ keywords:
 - csv
 - tsv
 - json
+- jsonl
 - ssh
 - scp
 - sftp


### PR DESCRIPTION
Per this PR: 

- https://github.com/ets/tap-spreadsheets-anywhere/pull/28
