### PR TITLE
add credentials env var back in for tap bq

### DIFF
--- a/_data/meltano/extractors/tap-bigquery/anelendata.yml
+++ b/_data/meltano/extractors/tap-bigquery/anelendata.yml
@@ -33,10 +33,10 @@ settings:
     See the ["Activate the Google BigQuery API" section of the repository's README](https://github.com/anelendata/tap-bigquery#step-1-activate-the-google-bigquery-api) and <https://cloud.google.com/docs/authentication/production>.
 
     By default, this file is expected to be at the root of your project directory.
+  env: GOOGLE_APPLICATION_CREDENTIALS
   label: Credentials Path
   name: credentials_path
   value: $MELTANO_PROJECT_ROOT/client_secrets.json
-  env: GOOGLE_APPLICATION_CREDENTIALS
 - description: Determines how much historical data will be extracted. Please be aware
     that the larger the time period and amount of data, the longer the initial extraction
     can be expected to take.

--- a/_data/meltano/extractors/tap-bigquery/anelendata.yml
+++ b/_data/meltano/extractors/tap-bigquery/anelendata.yml
@@ -36,6 +36,7 @@ settings:
   label: Credentials Path
   name: credentials_path
   value: $MELTANO_PROJECT_ROOT/client_secrets.json
+  env: GOOGLE_APPLICATION_CREDENTIALS
 - description: Determines how much historical data will be extracted. Please be aware
     that the larger the time period and amount of data, the longer the initial extraction
     can be expected to take.


### PR DESCRIPTION
It looks like this is an artificial setting that populates an env var for the tap to use but it was removed as the env var in https://github.com/meltano/hub/commit/da31d3018065e4ebc8a254c89dc9167079f99de7.

Related to a slack thread https://meltano.slack.com/archives/C01TCRBBJD7/p1684142412086759