### PR TITLE
add metadata refresh workflow

### DIFF
--- a/.github/workflows/metadata-refresh.yml
+++ b/.github/workflows/metadata-refresh.yml
@@ -19,7 +19,7 @@ jobs:
   metadata_refresh:
     name: Metadata Refresh
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment == 'production' || github.event_name == 'schedule' && 'production' || 'preview' }}
+    environment: ${{ github.event.inputs.environment || github.event_name == 'schedule' && 'production' || 'preview' }}
     env:
       AWS_S3_BUCKET: "${{secrets.HUB_METADATA_S3_BUCKET }}"
     permissions:
@@ -53,7 +53,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:
-        token: ${{ secrets.GH_PAT }}
+        token: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}
         commit-message: Refresh plugin metadata ${{ steps.date.outputs.date }}
         committer: GitHub <noreply@github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
@@ -62,8 +62,7 @@ jobs:
         delete-branch: true
         title: '[Hub Bot] Refresh metadata ${{ steps.date.outputs.date }}'
         body: |
-          Test
-          - testing
+          Updates Plugin Definitions
         assignees: pnadolny13
         reviewers: pnadolny13
         draft: false

--- a/.github/workflows/metadata-refresh.yml
+++ b/.github/workflows/metadata-refresh.yml
@@ -1,0 +1,54 @@
+name: Metadata Refresh
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'The environment to run the workflow in'
+        required: true
+        type: choice
+        default: 'preview'
+        options:
+          - 'preview'
+          - 'production'
+  # schedule:
+  #   - cron: '0 0 * * *' # Run at midnight UTC
+
+jobs:
+
+  metadata_refresh:
+    name: Metadata Refresh
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment == 'production' || github.event_name == 'schedule' && 'production' || 'preview' }}
+    env:
+      AWS_S3_BUCKET: "${{secrets.HUB_METADATA_S3_BUCKET }}"
+    permissions:
+      id-token: write # This is required for requesting the JWT
+    steps:
+    - uses: actions/checkout@v3.3.0
+      # TODO: will need this to trigger CI jobs
+      # with:
+      #   token: ${{ secrets.GH_PAT }}
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2.0.0
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        aws-region: us-west-2
+        role-session-name: "GitHubActions"
+
+    - name: Install hub_utils
+      run: pipx install git+https://github.com/pnadolny13/hub-utils.git@main
+
+    - name: Download Raw JSON Output
+      run: hub_utils download-metadata "/home/runner/work/downloaded_data"
+
+    - name: Merge Raw JSON and Existing Definition
+      run: hub_utils merge-metadata $(pwd) "/home/runner/work/downloaded_data"
+
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        add: '_data/meltano/*.yml'
+        message: 'Hub bot update'
+        new_branch: hub-bot-metadata-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}

--- a/.github/workflows/metadata-refresh.yml
+++ b/.github/workflows/metadata-refresh.yml
@@ -46,9 +46,24 @@ jobs:
     - name: Merge Raw JSON and Existing Definition
       run: hub_utils merge-metadata $(pwd) "/home/runner/work/downloaded_data"
 
-    - name: Commit changes
-      uses: EndBug/add-and-commit@v9
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
       with:
-        add: '_data/meltano/*.yml'
-        message: 'Hub bot update'
-        new_branch: hub-bot-metadata-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+        token: ${{ secrets.GH_PAT }}
+        commit-message: Refresh plugin metadata ${{ steps.date.outputs.date }}
+        committer: GitHub <noreply@github.com>
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        signoff: false
+        branch: hub-bot-metadata-${{ steps.date.outputs.date }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+        delete-branch: true
+        title: '[Hub Bot] Refresh metadata ${{ steps.date.outputs.date }}'
+        body: |
+          Test
+          - testing
+        assignees: pnadolny13
+        reviewers: pnadolny13
+        draft: false

--- a/.github/workflows/metadata-refresh.yml
+++ b/.github/workflows/metadata-refresh.yml
@@ -26,9 +26,6 @@ jobs:
       id-token: write # This is required for requesting the JWT
     steps:
     - uses: actions/checkout@v3.3.0
-      # TODO: will need this to trigger CI jobs
-      # with:
-      #   token: ${{ secrets.GH_PAT }}
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v2.0.0

--- a/.github/workflows/metadata-refresh.yml
+++ b/.github/workflows/metadata-refresh.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || github.event_name == 'schedule' && 'production' || 'preview' }}
     env:
-      AWS_S3_BUCKET: "${{secrets.HUB_METADATA_S3_BUCKET }}"
+      AWS_S3_BUCKET: "${{ secrets.HUB_METADATA_S3_BUCKET }}"
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
@@ -60,7 +60,7 @@ jobs:
         signoff: false
         branch: hub-bot-metadata-${{ steps.date.outputs.date }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
         delete-branch: true
-        title: '[Hub Bot] Refresh metadata ${{ steps.date.outputs.date }}'
+        title: 'chore: [Hub Bot] Refresh metadata ${{ steps.date.outputs.date }}'
         body: |
           Updates Plugin Definitions
         assignees: pnadolny13


### PR DESCRIPTION
Note that this is not a scheduled job yet. I dont have a way to test it until some version of the workflow is in main. I'd like to merge this then iterate on it a bit in a second PR where I also turn the schedule on along with the extraction job https://github.com/meltano/hub/pull/1208.

- Downloads the raw json files extracted by https://github.com/meltano/hub/pull/1208. It defaults to only SDK variants right now.
- Merge the downloaded json files with the existing definitions
- Create branch, commit changes, open PR

The create-pull-request GH action requires some credentials to allow it to open a PR https://github.com/peter-evans/create-pull-request#action-inputs. Currently we're referencing `secrets.GH_PAT`.

> Note: If you want pull requests created by this action to trigger an on: push or on: pull_request workflow then you cannot use the default GITHUB_TOKEN. See the [documentation here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) for workarounds.
