### PR TITLE
reformat all meltanolabs sdk variants

### DIFF
--- a/_data/meltano/extractors/tap-circle-ci/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-circle-ci/meltanolabs.yml
@@ -1,8 +1,8 @@
 capabilities:
-- catalog
-- state
-- discover
 - about
+- catalog
+- discover
+- state
 - stream-maps
 description: CI/CD Platfrom
 domain_url: https://circleci.com/
@@ -18,26 +18,26 @@ next_steps: ''
 pip_url: git+https://github.com/MeltanoLabs/tap-circle-ci.git
 repo: https://github.com/MeltanoLabs/tap-circle-ci
 settings:
+- description: The API base URL to use for requests. Default, https://circleci.com/api/v2.
+  kind: string
+  label: Base Url
+  name: base_url
+- description: 'Organization slug in the form vcs-slug/org-name. Example: org-slug=gh/CircleCI-Public'
+  kind: string
+  label: Org Slug
+  name: org_slug
 - description: Personal API Token you have generated that can be used to access the
     CircleCI API
   kind: password
   label: Token
   name: token
-- description: 'Organization slug in the form vcs-slug/org-name. Example: org-slug=gh/CircleCI-Public'
-  kind: string
-  label: Org Slug
-  name: org_slug
-- description: The API base URL to use for requests. Default, https://circleci.com/api/v2.
-  kind: string
-  label: Base Url
-  name: base_url
 - description: User-Agent header
   kind: string
   label: User Agent
   name: user_agent
 settings_group_validation:
-- - token
-  - org_slug
+- - org_slug
+  - token
 settings_preamble: ''
 usage: ''
 variant: meltanolabs

--- a/_data/meltano/extractors/tap-cloudwatch/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-cloudwatch/meltanolabs.yml
@@ -1,10 +1,10 @@
 capabilities:
-- catalog
-- state
-- discover
 - about
-- stream-maps
+- catalog
+- discover
 - schema-flattening
+- state
+- stream-maps
 description: AWS Application and Infrastructure Monitoring
 domain_url: https://aws.amazon.com/cloudwatch/
 executable: tap-cloudwatch
@@ -23,6 +23,19 @@ settings:
   kind: password
   label: AWS Access Key Id
   name: aws_access_key_id
+- description: The complete URL to use for the constructed client.
+  kind: string
+  label: AWS Endpoint Url
+  name: aws_endpoint_url
+- description: The AWS credentials profile name to use. The profile must be configured
+    and accessible.
+  kind: string
+  label: AWS Profile
+  name: aws_profile
+- description: 'The AWS region name (e.g. us-east-1) '
+  kind: string
+  label: AWS Region Name
+  name: aws_region_name
 - description: The secret key for your AWS account.
   kind: password
   label: AWS Secret Access Key
@@ -32,38 +45,6 @@ settings:
   kind: password
   label: AWS Session Token
   name: aws_session_token
-- description: The AWS credentials profile name to use. The profile must be configured
-    and accessible.
-  kind: string
-  label: AWS Profile
-  name: aws_profile
-- description: The complete URL to use for the constructed client.
-  kind: string
-  label: AWS Endpoint Url
-  name: aws_endpoint_url
-- description: 'The AWS region name (e.g. us-east-1) '
-  kind: string
-  label: AWS Region Name
-  name: aws_region_name
-- description: The earliest record date to sync
-  kind: date_iso8601
-  label: Start Date
-  name: start_date
-- description: The last record date to sync. This tap uses a 5 minute buffer to allow
-    Cloudwatch logs to arrive in full. If you request data from current time it will
-    automatically adjust your end_date to now - 5 mins.
-  kind: date_iso8601
-  label: End Date
-  name: end_date
-- description: The log group on which to perform the query.
-  kind: string
-  label: Log Group Name
-  name: log_group_name
-- description: The query string to use. For more information, see [CloudWatch Logs
-    Insights Query Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html).
-  kind: string
-  label: Query
-  name: query
 - description: The size of the time window to query by, default 3,600 seconds (i.e.
     1 hour). If the result set for a batch is greater than the max limit of 10,000
     records then the tap will query the same window again where >= the most recent
@@ -76,15 +57,12 @@ settings:
   kind: integer
   label: Batch Increment S
   name: batch_increment_s
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
+- description: The last record date to sync. This tap uses a 5 minute buffer to allow
+    Cloudwatch logs to arrive in full. If you request data from current time it will
+    automatically adjust your end_date to now - 5 mins.
+  kind: date_iso8601
+  label: End Date
+  name: end_date
 - description: "'True' to enable schema flattening and automatically expand nested\
     \ properties."
   kind: boolean
@@ -94,10 +72,32 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
+- description: The log group on which to perform the query.
+  kind: string
+  label: Log Group Name
+  name: log_group_name
+- description: The query string to use. For more information, see [CloudWatch Logs
+    Insights Query Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html).
+  kind: string
+  label: Query
+  name: query
+- description: The earliest record date to sync
+  kind: date_iso8601
+  label: Start Date
+  name: start_date
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
 settings_group_validation:
 - - log_group_name
-  - start_date
   - query
+  - start_date
 settings_preamble: ''
 usage: ''
 variant: meltanolabs

--- a/_data/meltano/extractors/tap-csv/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-csv/meltanolabs.yml
@@ -1,6 +1,6 @@
 capabilities:
-- discover
 - catalog
+- discover
 description: Generic data extractor of CSV (comma separated value) files
 domain_url: https://en.wikipedia.org/wiki/Comma-separated_values
 keywords:
@@ -14,6 +14,28 @@ namespace: tap_csv
 pip_url: git+https://github.com/MeltanoLabs/tap-csv.git
 repo: https://github.com/MeltanoLabs/tap-csv
 settings:
+- description: When True, add the metadata columns (`_sdc_source_file`, `_sdc_source_file_mtime`,
+    `_sdc_source_lineno`) to output.
+  kind: boolean
+  label: Add Metadata Columns
+  name: add_metadata_columns
+- description: |
+    Project-relative path to JSON file holding array of objects as described under [Files](#files) - with `entity`, `path`, `keys`, and other optional keys:
+
+    ```json
+    [
+      {
+        "entity": "<entity>",
+        "path": "<path>",
+        "keys": ["<key>"],
+      },
+      // ...
+    ]
+    ```
+  documentation: https://github.com/MeltanoLabs/tap-csv#settings
+  label: CSV Files Definition
+  name: csv_files_definition
+  placeholder: Ex. files-def.json
 - description: |
     Array of objects with `entity`, `path`, `keys`, and `encoding` [Optional] keys:
 
@@ -36,28 +58,6 @@ settings:
   kind: array
   label: Files
   name: files
-- description: |
-    Project-relative path to JSON file holding array of objects as described under [Files](#files) - with `entity`, `path`, `keys`, and other optional keys:
-
-    ```json
-    [
-      {
-        "entity": "<entity>",
-        "path": "<path>",
-        "keys": ["<key>"],
-      },
-      // ...
-    ]
-    ```
-  documentation: https://github.com/MeltanoLabs/tap-csv#settings
-  label: CSV Files Definition
-  name: csv_files_definition
-  placeholder: Ex. files-def.json
-- description: When True, add the metadata columns (`_sdc_source_file`, `_sdc_source_file_mtime`,
-    `_sdc_source_lineno`) to output.
-  kind: boolean
-  label: Add Metadata Columns
-  name: add_metadata_columns
 settings_group_validation:
 - - files
 - - csv_files_definition

--- a/_data/meltano/extractors/tap-dbt/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-dbt/meltanolabs.yml
@@ -1,10 +1,10 @@
 capabilities:
-- catalog
-- state
-- discover
 - about
-- stream-maps
+- catalog
+- discover
 - schema-flattening
+- state
+- stream-maps
 description: Analytics Engineering Platform
 domain_url: https://www.getdbt.com/product/
 keywords:
@@ -18,29 +18,17 @@ namespace: tap_dbt
 pip_url: git+https://github.com/meltanolabs/tap-dbt.git
 repo: https://github.com/meltanolabs/tap-dbt
 settings:
-- description: API key for the dbt Cloud API
-  kind: password
-  label: Api Key
-  name: api_key
 - description: dbt Cloud account IDs
   kind: array
   label: Account Ids
   name: account_ids
+- description: API key for the dbt Cloud API
+  kind: password
+  label: Api Key
+  name: api_key
 - description: Base URL for the dbt Cloud API
   label: Base Url
   name: base_url
-- description: User-Agent to make requests with
-  label: User Agent
-  name: user_agent
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
 - description: "'True' to enable schema flattening and automatically expand nested\
     \ properties."
   kind: boolean
@@ -50,7 +38,19 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+- description: User-Agent to make requests with
+  label: User Agent
+  name: user_agent
 settings_group_validation:
-- - api_key
-  - account_ids
+- - account_ids
+  - api_key
 variant: meltanolabs

--- a/_data/meltano/extractors/tap-duckdb/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-duckdb/meltanolabs.yml
@@ -1,10 +1,10 @@
 capabilities:
-- catalog
-- state
-- discover
 - about
-- stream-maps
+- catalog
+- discover
 - schema-flattening
+- state
+- stream-maps
 description: DuckDB is an in-process SQL OLAP database management system
 domain_url: https://duckdb.org/
 executable: tap-duckdb
@@ -20,19 +20,6 @@ next_steps: ''
 pip_url: git+https://github.com/MeltanoLabs/tap-duckdb.git
 repo: https://github.com/MeltanoLabs/tap-duckdb
 settings:
-- description: Path to .duckdb file
-  kind: string
-  label: Path
-  name: path
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
 - description: "'True' to enable schema flattening and automatically expand nested\
     \ properties."
   kind: boolean
@@ -42,6 +29,19 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
+- description: Path to .duckdb file
+  kind: string
+  label: Path
+  name: path
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
 settings_group_validation:
 - - path
 settings_preamble: ''

--- a/_data/meltano/extractors/tap-github/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-github/meltanolabs.yml
@@ -1,10 +1,10 @@
 capabilities:
-- catalog
-- state
-- discover
 - about
-- stream-maps
+- catalog
+- discover
 - schema-flattening
+- state
+- stream-maps
 description: Code hosting platform
 domain_url: https://docs.github.com/en/rest
 keywords:
@@ -19,61 +19,61 @@ namespace: tap_github
 pip_url: git+https://github.com/MeltanoLabs/tap-github.git
 repo: https://github.com/MeltanoLabs/tap-github
 settings:
-- label: User Agent
-  name: user_agent
-- description: The log level of the API response metrics.
-  label: Metrics Log Level
-  name: metrics_log_level
-- description: GitHub token to authenticate with.
-  kind: password
-  label: Auth Token
-  name: auth_token
 - description: List of GitHub tokens to authenticate with. Streams will loop through
     them when hitting rate limits.
   kind: array
   label: Additional Auth Tokens
   name: additional_auth_tokens
+- description: GitHub token to authenticate with.
+  kind: password
+  label: Auth Token
+  name: auth_token
+- description: The log level of the API response metrics.
+  label: Metrics Log Level
+  name: metrics_log_level
+- description: An array of strings containing the github organizations to be included
+  kind: array
+  label: Organizations
+  name: organizations
 - description: Add a buffer to avoid consuming all query points for the token at hand.
     Defaults to 1000.
   kind: integer
   label: Rate Limit Buffer
   name: rate_limit_buffer
+- description: An array of strings containing the github repos to be included
+  kind: array
+  label: Repositories
+  name: repositories
 - description: An array of search descriptor objects with the following properties.
     "name" - a human readable name for the search query. "query" -  a github search
     string (generally the same as would come after ?q= in the URL)
   kind: array
   label: Searches
   name: searches
-- description: An array of strings containing the github organizations to be included
-  kind: array
-  label: Organizations
-  name: organizations
-- description: An array of strings containing the github repos to be included
-  kind: array
-  label: Repositories
-  name: repositories
-- description: A list of GithHub usernames.
-  kind: array
-  label: User Usernames
-  name: user_usernames
-- description: A list of GitHub user ids.
-  kind: array
-  label: User IDs
-  name: user_ids
-- kind: date_iso8601
-  label: Start Date
-  name: start_date
-- kind: object
-  label: Stream Maps
-  name: stream_maps
-- kind: object
-  label: Stream Map Config
-  name: stream_map_config
 - description: Set to true to skip API calls for the parent streams (such as repositories)
     if it is not selected but children are.
   kind: boolean
   label: Skip Parent Streams
   name: skip_parent_streams
+- kind: date_iso8601
+  label: Start Date
+  name: start_date
+- kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- kind: object
+  label: Stream Maps
+  name: stream_maps
+- label: User Agent
+  name: user_agent
+- description: A list of GitHub user ids.
+  kind: array
+  label: User IDs
+  name: user_ids
+- description: A list of GithHub usernames.
+  kind: array
+  label: User Usernames
+  name: user_usernames
 settings_group_validation:
 - - repositories
 - - organizations

--- a/_data/meltano/extractors/tap-google-analytics/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-google-analytics/meltanolabs.yml
@@ -1,8 +1,8 @@
 capabilities:
+- about
 - catalog
 - discover
 - state
-- about
 - stream-maps
 description: App and website analytics platform hosted by Google
 domain_url: https://developers.google.com/analytics/devguides/reporting/core/v4/
@@ -17,6 +17,16 @@ namespace: tap_google_analytics
 pip_url: git+https://github.com/MeltanoLabs/tap-google-analytics.git
 repo: https://github.com/MeltanoLabs/tap-google-analytics
 settings:
+- description: |
+    Follow the above steps for [Key File Location](#key-file-location) but instead of providing a path you can provide the serialized json directly. This can be useful for ephemeral runtime environments where its easier to provide an environment variable instead of a file.
+  kind: object
+  label: Client Secrets JSON
+  name: client_secrets
+  placeholder: Ex. client_secrets.json
+- description: Date up to when historical data will be extracted.
+  kind: date_iso8601
+  label: End Date
+  name: end_date
 - description: |
     #### How to get
 
@@ -79,12 +89,10 @@ settings:
   label: Client Secrets File Location
   name: key_file_location
   placeholder: Ex. $MELTANO_PROJECT_ROOT/client_secrets.json
-- description: |
-    Follow the above steps for [Key File Location](#key-file-location) but instead of providing a path you can provide the serialized json directly. This can be useful for ephemeral runtime environments where its easier to provide an environment variable instead of a file.
-  kind: object
-  label: Client Secrets JSON
-  name: client_secrets
-  placeholder: Ex. client_secrets.json
+- description: See https://developers.google.com/analytics/devguides/reporting/core/v4/authorization#OAuth2Authorizing.
+  kind: password
+  label: OAuth Access Token
+  name: oauth_credentials.access_token
 - description: |
     See <https://developers.google.com/analytics/devguides/reporting/core/v4/authorization#OAuth2Authorizing>.
 
@@ -98,33 +106,8 @@ settings:
   name: oauth_credentials.client_secret
 - description: See https://developers.google.com/analytics/devguides/reporting/core/v4/authorization#OAuth2Authorizing.
   kind: password
-  label: OAuth Access Token
-  name: oauth_credentials.access_token
-- description: See https://developers.google.com/analytics/devguides/reporting/core/v4/authorization#OAuth2Authorizing.
-  kind: password
   label: OAuth Refresh Token
   name: oauth_credentials.refresh_token
-- description: |
-    The ID for the view to fetch data from.
-
-    #### How to get
-
-    To get your View ID:
-
-    1. Visit Google Analytics: <https://analytics.google.com/>
-    2. Log in if you haven't already.
-    3. Open the account/property/view selector in the top left corner
-
-    ![Screenshot of closed account selector](/assets/images/tap-google-analytics/account-selector-closed.png)
-
-    3. Select the account, property, and view that you would like to connect with Meltano
-
-    ![Screenshot of open account selector](/assets/images/tap-google-analytics/account-selector-open.png)
-
-    4. You will see the View ID displayed inside the selector below the name of the view (e.g. "All Web Site Data"): `188274549`
-  label: View ID
-  name: view_id
-  placeholder: Ex. 198343027
 - description: |
     Project-relative path to JSON file with the definition of the reports to be generated.
 
@@ -191,21 +174,38 @@ settings:
   kind: date_iso8601
   label: Start Date
   name: start_date
-- description: Date up to when historical data will be extracted.
-  kind: date_iso8601
-  label: End Date
-  name: end_date
+- description: |
+    The ID for the view to fetch data from.
+
+    #### How to get
+
+    To get your View ID:
+
+    1. Visit Google Analytics: <https://analytics.google.com/>
+    2. Log in if you haven't already.
+    3. Open the account/property/view selector in the top left corner
+
+    ![Screenshot of closed account selector](/assets/images/tap-google-analytics/account-selector-closed.png)
+
+    3. Select the account, property, and view that you would like to connect with Meltano
+
+    ![Screenshot of open account selector](/assets/images/tap-google-analytics/account-selector-open.png)
+
+    4. You will see the View ID displayed inside the selector below the name of the view (e.g. "All Web Site Data"): `188274549`
+  label: View ID
+  name: view_id
+  placeholder: Ex. 198343027
 settings_group_validation:
 - - key_file_location
-  - view_id
   - start_date
+  - view_id
 - - client_secrets
-  - view_id
   - start_date
-- - oauth_credentials.client_id
+  - view_id
+- - oauth_credentials.access_token
+  - oauth_credentials.client_id
   - oauth_credentials.client_secret
-  - oauth_credentials.access_token
   - oauth_credentials.refresh_token
-  - view_id
   - start_date
+  - view_id
 variant: meltanolabs

--- a/_data/meltano/extractors/tap-jaffle-shop/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-jaffle-shop/meltanolabs.yml
@@ -43,7 +43,7 @@ settings:
   kind: string
   label: Stream Name Prefix
   name: stream_name_prefix
-  value: "tap_jaffle_shop-raw_"
+  value: tap_jaffle_shop-raw_
 - description: The number of years to simulate data for.
   kind: integer
   label: Years

--- a/_data/meltano/extractors/tap-messagebird/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-messagebird/meltanolabs.yml
@@ -1,9 +1,9 @@
 capabilities:
+- about
 - catalog
 - discover
-- about
-- stream-maps
 - schema-flattening
+- stream-maps
 description: An omnichannel communications platform, built for global scale.
 domain_url: https://www.messagebird.com
 keywords:
@@ -23,19 +23,6 @@ settings:
   kind: password
   label: Api Key
   name: api_key
-- description: The sync start date that determines how much historical data will be extracted. ISO8601 format of date. Defaults, 3 years ago.
-  kind: date_iso8601
-  label: Start Date
-  name: start_date
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
 - description: "'True' to enable schema flattening and automatically expand nested\
     \ properties."
   kind: boolean
@@ -45,6 +32,20 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
+- description: The sync start date that determines how much historical data will be
+    extracted. ISO8601 format of date. Defaults, 3 years ago.
+  kind: date_iso8601
+  label: Start Date
+  name: start_date
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
 settings_group_validation:
 - - api_key
 settings_preamble: ''

--- a/_data/meltano/extractors/tap-postgres/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-postgres/meltanolabs.yml
@@ -1,10 +1,10 @@
 capabilities:
-- catalog
-- state
-- discover
 - about
-- stream-maps
+- catalog
+- discover
 - schema-flattening
+- state
+- stream-maps
 description: PostgreSQL database extractor
 domain_url: https://www.postgresql.org/
 keywords:
@@ -19,19 +19,6 @@ next_steps: ''
 pip_url: git+https://github.com/MeltanoLabs/tap-postgres.git
 repo: https://github.com/MeltanoLabs/tap-postgres
 settings:
-- description: Example postgresql://postgres:postgres@localhost:5432/postgres
-  kind: string
-  label: Sqlalchemy Url
-  name: sqlalchemy_url
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
 - description: "'True' to enable schema flattening and automatically expand nested\
     \ properties."
   kind: boolean
@@ -41,6 +28,19 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
+- description: Example postgresql://postgres:postgres@localhost:5432/postgres
+  kind: string
+  label: Sqlalchemy Url
+  name: sqlalchemy_url
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
 settings_group_validation:
 - - sqlalchemy_url
 settings_preamble: ''

--- a/_data/meltano/extractors/tap-slack/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-slack/meltanolabs.yml
@@ -1,8 +1,8 @@
 capabilities:
-- catalog
-- state
-- discover
 - about
+- catalog
+- discover
+- state
 - stream-maps
 description: Team communication tool
 domain_url: https://api.slack.com/
@@ -61,6 +61,34 @@ settings:
   kind: password
   label: API Key
   name: api_key
+- description: Whether the bot user should attempt to join channels that it has not
+    yet joined. The bot user must be a member of the channel to retrieve messages.
+  kind: boolean
+  label: Auto Join Channels
+  name: auto_join_channels
+- description: An array of the types of conversations the tap will attempt to extract
+    data from. Must be one of 'public_channel', 'mpim', 'private_channel', or 'im'.
+    Note that the Slack app must have the appropriate privileges and be a member of
+    the conversations to sync messages.
+  kind: array
+  label: Channel Types
+  name: channel_types
+- description: A list of channel IDs that should not be retrieved. Excluding overrides
+    a selected setting, so if a channel is included in both selected and excluded,
+    it will be excluded.
+  kind: array
+  label: Excluded Channels
+  name: excluded_channels
+- description: Whether to include streams that require admin privileges or not. If
+    the user does not have the proper scopes then the tap will throw and exception.
+  kind: boolean
+  label: Include Admin Streams
+  name: include_admin_streams
+- description: A list of channel IDs that should be retrieved. If not defined then
+    all are selected.
+  kind: array
+  label: Selected Channels
+  name: selected_channels
 - description: Determines how much historical data will be extracted. Please be aware
     that the larger the time period and amount of data, the longer the initial extraction
     can be expected to take.
@@ -72,34 +100,6 @@ settings:
   kind: integer
   label: Thread Lookback Days
   name: thread_lookback_days
-- description: An array of the types of conversations the tap will attempt to extract
-    data from. Must be one of 'public_channel', 'mpim', 'private_channel', or 'im'.
-    Note that the Slack app must have the appropriate privileges and be a member of
-    the conversations to sync messages.
-  kind: array
-  label: Channel Types
-  name: channel_types
-- description: Whether the bot user should attempt to join channels that it has not
-    yet joined. The bot user must be a member of the channel to retrieve messages.
-  kind: boolean
-  label: Auto Join Channels
-  name: auto_join_channels
-- description: A list of channel IDs that should be retrieved. If not defined then
-    all are selected.
-  kind: array
-  label: Selected Channels
-  name: selected_channels
-- description: A list of channel IDs that should not be retrieved. Excluding overrides
-    a selected setting, so if a channel is included in both selected and excluded,
-    it will be excluded.
-  kind: array
-  label: Excluded Channels
-  name: excluded_channels
-- description: Whether to include streams that require admin privileges or not. If the user does
-    not have the proper scopes then the tap will throw and exception.
-  kind: boolean
-  label: Include Admin Streams
-  name: include_admin_streams
 settings_group_validation:
 - - api_key
 variant: meltanolabs

--- a/_data/meltano/extractors/tap-snowflake/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-snowflake/meltanolabs.yml
@@ -1,10 +1,10 @@
 capabilities:
-- catalog
-- state
-- discover
 - about
-- stream-maps
+- catalog
+- discover
 - schema-flattening
+- state
+- stream-maps
 description: Extractor for Snowflake data warehouse
 domain_url: https://www.snowflake.com/
 keywords:
@@ -19,14 +19,6 @@ next_steps: ''
 pip_url: meltanolabs-tap-snowflake
 repo: https://github.com/MeltanoLabs/tap-snowflake
 settings:
-- description: The login name for your Snowflake user.
-  kind: string
-  label: User
-  name: user
-- description: The password for your Snowflake user.
-  kind: password
-  label: Password
-  name: password
 - description: Your account identifier. See [Account Identifiers](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html).
   kind: string
   label: Account
@@ -35,27 +27,6 @@ settings:
   kind: string
   label: Database
   name: database
-- description: The initial schema for the Snowflake session.
-  kind: string
-  label: Schema
-  name: schema
-- description: The initial warehouse for the session.
-  kind: string
-  label: Warehouse
-  name: warehouse
-- description: The initial role for the session.
-  kind: string
-  label: Role
-  name: role
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
 - description: "'True' to enable schema flattening and automatically expand nested\
     \ properties."
   kind: boolean
@@ -65,10 +36,39 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
+- description: The password for your Snowflake user.
+  kind: password
+  label: Password
+  name: password
+- description: The initial role for the session.
+  kind: string
+  label: Role
+  name: role
+- description: The initial schema for the Snowflake session.
+  kind: string
+  label: Schema
+  name: schema
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+- description: The login name for your Snowflake user.
+  kind: string
+  label: User
+  name: user
+- description: The initial warehouse for the session.
+  kind: string
+  label: Warehouse
+  name: warehouse
 settings_group_validation:
-- - password
+- - account
+  - password
   - user
-  - account
 settings_preamble: ''
 usage: ''
 variant: meltanolabs

--- a/_data/meltano/extractors/tap-stackexchange/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-stackexchange/meltanolabs.yml
@@ -16,30 +16,30 @@ namespace: tap_stackexchange
 pip_url: git+https://github.com/MeltanoLabs/tap-stackexchange.git
 repo: https://github.com/MeltanoLabs/tap-stackexchange
 settings:
-- description: Question tags to retrieve.
-  kind: array
-  label: Question tags
-  name: tags
-- description: StackExchange site to look for questions.
-  documentation: https://stackexchange.com/sites
-  label: Site
-  name: site
-- description: Key to receive a higher request quota.
-  documentation: https://api.stackexchange.com/docs/authentication
-  kind: password
-  label: Stack App key
-  name: key
-- description: The earliest record date to sync
-  documentation: https://api.stackexchange.com/docs/dates
-  kind: integer
-  label: Start date
-  name: start_date
 - description: Custom API filter to apply to all requests
   documentation: https://api.stackexchange.com/docs/filters
   kind: string
   label: Filter
   name: filter
+- description: Key to receive a higher request quota.
+  documentation: https://api.stackexchange.com/docs/authentication
+  kind: password
+  label: Stack App key
+  name: key
+- description: StackExchange site to look for questions.
+  documentation: https://stackexchange.com/sites
+  label: Site
+  name: site
+- description: The earliest record date to sync
+  documentation: https://api.stackexchange.com/docs/dates
+  kind: integer
+  label: Start date
+  name: start_date
+- description: Question tags to retrieve.
+  kind: array
+  label: Question tags
+  name: tags
 settings_group_validation:
-- - tags
-  - site
+- - site
+  - tags
 variant: meltanolabs

--- a/_data/meltano/loaders/target-csv/meltanolabs.yml
+++ b/_data/meltano/loaders/target-csv/meltanolabs.yml
@@ -15,22 +15,39 @@ next_steps: ''
 pip_url: git+https://github.com/MeltanoLabs/target-csv.git
 repo: https://github.com/MeltanoLabs/target-csv
 settings:
-- description: Optional path prefix which will be prepended to the file path indicated
-    by `file_naming_schema`.
+- description: 'A python format string to use when outputting the `{datestamp}` string.
+    For reference, see: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes'
   kind: string
-  label: Output Path Prefix
-  name: output_path_prefix
+  label: Datestamp Format
+  name: datestamp_format
 - description: "The scheme with which output files will be named. Naming scheme may\
     \ leverage any of the following substitutions: \n\n- `{stream_name}`- `{datestamp}`-\
     \ `{timestamp}`"
   kind: string
   label: File Naming Scheme
   name: file_naming_scheme
-- description: 'A python format string to use when outputting the `{datestamp}` string.
-    For reference, see: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes'
+- description: Optional path prefix which will be prepended to the file path indicated
+    by `file_naming_schema`.
   kind: string
-  label: Datestamp Format
-  name: datestamp_format
+  label: Output Path Prefix
+  name: output_path_prefix
+- description: "Determines the overwrite behavior if destination file already exists.\
+    \ Must be one of the following string values: \n\n- `append_records` (default)\
+    \ - append records at the insertion point\n- `replace_file` - replace entire file\
+    \ using `default_CSV_template`\n"
+  kind: string
+  label: Overwrite Behavior
+  name: overwrite_behavior
+- description: "A property in the record which will be used as a sort key.\n\nIf this\
+    \ property is omitted, records will not be sorted."
+  kind: string
+  label: Record Sort Property Name
+  name: record_sort_property_name
+- description: 'Allows inline stream transformations and aliasing. For more information
+    see: https://sdk.meltano.com/en/latest/stream_maps.html'
+  kind: object
+  label: Stream Maps
+  name: stream_maps
 - description: 'A python format string to use when outputting the `{timestamp}` string.
     For reference, see: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes'
   kind: string
@@ -42,23 +59,6 @@ settings:
   kind: string
   label: Timestamp Timezone
   name: timestamp_timezone
-- description: 'Allows inline stream transformations and aliasing. For more information
-    see: https://sdk.meltano.com/en/latest/stream_maps.html'
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: "A property in the record which will be used as a sort key.\n\nIf this\
-    \ property is omitted, records will not be sorted."
-  kind: string
-  label: Record Sort Property Name
-  name: record_sort_property_name
-- description: "Determines the overwrite behavior if destination file already exists.\
-    \ Must be one of the following string values: \n\n- `append_records` (default)\
-    \ - append records at the insertion point\n- `replace_file` - replace entire file\
-    \ using `default_CSV_template`\n"
-  kind: string
-  label: Overwrite Behavior
-  name: overwrite_behavior
 settings_group_validation:
 - []
 settings_preamble: ''

--- a/_data/meltano/loaders/target-postgres/meltanolabs.yml
+++ b/_data/meltano/loaders/target-postgres/meltanolabs.yml
@@ -1,7 +1,7 @@
 capabilities:
 - about
-- stream-maps
 - schema-flattening
+- stream-maps
 description: PostgreSQL database loader
 dialect: postgres
 domain_url: https://www.postgresql.org/
@@ -18,67 +18,26 @@ next_steps: ''
 pip_url: git+https://github.com/MeltanoLabs/target-postgres.git
 repo: https://github.com/MeltanoLabs/target-postgres
 settings:
-- description: Hostname for postgres instance. Note if sqlalchemy_url is set this
-    will be ignored.
-  kind: string
-  label: Host
-  name: host
-- description: The port on which postgres is awaiting connection. Note if sqlalchemy_url
-    is set this will be ignored. Defaults to 5432
-  kind: integer
-  label: Port
-  name: port
-- description: User name used to authenticate. Note if sqlalchemy_url is set this
-    will be ignored.
-  kind: string
-  label: User
-  name: user
-- description: Password used to authenticate. Note if sqlalchemy_url is set this will
-    be ignored.
-  kind: password
-  label: Password
-  name: password
-- description: Database name. Note if sqlalchemy_url is set this will be ignored.
-  kind: string
-  label: Database
-  name: database
-- description: SQLAlchemy connection string. This will override using host, user,
-    password, port, dialect. Note that you must esacpe password special characters
-    properly see https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords
-  kind: string
-  label: Sqlalchemy Url
-  name: sqlalchemy_url
-- description: Dialect+driver see https://docs.sqlalchemy.org/en/20/core/engines.html.
-    Generally just leave this alone. Note if sqlalchemy_url is set this will be ignored.
-  kind: string
-  label: Dialect+Driver
-  name: dialect+driver
-- description: 'Postgres schema to send data to, example: tap-clickup'
-  kind: string
-  label: Default Target Schema
-  name: default_target_schema
-  value: $MELTANO_EXTRACT__LOAD_SCHEMA
-- description: When activate version is sent from a tap this specefies if we should
-    delete the records that don't match, or mark them with a date in the `_sdc_deleted_at`
-    column.
-  kind: boolean
-  label: Hard Delete
-  name: hard_delete
 - description: Note that this must be enabled for activate_version to work!This adds
     _sdc_extracted_at, _sdc_batched_at, and more to every table. See https://sdk.meltano.com/en/latest/implementation/record_metadata.html
     for more information.
   kind: boolean
   label: Add Record Metadata
   name: add_record_metadata
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
+- description: Database name. Note if sqlalchemy_url is set this will be ignored.
+  kind: string
+  label: Database
+  name: database
+- description: 'Postgres schema to send data to, example: tap-clickup'
+  kind: string
+  label: Default Target Schema
+  name: default_target_schema
+  value: $MELTANO_EXTRACT__LOAD_SCHEMA
+- description: Dialect+driver see https://docs.sqlalchemy.org/en/20/core/engines.html.
+    Generally just leave this alone. Note if sqlalchemy_url is set this will be ignored.
+  kind: string
+  label: Dialect+Driver
+  name: dialect+driver
 - description: "'True' to enable schema flattening and automatically expand nested\
     \ properties."
   kind: boolean
@@ -88,6 +47,47 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
+- description: When activate version is sent from a tap this specefies if we should
+    delete the records that don't match, or mark them with a date in the `_sdc_deleted_at`
+    column.
+  kind: boolean
+  label: Hard Delete
+  name: hard_delete
+- description: Hostname for postgres instance. Note if sqlalchemy_url is set this
+    will be ignored.
+  kind: string
+  label: Host
+  name: host
+- description: Password used to authenticate. Note if sqlalchemy_url is set this will
+    be ignored.
+  kind: password
+  label: Password
+  name: password
+- description: The port on which postgres is awaiting connection. Note if sqlalchemy_url
+    is set this will be ignored. Defaults to 5432
+  kind: integer
+  label: Port
+  name: port
+- description: SQLAlchemy connection string. This will override using host, user,
+    password, port, dialect. Note that you must esacpe password special characters
+    properly see https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords
+  kind: string
+  label: Sqlalchemy Url
+  name: sqlalchemy_url
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+- description: User name used to authenticate. Note if sqlalchemy_url is set this
+    will be ignored.
+  kind: string
+  label: User
+  name: user
 settings_group_validation:
 - []
 settings_preamble: ''

--- a/_data/meltano/loaders/target-snowflake/meltanolabs.yml
+++ b/_data/meltano/loaders/target-snowflake/meltanolabs.yml
@@ -1,8 +1,7 @@
 capabilities:
 - about
-- stream-maps
 - schema-flattening
-# - target-schema
+- stream-maps
 description: Snowflake database loader
 domain_url: https://www.snowflake.com/
 executable: target-snowflake
@@ -18,34 +17,10 @@ next_steps: ''
 pip_url: git+https://github.com/MeltanoLabs/target-snowflake.git
 repo: https://github.com/MeltanoLabs/target-snowflake
 settings:
-- description: The login name for your Snowflake user.
-  kind: string
-  label: User
-  name: user
-- description: The password for your Snowflake user.
-  kind: password
-  label: Password
-  name: password
 - description: Your account identifier. See [Account Identifiers](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html).
   kind: string
   label: Account
   name: account
-- description: The initial database for the Snowflake session.
-  kind: string
-  label: Database
-  name: database
-- description: The initial schema for the Snowflake session.
-  kind: string
-  label: Schema
-  name: schema
-- description: The initial warehouse for the session.
-  kind: string
-  label: Warehouse
-  name: warehouse
-- description: The initial role for the session.
-  kind: string
-  label: Role
-  name: role
 - description: Whether to add metadata columns.
   kind: boolean
   label: Add Record Metadata
@@ -54,19 +29,14 @@ settings:
   kind: boolean
   label: Clean Up Batch Files
   name: clean_up_batch_files
+- description: The initial database for the Snowflake session.
+  kind: string
+  label: Database
+  name: database
 - description: The default target database schema name to use for all streams.
   kind: string
   label: Default Target Schema
   name: default_target_schema
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
 - description: "'True' to enable schema flattening and automatically expand nested\
     \ properties."
   kind: boolean
@@ -76,11 +46,40 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
+- description: The password for your Snowflake user.
+  kind: password
+  label: Password
+  name: password
+- description: The initial role for the session.
+  kind: string
+  label: Role
+  name: role
+- description: The initial schema for the Snowflake session.
+  kind: string
+  label: Schema
+  name: schema
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+- description: The login name for your Snowflake user.
+  kind: string
+  label: User
+  name: user
+- description: The initial warehouse for the session.
+  kind: string
+  label: Warehouse
+  name: warehouse
 settings_group_validation:
-- - password
-  - account
-  - user
+- - account
   - database
+  - password
+  - user
 settings_preamble: ''
 usage: ''
 variant: meltanolabs

--- a/_data/meltano/loaders/target-yaml/meltanolabs.yml
+++ b/_data/meltano/loaders/target-yaml/meltanolabs.yml
@@ -64,5 +64,5 @@ settings:
     `{datestamp}`. Defaults to "UTC". For a list of possible values, please see -https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   label: Timestamp Timezone
   name: timestamp_timezone
-variant: meltanolabs
 settings_group_validation: []
+variant: meltanolabs

--- a/_data/meltano/loaders/target-yaml/meltanolabs.yml
+++ b/_data/meltano/loaders/target-yaml/meltanolabs.yml
@@ -14,6 +14,14 @@ namespace: target_yaml
 pip_url: git+https://github.com/MeltanoLabs/target-yaml.git
 repo: https://github.com/MeltanoLabs/target-yaml
 settings:
+- description: A python format string to use when outputting the `{datestamp}` string.
+    For reference, see - https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+  label: Datestamp Format
+  name: datestamp_format
+- description: Text string to use for a yaml template file. This text will be used
+    to create a new file if the destination file does not exist.
+  label: Default Yaml Template
+  name: default_yaml_template
 - description: |
     The scheme with which output files will be named. Naming scheme may leverage any of the following substitutions:
      - `{stream_name}`
@@ -21,23 +29,14 @@ settings:
      - `{timestamp}`
   label: File Naming Scheme
   name: file_naming_scheme
-- description: A python format string to use when outputting the `{datestamp}` string.
-    For reference, see - https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
-  label: Datestamp Format
-  name: datestamp_format
-- description: A python format string to use when outputting the `{datestamp}` string.
-    For reference, see - https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
-  label: Timestamp Format
-  name: timestamp_format
-- description: The timezone code or name to use when generating `{timestamp}` and
-    `{datestamp}`. Defaults to "UTC". For a list of possible values, please see -https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-  label: Timestamp Timezone
-  name: timestamp_timezone
-- description: Allows inline stream transformations and aliasing. For more information
-    see - https://sdk.meltano.com/en/latest/stream_maps.html
-  kind: object
-  label: Stream Maps
-  name: stream_maps
+- description: |
+    Determines the overwrite behavior if destination file already exists.
+    Must be one of the following string values:
+      - `append_records` (default): append records at the insertion point
+      - `replace_records`: replace all records at the insertion point
+      - `replace_file`: replace entire file using `default_yaml_template`
+  label: Overwrite Behavior
+  name: overwrite_behavior
 - description: |
     A jsonpath string determining the insertion point for new records.
     Currently, this must be the path to a map key which will be populated by a list of records.  For example "$.metrics" will populate the file with `metrics - [{<record1>},{<record2>},...]`  For JSONPath syntax help, see - https://jsonpath.com
@@ -52,16 +51,18 @@ settings:
     property is omitted, records will not be sorted.
   label: Record Sort Property Name
   name: record_sort_property_name
-- description: |
-    Determines the overwrite behavior if destination file already exists.
-    Must be one of the following string values:
-      - `append_records` (default): append records at the insertion point
-      - `replace_records`: replace all records at the insertion point
-      - `replace_file`: replace entire file using `default_yaml_template`
-  label: Overwrite Behavior
-  name: overwrite_behavior
-- description: Text string to use for a yaml template file. This text will be used
-    to create a new file if the destination file does not exist.
-  label: Default Yaml Template
-  name: default_yaml_template
+- description: Allows inline stream transformations and aliasing. For more information
+    see - https://sdk.meltano.com/en/latest/stream_maps.html
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+- description: A python format string to use when outputting the `{datestamp}` string.
+    For reference, see - https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+  label: Timestamp Format
+  name: timestamp_format
+- description: The timezone code or name to use when generating `{timestamp}` and
+    `{datestamp}`. Defaults to "UTC". For a list of possible values, please see -https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+  label: Timestamp Timezone
+  name: timestamp_timezone
 variant: meltanolabs
+settings_group_validation: []


### PR DESCRIPTION
This is the first set of variants that I'll try to auto update. To make the next set of changes more readable this PR simply enforces a consistent sort ordering so subsequent auto updates wont have volatile diffs that change each time.

The sort logic is alpha sort by value and for settings we use `name` as the sort value.