### PR TITLE
feat: Deselect `traffic*` streams by default in tap-github (meltanolabs)

### DIFF
--- a/_data/meltano/extractors/tap-github/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-github/meltanolabs.yml
@@ -18,6 +18,9 @@ name: tap-github
 namespace: tap_github
 pip_url: git+https://github.com/MeltanoLabs/tap-github.git
 repo: https://github.com/MeltanoLabs/tap-github
+select:
+- "*.*"
+- "!traffic_*.*"
 settings:
 - description: List of GitHub tokens to authenticate with. Streams will loop through
     them when hitting rate limits.


### PR DESCRIPTION
See https://github.com/MeltanoLabs/tap-github/pull/193