### PR TITLE
fix superset docs and pin conflicting dependency

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -598,4 +598,4 @@ utilities:
   notebook: matatika
   postgres: postgres
   sqlfluff: sqlfluff
-  superset: apache
+  superset: meltano

--- a/_data/meltano/utilities/superset/apache.yml
+++ b/_data/meltano/utilities/superset/apache.yml
@@ -67,7 +67,7 @@ next_steps: |
      utilities:
      - name: superset
        variant: apache
-       pip_url: apache-superset==1.5.0 snowflake-sqlalchemy
+       pip_url: apache-superset==1.5.0 markupsafe==2.0.1 cryptography==3.4.7 snowflake-sqlalchemy
      ```
   3. Re-install the plugin:
 
@@ -76,7 +76,7 @@ next_steps: |
      ```
 
   Now when you (re)start Superset, you will be able to connect to a new type of database, like Snowflake in the example.
-pip_url: apache-superset==1.5.0 markupsafe==2.0.1
+pip_url: apache-superset==1.5.0 markupsafe==2.0.1 cryptography==3.4.7
 prereq: |
   #### Dependencies
 

--- a/_data/meltano/utilities/superset/meltano.yml
+++ b/_data/meltano/utilities/superset/meltano.yml
@@ -40,15 +40,15 @@ next_steps: |
 
     ```sh
     # create a new secret key
-    meltano config superset_ext set SECRET_KEY $(openssl rand -base64 42)
+    meltano config superset set SECRET_KEY $(openssl rand -base64 42)
     # create the initial config, database, and auth roles.
-    meltano invoke superset_ext:initialize
+    meltano invoke superset:initialize
     ```
   2. Create an admin user: (use `admin` as username to be able to load the examples)
 
     ```sh
     # add a superset admin using prompting for required values
-    meltano invoke superset_ext:create-admin
+    meltano invoke superset:create-admin
     ```
 
     This is equivalent to `superset fab create-admin` in the Superset documentation
@@ -56,7 +56,7 @@ next_steps: |
   3. Optionally, load some example data to play with:
 
     ```sh
-    meltano invoke superset_ext:load-examples
+    meltano invoke superset:load-examples
     ```
 
     This is equivalent to `superset load_examples` in the Superset documentation
@@ -66,7 +66,7 @@ next_steps: |
   4. Launch the Superset UI and log in using the username/password you created:
 
     ```sh
-    meltano invoke superset_ext:ui
+    meltano invoke superset:ui
     ```
 
     By default, the UI will be available at at [`http://localhost:8088`](http://localhost:8088). You can change this using the `ui.bind_host` and `ui.port` settings documented below.
@@ -78,24 +78,25 @@ next_steps: |
   You can find the list of supported databases and the appropriate PyPI (pip) packages in the [Supported Databases and Dependencies](https://superset.apache.org/docs/databases/installing-database-drivers#supported-databases-and-dependencies) section in the Superset documenation. These can then be added to your Meltano project by configuring
   a custom `pip_url` for the `superset` utility:
 
-  1. Find the `superset_ext` plugin definition in your `meltano.yml` project file
+  1. Find the `superset` plugin definition in your `meltano.yml` project file
   2. Update the `pip_url` property to include the desired additional packages:
 
      ```yaml
      utilities:
      - name: superset
        variant: apache
-       pip_url: apache-superset==2.0.0 flask==2.0.3 werkzeug==2.0.3 jinja2==3.0.1 wtforms==2.3.3 git+https://github.com/meltano/superset-ext.git@main snowflake-sqlalchemy
+       pip_url: apache-superset==2.0.0 flask==2.0.3 werkzeug==2.0.3 jinja2==3.0.1 wtforms==2.3.3
+         git+https://github.com/meltano/superset-ext.git@main cryptography==3.4.7
      ```
   3. Re-install the plugin:
 
      ```sh
-     meltano install utility superset_ext
+     meltano install utility superset
      ```
 
   Now when you (re)start Superset, you will be able to connect to a new type of database, like Snowflake in the example.
 pip_url: apache-superset==2.0.0 flask==2.0.3 werkzeug==2.0.3 jinja2==3.0.1 wtforms==2.3.3
-  git+https://github.com/meltano/superset-ext.git@main
+  git+https://github.com/meltano/superset-ext.git@main cryptography==3.4.7
 repo: https://github.com/apache/superset
 settings:
 - description: Host used by `meltano invoke superset:ui`. Used in the `gunicorn` `--bind`


### PR DESCRIPTION
Related to https://github.com/meltano/superset-ext/pull/8

- The docs were outdated for the EDK variant using superset_ext which isnt what the extension expects anymore
- Theres an issue in the [superset dependencies](https://github.com/apache/superset/issues/22571) that causes an error unless we explicitly pin a version of `cryptography` also see [MDS in a box where the same thing was done](https://github.com/matsonj/nba-monte-carlo/issues/63). I updated for both of these variants
- Set the EDK variant to default