### PR TITLE
hide tap-abcfinancial

### DIFF
--- a/_data/meltano/extractors/tap-abcfinancial/dmzobel.yml
+++ b/_data/meltano/extractors/tap-abcfinancial/dmzobel.yml
@@ -4,6 +4,7 @@ capabilities:
 - state
 description: SaaS solution for club management
 domain_url: https://abcfinancial.3scale.net
+hidden: true
 keywords:
 - api
 label: ABC Fitness Solutions


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/991

I opened https://github.com/dmzobel/tap-abcfinancial/pull/5 to fix the issue but until its merged, if ever since that repo is stale, we should hide this tap.