### PR TITLE
Recruitee refresh

### DIFF
--- a/_data/meltano/extractors/tap-recruitee/rawwar.yml
+++ b/_data/meltano/extractors/tap-recruitee/rawwar.yml
@@ -1,0 +1,63 @@
+capabilities:
+- about
+- catalog
+- discover
+- schema-flattening
+- state
+- stream-maps
+description: Talent Acquisition Platform
+domain_url: https://recruitee.com/
+executable: tap-recruitee
+keywords:
+- meltano_sdk
+- api
+label: Recruitee
+logo_url: /assets/logos/extractors/recruitee.png
+maintenance_status: development
+name: tap-recruitee
+namespace: tap_recruitee
+next_steps: ''
+pip_url: git+https://github.com/rawwar/tap-recruitee.git
+repo: https://github.com/rawwar/tap-recruitee
+settings:
+- description: The url for the API service
+  kind: string
+  label: API URL
+  name: api_url
+  value: https://api.mysample.com
+- description: The token to authenticate against the API service
+  kind: password
+  label: Auth Token
+  name: auth_token
+- description: "'True' to enable schema flattening and automatically expand nested\
+    \ properties."
+  kind: boolean
+  label: Flattening Enabled
+  name: flattening_enabled
+- description: The max depth to flatten schemas.
+  kind: integer
+  label: Flattening Max Depth
+  name: flattening_max_depth
+- description: Project IDs to replicate
+  kind: array
+  label: Project IDs
+  name: project_ids
+- description: The earliest record date to sync
+  kind: date_iso8601
+  label: Start Date
+  name: start_date
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+settings_group_validation:
+- - auth_token
+  - project_ids
+settings_preamble: ''
+usage: ''
+variant: rawwar

--- a/_data/meltano/extractors/tap-recruitee/tahasadiki.yml
+++ b/_data/meltano/extractors/tap-recruitee/tahasadiki.yml
@@ -1,6 +1,7 @@
 capabilities:
 - catalog
 - discover
+- state
 description: Talent Acquisition Platform
 domain_url: https://recruitee.com/
 keywords:
@@ -10,7 +11,35 @@ logo_url: /assets/logos/extractors/recruitee.png
 maintenance_status: unknown
 name: tap-recruitee
 namespace: tap_recruitee
-pip_url: git+https://github.com/Tahasadiki/tap-recruitee.git
+pip_url: >
+  git+https://github.com/Tahasadiki/tap-recruitee.git
+  attrs==18.1.0
+  backoff==1.3.2
+  python-dateutil==2.7.3
+  requests==2.20.0
+  singer-python==5.3.3
 repo: https://github.com/Tahasadiki/tap-recruitee
-settings: []
+settings:
+- description: The url for the API service
+  kind: string
+  label: URL
+  name: url
+  value: https://api.recruitee.com/
+- description: The earliest record date to sync
+  kind: date_iso8601
+  label: Start Date
+  name: start_date
+- description: The token to authenticate against the API service
+  kind: password
+  label: Auth Token
+  name: auth_token
+- description: The Recruitee company ID.
+  kind: string
+  label: Company ID
+  name: company_id
+settings_group_validation:
+- - auth_token
+  - company_id
+  - start_date
+  - url
 variant: tahasadiki


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/989

- fixes the bug by pinning additional dependencies explicitly as suggested by @edgarrmondragon. I'm now able to install and run `--help` successfully.
- add @rawwar's new SDK variant - It looks like its not completely done yet but its set as `development` status and will let others know that theres something thats work in progress. Also it opens the option for others to join forces with you if they were thinking about rebuilding this tap also.