### PR TITLE
add api schema tests back in

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -63,6 +63,10 @@ jobs:
         --hub-url ${{ env.HUB_URL }}
         --api-url ${{ env.API_URL }}
 
+    - name: Test API
+      run: >
+        poetry run python utility_scripts/api/api_schema_validate.py
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v3.1.1
       with:

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -63,7 +63,7 @@ jobs:
         --hub-url ${{ env.HUB_URL }}
         --api-url ${{ env.API_URL }}
 
-    - name: Test API
+    - name: Test API Schema
       run: >
         poetry run python utility_scripts/api/api_schema_validate.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 *.DS_Store
 .vscode
 .idea
+_hub_api*

--- a/_data/meltano/transformers/dbt/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt/dbt-labs.yml
@@ -40,6 +40,7 @@ commands:
     description: Runs tests on data in deployed models.
 docs: https://docs.meltano.com/guide/transformation
 domain_url: https://www.getdbt.com/
+hidden: true
 label: dbt
 logo_url: /assets/logos/transformers/dbt.png
 maintenance_status: active

--- a/_data/meltano/transformers/dbt/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt/dbt-labs.yml
@@ -40,7 +40,6 @@ commands:
     description: Runs tests on data in deployed models.
 docs: https://docs.meltano.com/guide/transformation
 domain_url: https://www.getdbt.com/
-hidden: true
 label: dbt
 logo_url: /assets/logos/transformers/dbt.png
 maintenance_status: active

--- a/schemas/plugin_definitions/files.schema.json
+++ b/schemas/plugin_definitions/files.schema.json
@@ -38,7 +38,8 @@
                 "next_steps": {},
                 "settings_preamble": {},
                 "usage": {},
-                "prereq": {}
+                "prereq": {},
+                "hidden": {}
             }
         }
     ]

--- a/schemas/plugin_definitions/mappers.schema.json
+++ b/schemas/plugin_definitions/mappers.schema.json
@@ -37,7 +37,8 @@
                 "next_steps": {},
                 "settings_preamble": {},
                 "usage": {},
-                "prereq": {}
+                "prereq": {},
+                "hidden": {}
             }
         }
     ]

--- a/schemas/plugin_definitions/orchestrators.schema.json
+++ b/schemas/plugin_definitions/orchestrators.schema.json
@@ -35,7 +35,8 @@
                 "next_steps": {},
                 "settings_preamble": {},
                 "usage": {},
-                "prereq": {}
+                "prereq": {},
+                "hidden": {}
             }
         }
     ]

--- a/schemas/plugin_definitions/transformers.schema.json
+++ b/schemas/plugin_definitions/transformers.schema.json
@@ -35,7 +35,8 @@
                 "next_steps": {},
                 "settings_preamble": {},
                 "usage": {},
-                "prereq": {}
+                "prereq": {},
+                "hidden": {}
             }
         }
     ]

--- a/schemas/plugin_definitions/transforms.schema.json
+++ b/schemas/plugin_definitions/transforms.schema.json
@@ -35,7 +35,8 @@
                 "next_steps": {},
                 "settings_preamble": {},
                 "usage": {},
-                "prereq": {}
+                "prereq": {},
+                "hidden": {}
             }
         }
     ]

--- a/schemas/plugin_definitions/utilities.schema.json
+++ b/schemas/plugin_definitions/utilities.schema.json
@@ -36,7 +36,8 @@
                 "next_steps": {},
                 "settings_preamble": {},
                 "usage": {},
-                "prereq": {}
+                "prereq": {},
+                "hidden": {}
             }
         }
     ]

--- a/utility_scripts/api/api_schema_validate.py
+++ b/utility_scripts/api/api_schema_validate.py
@@ -15,11 +15,11 @@ logger = logging.getLogger(os.path.basename(__file__))
 class APIValidator:
     """Validates the Meltano plugin API content."""
 
-    def __init__(self, file_path="_site/meltano/api/v1/plugins/"):
+    def __init__(self, file_path="_hub_api/plugins/"):
         """Initialize APIValidator.
 
         Args:
-            file_path: Path to Meltano API files. Defaults to "meltano/api/v1/plugins/".
+            file_path: Path to Meltano API files. Defaults to "_hub_api/plugins/".
         """
         self.file_path = file_path
         self._set_schema_store()

--- a/utility_scripts/api/make_files.py
+++ b/utility_scripts/api/make_files.py
@@ -156,6 +156,9 @@ class ApiBuilder:
                         default_variant_logo = definition.get("logo_url")
 
                 # Add to plugin type index
+                if plugin_name.startswith('.'):
+                    continue
+                    # raise Exception(plugin_name, plugin_type, plugin_path)
                 plugin_type_index[plugin_name] = {
                     "default_variant": default_variant,
                     "variants": variants,

--- a/utility_scripts/api/make_files.py
+++ b/utility_scripts/api/make_files.py
@@ -26,6 +26,16 @@ SKIP_FIELDS = [
     "prereq",
 ]
 
+SKIP_FIELDS_BY_TYPE = {
+    "extractors": SKIP_FIELDS + [],
+    "loaders": SKIP_FIELDS + [],
+    "transformers": SKIP_FIELDS + ["hidden"],
+    "utilities": SKIP_FIELDS + ["hidden"],
+    "transforms": SKIP_FIELDS + ["hidden"],
+    "orchestrators": SKIP_FIELDS + ["hidden"],
+    "mappers": SKIP_FIELDS + ["hidden"],
+    "files": SKIP_FIELDS + ["hidden"],
+}
 
 class PluginType(str, enum.Enum):
     """Plugin types."""
@@ -131,7 +141,7 @@ class ApiBuilder:
                         "docs"
                     ] = f"{self.base_hub_url}/{plugin_type}/{plugin_full_name}"
 
-                    for field in SKIP_FIELDS:
+                    for field in SKIP_FIELDS_BY_TYPE.get(plugin_type):
                         definition.pop(field, None)
 
                     # -- End plugin definition cleanup
@@ -155,10 +165,9 @@ class ApiBuilder:
                     if variant == default_variant:
                         default_variant_logo = definition.get("logo_url")
 
-                # Add to plugin type index
                 if plugin_name.startswith('.'):
                     continue
-                    # raise Exception(plugin_name, plugin_type, plugin_path)
+                # Add to plugin type index
                 plugin_type_index[plugin_name] = {
                     "default_variant": default_variant,
                     "variants": variants,

--- a/utility_scripts/plugin_definitions/plugin_schema_validate.py
+++ b/utility_scripts/plugin_definitions/plugin_schema_validate.py
@@ -30,10 +30,16 @@ class PluginSchemaValidator:
     def _set_schema_store(self, schemas_dir='plugin_definitions'):
         self.schema_store = {}
         for source in Path("schemas/common").iterdir():
+            if not source.name.endswith('.json'):
+                # Skip non schema files
+                continue
             with open(source) as schema_file:
                 schema = json.load(schema_file)
                 self.schema_store[schema["$id"]] = schema
         for source in Path(f"schemas/{schemas_dir}").iterdir():
+            if not source.name.endswith('.json'):
+                # Skip non schema files
+                continue
             with open(source) as schema_file:
                 schema = json.load(schema_file)
                 self.schema_store[schema["$id"]] = schema
@@ -63,6 +69,9 @@ class PluginSchemaValidator:
         """Iterate plugin defintions and validate against JSON schemas."""
         logger.info("Schema validation started...")
         for plugin_category in os.listdir(self.file_path):
+            if plugin_category.startswith('.'):
+                # Skip non plugin definition files
+                continue
             logger.info(f"Validating schema for plugin type: {plugin_category}")
             schema = self._read_json_schema(f"{plugin_category}.schema.json")
             plugin_count = 0
@@ -70,6 +79,9 @@ class PluginSchemaValidator:
             for plugin_name in os.listdir(
                 os.path.join(self.file_path, plugin_category)
             ):
+                if plugin_name.startswith('.'):
+                    # Skip non plugin definition files
+                    continue
                 for variant_name in os.listdir(
                     os.path.join(self.file_path, plugin_category, plugin_name)
                 ):


### PR DESCRIPTION
@tayloramurphy as part of adding `hidden` flags to files bundles [we got a test failure](https://github.com/meltano/hub/pull/1135#issuecomment-1412365864) because the schemas dont accept those flags. This also raised to me the fact that we stopped testing the schema of the generated API which is concerning because what we allow in the plugin definitions and in the API are not the same e.g. usage, next_steps, etc. Luckily nothing is violating the schema though 😅 .

I can make `hidden` an acceptable attribute in the plugin definition but I'm not sure if we want it to be exposed as part of the API, like it is today with extractors/loaders. I'd lean towards no because we're mostly using the flag to hide or show in the hub but I know the hidden attribute also affects what shows up in the deprecated meltano UI.