### PR TITLE
feat: provide matching default db path for `target-duckdb` and `dbt-duckdb`

### DIFF
--- a/_data/meltano/loaders/target-duckdb/jwills.yml
+++ b/_data/meltano/loaders/target-duckdb/jwills.yml
@@ -14,6 +14,7 @@ settings:
   label: File Path
   name: filepath
   placeholder: /path/to/local/duckdb.file
+  value: ${MELTANO_PROJECT_ROOT}/output/warehouse.duckdb
 - description: Maximum number of rows in each batch. At the end of each batch, the
     rows in the batch are loaded into DuckDB.
   kind: integer

--- a/_data/meltano/utilities/dbt-duckdb/jwills.yml
+++ b/_data/meltano/utilities/dbt-duckdb/jwills.yml
@@ -97,6 +97,7 @@ settings:
   kind: string
   label: Path
   name: path
+  value: "${MELTANO_PROJECT_ROOT}/output/warehouse.duckdb"
 - description: Specify the schema to write into.
   kind: string
   label: Schema

--- a/_data/meltano/utilities/dbt-duckdb/jwills.yml
+++ b/_data/meltano/utilities/dbt-duckdb/jwills.yml
@@ -97,7 +97,7 @@ settings:
   kind: string
   label: Path
   name: path
-  value: "${MELTANO_PROJECT_ROOT}/output/warehouse.duckdb"
+  value: ${MELTANO_PROJECT_ROOT}/output/warehouse.duckdb
 - description: Specify the schema to write into.
   kind: string
   label: Schema


### PR DESCRIPTION
This would use the `output` folder as a default location for the generated duck DB database file. I've applied the same default path for both `target-duckdb` and `dbt-duckdb`, so if users do not want to override a path, they will by default get both working together.

Specifically: `warehouse.duckdb` in `${MELTANO_PROJECT_ROOT}/output`

The reason for this change is so that we quickly swap in `target-duckdb` for speedrun invocations like this one in slack: https://meltano.slack.com/archives/C04632W0HT2/p1680301581525659

I don't believe this is a breaking change since previously both plugins would simply fail if paths were not provided.