### PR TITLE
downgrade target-s3 to development status

### DIFF
--- a/_data/meltano/loaders/target-s3/crowemi.yml
+++ b/_data/meltano/loaders/target-s3/crowemi.yml
@@ -11,7 +11,7 @@ keywords:
 - file
 label: S3 (Multi Format)
 logo_url: /assets/logos/loaders/s3.png
-maintenance_status: active
+maintenance_status: development
 name: target-s3
 namespace: target_s3
 next_steps: ''
@@ -124,6 +124,7 @@ settings:
 settings_group_validation:
 - - aws_region
   - bucket
+  - format_type
 settings_preamble: ''
 usage: ''
 variant: crowemi


### PR DESCRIPTION
A user in slack was stuck on this target so I was testing it out and noticed that its still in development. I opened some issues to track what I noticed on https://github.com/crowemi/target-s3/issues and pinged the maintainer to see what the development plan is https://meltano.slack.com/archives/C01RKUVUG4S/p1680544334254469?thread_ts=1666981269.271539&cid=C01RKUVUG4S.