### PR TITLE
bump meltanolabs statuses

### DIFF
--- a/_data/meltano/extractors/tap-airbyte-wrapper/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-airbyte-wrapper/meltanolabs.yml
@@ -13,7 +13,7 @@ keywords:
 - airbyte_protocol
 label: Airbyte Protocol Wrapper
 logo_url: /assets/logos/extractors/airbyte.png
-maintenance_status: beta
+maintenance_status: active
 name: tap-airbyte-wrapper
 namespace: tap_airbyte_wrapper
 next_steps: ''

--- a/_data/meltano/extractors/tap-duckdb/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-duckdb/meltanolabs.yml
@@ -13,7 +13,7 @@ keywords:
 - database
 label: DuckDB
 logo_url: /assets/logos/extractors/duckdb.png
-maintenance_status: development
+maintenance_status: beta
 name: tap-duckdb
 namespace: tap_duckdb
 next_steps: ''

--- a/_data/meltano/extractors/tap-dynamodb/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-dynamodb/meltanolabs.yml
@@ -13,7 +13,7 @@ keywords:
 - aws
 label: DynamoDB
 logo_url: /assets/logos/extractors/dynamodb.png
-maintenance_status: beta
+maintenance_status: active
 name: tap-dynamodb
 namespace: tap_dynamodb
 next_steps: ''

--- a/_data/meltano/extractors/tap-messagebird/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-messagebird/meltanolabs.yml
@@ -12,7 +12,7 @@ keywords:
 - api
 label: Messagebird
 logo_url: /assets/logos/extractors/messagebird.png
-maintenance_status: development
+maintenance_status: active
 name: tap-messagebird
 namespace: tap_messagebird
 next_steps: ''

--- a/_data/meltano/extractors/tap-postgres/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-postgres/meltanolabs.yml
@@ -12,7 +12,7 @@ keywords:
 - database
 label: Postgres
 logo_url: /assets/logos/extractors/postgres.png
-maintenance_status: development
+maintenance_status: active
 name: tap-postgres
 namespace: tap_postgres
 next_steps: ''

--- a/_data/meltano/extractors/tap-pulumi-cloud/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-pulumi-cloud/meltanolabs.yml
@@ -11,7 +11,7 @@ keywords:
 - meltano_sdk
 label: Pulumi Cloud
 logo_url: /assets/logos/extractors/pulumi-cloud.png
-maintenance_status: beta
+maintenance_status: active
 name: tap-pulumi-cloud
 namespace: tap_pulumi_cloud
 next_steps: ''

--- a/_data/meltano/extractors/tap-snowflake/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-snowflake/meltanolabs.yml
@@ -12,7 +12,7 @@ keywords:
 - database
 label: Snowflake
 logo_url: /assets/logos/extractors/snowflake.png
-maintenance_status: development
+maintenance_status: active
 name: tap-snowflake
 namespace: tap_snowflake
 next_steps: ''

--- a/_data/meltano/loaders/target-postgres/meltanolabs.yml
+++ b/_data/meltano/loaders/target-postgres/meltanolabs.yml
@@ -11,7 +11,7 @@ keywords:
 - database
 label: Postgres
 logo_url: /assets/logos/loaders/postgres.png
-maintenance_status: beta
+maintenance_status: active
 name: target-postgres
 namespace: target_postgres
 next_steps: ''


### PR DESCRIPTION
Most of the meltanolabs variants on the hub should be set to active status. I refreshed them.

These I still left in beta:
- target-snowflake
- target-chroma
- tap-duckdb