### PR TITLE
fix: Adjust environment conditional for metadata extract action

### DIFF
--- a/.github/workflows/metadata-extract.yml
+++ b/.github/workflows/metadata-extract.yml
@@ -62,7 +62,7 @@ jobs:
     name: SDK Extractors - Metadata Extract
     needs: get_variants_list
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment == 'production' || github.event_name == 'schedule' && 'production' || 'preview' }}
+    environment: ${{ github.event.inputs.environment || github.event_name == 'schedule' && 'production' || 'preview' }}
     env:
       AWS_S3_BUCKET: "${{secrets.HUB_METADATA_S3_BUCKET }}"
     strategy:
@@ -120,7 +120,7 @@ jobs:
     name: SDK Loaders - Metadata Extract
     needs: get_variants_list
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment == 'production' || github.event_name == 'schedule' && 'production' || 'preview' }}
+    environment: ${{ github.event.inputs.environment || github.event_name == 'schedule' && 'production' || 'preview' }}
     env:
       AWS_S3_BUCKET: "${{secrets.HUB_METADATA_S3_BUCKET }}"
     strategy:
@@ -199,7 +199,7 @@ jobs:
     if: ${{ always() }}
     needs: [metadata_extract_airbyte_p1, get_variants_list]
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment == 'production' || github.event_name == 'schedule' && 'production' || 'preview' }}
+    environment: ${{ github.event.inputs.environment || github.event_name == 'schedule' && 'production' || 'preview' }}
     env:
       AWS_S3_BUCKET: "${{secrets.HUB_METADATA_S3_BUCKET }}"
     strategy:


### PR DESCRIPTION
This conditional is not actually setting 'production' as the environment. 

Ran a few tests on another branch. Basically getting a failed when setting credentials error where it's not using an env at all. Switching to removing the conditional so it uses the input environment and when selecting `production` now I am at least getting a job failed status where it doesn't attempt to run the action at all since the production env is protected by a branch rule for main only deployments. Selecting preview works as expected since preview can run on any branch. 