### PR TITLE
fix command docs, remove args

### DIFF
--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -3,7 +3,9 @@
     <p class="text-3xl py-4" id="commands">Commands</p>
     <span
       >The {{ name }} {{ plugin_type }} supports the following commands that can be used with
-      <pre><code>meltano invoke</code></pre>
+      <a href="https://docs.meltano.com/reference/command-line-interface#invoke">
+        <pre><code>meltano invoke</code></pre>
+      </a>
       :</span
     >
     <div v-for="(command, key, index) in commands" v-bind:key="index">


### PR DESCRIPTION
We currently show a [command section](https://hub.meltano.com/utilities/airflow#commands) on the utility pages that says you can run `meltano invoke airflow:create-admin [args...]` but I think this is a typo. You either have to not include the colon to run with args or no args are allowed. I'm not sure what way we want to recommend in the docs but this PR removes the reference to args.

