### PR TITLE
ci: Skip preview deployment of Hub API in dependabot PRs

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'production' || 'preview' }}
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     steps:
     - uses: actions/checkout@v3.3.0
 

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'production' || 'preview' }}
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
     - uses: actions/checkout@v3.3.0
 
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     needs: build
+    if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:


### PR DESCRIPTION
Dependabot PRs don't have OICD access to sync Hub files with S3, so they're failing.

This PR disables the `publish` job if it was triggered by dependabot.
