### PR TITLE
Add quality attribute - Part 1

### DIFF
--- a/_data/meltano/extractors/tap-exacttarget/uptilab2.yml
+++ b/_data/meltano/extractors/tap-exacttarget/uptilab2.yml
@@ -17,11 +17,13 @@ settings:
   kind: boolean
   label: Discover Data Extension
   name: discover_data_extension
-- description: A setting to alter the replication method to incremental mode. This can also be done using the tap's [stream metadata settings](https://docs.meltano.com/guide/integration#replication-methods).
+- description: A setting to alter the replication method to incremental mode. This
+    can also be done using the tap's [stream metadata settings](https://docs.meltano.com/guide/integration#replication-methods).
   kind: boolean
   label: Incremental Mode Send
   name: incremental_mode_send
-- description: The amount of days to offset the start date or bookmarked date by. The value is an integer in days. Default, None.
+- description: The amount of days to offset the start date or bookmarked date by.
+    The value is an integer in days. Default, None.
   kind: integer
   label: Offset Start Date (Days)
   name: offset_start_date

--- a/_data/meltano/extractors/tap-github/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-github/meltanolabs.yml
@@ -19,8 +19,8 @@ namespace: tap_github
 pip_url: git+https://github.com/MeltanoLabs/tap-github.git
 repo: https://github.com/MeltanoLabs/tap-github
 select:
-- "*.*"
-- "!traffic_*.*"
+- '*.*'
+- '!traffic_*.*'
 settings:
 - description: List of GitHub tokens to authenticate with. Streams will loop through
     them when hitting rate limits.

--- a/_data/meltano/extractors/tap-mysql/transferwise.yml
+++ b/_data/meltano/extractors/tap-mysql/transferwise.yml
@@ -62,7 +62,7 @@ settings:
     Can be either 'mysql' or 'mariadb'.
   label: Engine
   name: engine
-  value: 'mysql'
+  value: mysql
 - description: Whether the MySQL/MariaDB connection should use SSL.
   kind: boolean
   label: SSL
@@ -87,10 +87,10 @@ settings:
   label: Session SQLs
   name: session_sqls
   value:
-  - "SET @@session.time_zone='+0:00'"
-  - "SET @@session.wait_timeout=28800"
-  - "SET @@session.net_read_timeout=3600"
-  - "SET @@session.innodb_lock_wait_timeout=3600"
+  - SET @@session.time_zone='+0:00'
+  - SET @@session.wait_timeout=28800
+  - SET @@session.net_read_timeout=3600
+  - SET @@session.innodb_lock_wait_timeout=3600
 settings_group_validation:
 - - host
   - port

--- a/_data/meltano/extractors/tap-netsuite/gthesheep.yml
+++ b/_data/meltano/extractors/tap-netsuite/gthesheep.yml
@@ -23,7 +23,8 @@ settings:
   kind: password
   label: NetSuite Client ID
   name: client_id
-- description: Your Client Secret for token based authentication consumer key for REST connection.
+- description: Your Client Secret for token based authentication consumer key for
+    REST connection.
   kind: password
   label: NetSuite Client Secret
   name: client_secret

--- a/_data/meltano/extractors/tap-norwaycitybikeapi/andrejakobsen.yml
+++ b/_data/meltano/extractors/tap-norwaycitybikeapi/andrejakobsen.yml
@@ -23,7 +23,7 @@ settings:
     a dash and the application's name.
   label: Client-Identifier Header
   name: client_identifier
-- description: "Choose between three Norwegian cities: Trondheim, Oslo and Bergen"
+- description: 'Choose between three Norwegian cities: Trondheim, Oslo and Bergen'
   label: City Name
   name: city_name
 settings_group_validation:

--- a/_data/meltano/extractors/tap-singer-jsonl/kgpayne.yml
+++ b/_data/meltano/extractors/tap-singer-jsonl/kgpayne.yml
@@ -15,7 +15,8 @@ next_steps: ''
 pip_url: tap-singer-jsonl
 repo: https://github.com/kgpayne/tap-singer-jsonl
 settings:
-- description: The source configuration to use when reading `.singer.gz` files. Currently `local` and `s3` are supported.
+- description: The source configuration to use when reading `.singer.gz` files. Currently
+    `local` and `s3` are supported.
   kind: string
   label: Source
   name: source
@@ -29,12 +30,15 @@ settings:
   kind: array
   label: Folders
   name: local.folders
-- description: Whether to scan directories recursively when discovering `.singer.gz` files.
+- description: Whether to scan directories recursively when discovering `.singer.gz`
+    files.
   kind: boolean
   label: Recursive
   name: local.recursive
   value: false
-- description: Array of file paths to singer-formatted files. **Note:** extension is ignored, and compression is inferred automatically by `smart_open`. Both `local.folders` and `local.paths` can be specified together.
+- description: Array of file paths to singer-formatted files. **Note:** extension
+    is ignored, and compression is inferred automatically by `smart_open`. Both `local.folders`
+    and `local.paths` can be specified together.
   kind: array
   label: Paths
   name: local.paths
@@ -46,7 +50,9 @@ settings:
   kind: string
   label: Prefix
   name: s3.prefix
-- description: S3 file paths to singer-formatted files. **Note:** extension is ignored, and compression is inferred automatically by `smart_open`. Both `s3.prefix` and `s3.paths` can be specified together.
+- description: S3 file paths to singer-formatted files. **Note:** extension is ignored,
+    and compression is inferred automatically by `smart_open`. Both `s3.prefix` and
+    `s3.paths` can be specified together.
   kind: array
   label: Paths
   name: s3.paths

--- a/_data/meltano/extractors/tap-snapchat-ads/gthesheep.yml
+++ b/_data/meltano/extractors/tap-snapchat-ads/gthesheep.yml
@@ -40,7 +40,8 @@ settings:
   label: Swipe Up Attribution Window
   name: swipe_up_attribution_window
   value: 28_DAY
-- description: Attribution window for views 1_HOUR, 3_HOUR, 6_HOUR, 1_DAY (default), 7_DAY, 28_DAY
+- description: Attribution window for views 1_HOUR, 3_HOUR, 6_HOUR, 1_DAY (default),
+    7_DAY, 28_DAY
   kind: string
   label: View Attribution Window
   name: view_attribution_window
@@ -61,7 +62,8 @@ settings:
   kind: object
   label: Stream Map Config
   name: stream_map_config
-- description: "'True' to enable schema flattening and automatically expand nested properties."
+- description: "'True' to enable schema flattening and automatically expand nested\
+    \ properties."
   kind: boolean
   label: Flattening Enabled
   name: flattening_enabled

--- a/_data/meltano/loaders/target-duckdb/jwills.yml
+++ b/_data/meltano/loaders/target-duckdb/jwills.yml
@@ -89,6 +89,6 @@ settings:
   label: Temporary Directory
   name: temp_dir
 settings_group_validation:
-- - 'filepath'
-  - 'default_target_schema'
+- - filepath
+  - default_target_schema
 variant: jwills

--- a/_data/meltano/loaders/target-elasticsearch/dtmirizzi.yml
+++ b/_data/meltano/loaders/target-elasticsearch/dtmirizzi.yml
@@ -74,7 +74,7 @@ settings:
   kind: string
   label: Index Format
   name: index_format
-  value: 'ecs-{{ stream_name }}-{{ current_timestamp_daily }}'
+  value: ecs-{{ stream_name }}-{{ current_timestamp_daily }}
 - description: |
     Index Schema Fields allows you to specify specific record values via jsonpath
     from the stream to be used in index formulation.

--- a/_data/meltano/loaders/target-gcs/datateer.yml
+++ b/_data/meltano/loaders/target-gcs/datateer.yml
@@ -24,7 +24,7 @@ settings:
 - description: The date formate for the export date used in the bucket key path
   kind: string
   name: date_format
-  value: "%Y-%m-%d"
+  value: '%Y-%m-%d'
 - description: This is the base key prefix which lets you define where the stream
     will write to in the bucket. By default, we use `meltano/${MELTANO_EXTRACT__LOAD_SCHEMA}/`
     which is derived from the tap. For example tap-jira would end up in meltano/tap_jira/...
@@ -36,7 +36,7 @@ settings:
     convention uses hive style partitioning
   kind: string
   name: key_naming_convention
-  value: "{stream}/export_date={date}/{timestamp}.jsonl"
+  value: '{stream}/export_date={date}/{timestamp}.jsonl'
 settings_group_validation:
 - - bucket_name
   - credentials_file

--- a/_data/meltano/loaders/target-iomete/iomete.yml
+++ b/_data/meltano/loaders/target-iomete/iomete.yml
@@ -5,7 +5,7 @@ description: Serverless lakehouse platform.
 domain_url: https://iomete.com/
 executable: singer-target-iomete
 keywords:
-- 'lakehouse'
+- lakehouse
 label: IOMETE
 logo_url: /assets/logos/loaders/iomete.png
 maintenance_status: active

--- a/_data/meltano/loaders/target-singer-jsonl/kgpayne.yml
+++ b/_data/meltano/loaders/target-singer-jsonl/kgpayne.yml
@@ -14,7 +14,8 @@ next_steps: ''
 pip_url: target-singer-jsonl
 repo: https://github.com/kgpayne/target-singer-jsonl
 settings:
-- description: The destination configuration to use. Currently `local` and `s3` are supported.
+- description: The destination configuration to use. Currently `local` and `s3` are
+    supported.
   kind: string
   label: Destination
   name: destination

--- a/_data/meltano/orchestrators/airflow/apache.yml
+++ b/_data/meltano/orchestrators/airflow/apache.yml
@@ -1,7 +1,7 @@
 commands:
   create-admin:
-    args: "users create --username admin --firstname FIRST_NAME --lastname LAST_NAME\
-      \ --role Admin --email admin@example.org"
+    args: users create --username admin --firstname FIRST_NAME --lastname LAST_NAME
+      --role Admin --email admin@example.org
     description: Create an admin user.
   ui:
     args: webserver

--- a/_data/meltano/transformers/dbt-bigquery/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt-bigquery/dbt-labs.yml
@@ -66,14 +66,14 @@ settings:
   label: Authentication Method
   name: auth_method
 - aliases:
-  - "database"
+  - database
   description: |
     The BigQuery project ID.
   kind: string
   label: Project
   name: project
 - aliases:
-  - "schema"
+  - schema
   description: |
     The dataset to use.
   kind: string
@@ -84,14 +84,14 @@ settings:
   label: Refresh Token
   name: refresh_token
 - aliases:
-  - "user"
+  - user
   description: |
     The client id to use, if authenticating via oauth-secrets method.
   kind: string
   label: Client ID
   name: client_id
 - aliases:
-  - "password"
+  - password
   description: |
     The client secret to use, if authenticating via oauth-secrets method.
   kind: password

--- a/_data/meltano/transformers/dbt-postgres/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt-postgres/dbt-labs.yml
@@ -81,7 +81,7 @@ settings:
   label: Port
   name: port
 - aliases:
-  - "database"
+  - database
   description: |
     The db to connect to.
   kind: string

--- a/_data/meltano/transformers/dbt-redshift/dbt-labs.yml
+++ b/_data/meltano/transformers/dbt-redshift/dbt-labs.yml
@@ -92,7 +92,7 @@ settings:
   label: Port
   name: port
 - aliases:
-  - "database"
+  - database
   description: |
     The name of the db to connect to.
   kind: string

--- a/_data/meltano/utilities/airflow/apache.yml
+++ b/_data/meltano/utilities/airflow/apache.yml
@@ -1,7 +1,7 @@
 commands:
   create-admin:
-    args: "users create --username admin --firstname FIRST_NAME --lastname LAST_NAME\
-      \ --role Admin --email admin@example.org"
+    args: users create --username admin --firstname FIRST_NAME --lastname LAST_NAME
+      --role Admin --email admin@example.org
     description: Create an Airflow user with admin privileges.
   describe:
     args: describe

--- a/_data/meltano/utilities/clickhouse/clickhouse.yml
+++ b/_data/meltano/utilities/clickhouse/clickhouse.yml
@@ -4,8 +4,8 @@ commands:
     container_spec:
       image: clickhouse/clickhouse-server:latest
       ports:
-        "8123": "8123"
-        "9000": "9000"
+        '8123': '8123'
+        '9000': '9000'
 definition: is a containerized instance of Clickhouse useful for local development.
 description: Open source, column-oriented data warehouse.
 docs: https://clickhouse.com/docs/

--- a/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
@@ -97,14 +97,14 @@ settings:
   label: Authentication Method
   name: auth_method
 - aliases:
-  - "database"
+  - database
   description: |
     The BigQuery project ID.
   kind: string
   label: Project
   name: project
 - aliases:
-  - "schema"
+  - schema
   description: |
     The dataset to use.
   kind: string
@@ -116,14 +116,14 @@ settings:
   label: Refresh Token
   name: refresh_token
 - aliases:
-  - "user"
+  - user
   description: |
     The client id to use, if authenticating via oauth-secrets method.
   kind: string
   label: Client ID
   name: client_id
 - aliases:
-  - "password"
+  - password
   description: |
     The client secret to use, if authenticating via oauth-secrets method.
   kind: password

--- a/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
@@ -111,7 +111,7 @@ settings:
   label: Port
   name: port
 - aliases:
-  - "database"
+  - database
   description: |
     The db to connect to.
   kind: string

--- a/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
@@ -123,7 +123,7 @@ settings:
   label: Port
   name: port
 - aliases:
-  - "database"
+  - database
   description: |
     The name of the db to connect to.
   kind: string

--- a/_data/meltano/utilities/evidence/meltanolabs.yml
+++ b/_data/meltano/utilities/evidence/meltanolabs.yml
@@ -5,7 +5,8 @@ commands:
     executable: evidence_extension
   build-strict:
     args: build --strict
-    description: Build your Evidence, but fail if there are errors in components. Commonly used in CI/CD.
+    description: Build your Evidence, but fail if there are errors in components.
+      Commonly used in CI/CD.
     executable: evidence_extension
   describe:
     args: describe
@@ -213,9 +214,9 @@ settings:
   label: Send Anonymous Usage Stats
   name: send_anonymous_usage_stats
   options:
-  - value: 'yes'
-  - value: 'no'
-  value: 'yes'
+  - value: yes
+  - value: no
+  value: yes
 settings_group_validation:
 - - home_dir
 - - home_dir

--- a/_data/meltano/utilities/metabase/metabase.yml
+++ b/_data/meltano/utilities/metabase/metabase.yml
@@ -10,9 +10,9 @@ commands:
         PWD: /
       image: metabase/metabase:latest
       ports:
-        "3000": "3000/tcp"
+        '3000': 3000/tcp
       volumes:
-      - "$MELTANO_PROJECT_ROOT/.meltano/utilities/metabase/data/:/metabase-data"
+      - $MELTANO_PROJECT_ROOT/.meltano/utilities/metabase/data/:/metabase-data
 description: Metabase is the easy, open-source way for everyone in your company to
   ask questions and learn from data.
 docs: https://www.metabase.com/

--- a/_data/meltano/utilities/postgres/postgres.yml
+++ b/_data/meltano/utilities/postgres/postgres.yml
@@ -10,9 +10,9 @@ commands:
         POSTGRES_USER: warehouse
       image: postgres:15
       ports:
-        "5432": "5432/tcp"
+        '5432': 5432/tcp
       volumes:
-      - "$MELTANO_PROJECT_ROOT/.meltano/utilities/postgres/data/:/var/lib/postgresql/data"
+      - $MELTANO_PROJECT_ROOT/.meltano/utilities/postgres/data/:/var/lib/postgresql/data
 definition: is a containerized instance of Postgres useful for local development.
 description: The World's Most Advanced Open Source Relational Database.
 docs: https://www.postgresql.org/

--- a/_data/meltano/utilities/superset/apache.yml
+++ b/_data/meltano/utilities/superset/apache.yml
@@ -91,7 +91,7 @@ settings:
     option along with `ui.port`.
   label: UI Bind Host
   name: ui.bind_host
-  value: "0.0.0.0"
+  value: 0.0.0.0
 - description: Port used by `meltano invoke superset:ui`. Used in the `gunicorn` `--bind`
     option along with `ui.bind_host`.
   label: UI Port

--- a/_data/meltano/utilities/superset/meltano.yml
+++ b/_data/meltano/utilities/superset/meltano.yml
@@ -103,7 +103,7 @@ settings:
     option along with `ui.port`.
   label: UI Bind Host
   name: ui.bind_host
-  value: "0.0.0.0"
+  value: 0.0.0.0
 - description: Port used by `meltano invoke superset:ui`. Used in the `gunicorn` `--bind`
     option along with `ui.bind_host`.
   label: UI Port

--- a/schemas/plugin_definitions/extractors.schema.json
+++ b/schemas/plugin_definitions/extractors.schema.json
@@ -37,6 +37,7 @@
                 "schema": {},
                 "select": {},
                 "maintenance_status": {},
+                "quality": {},
                 "domain_url": {},
                 "keywords": {},
                 "requires": {},

--- a/schemas/plugin_definitions/files.schema.json
+++ b/schemas/plugin_definitions/files.schema.json
@@ -32,6 +32,7 @@
                 "variant": {},
                 "logo_url": {},
                 "maintenance_status": {},
+                "quality": {},
                 "domain_url": {},
                 "keywords": {},
                 "definition": {},

--- a/schemas/plugin_definitions/hub_metadata.schema.json
+++ b/schemas/plugin_definitions/hub_metadata.schema.json
@@ -17,6 +17,17 @@
             ],
             "description": "The maintenance_status of the variant."
         },
+        "quality": {
+            "type": "string",
+            "title": "Connector Quality",
+            "enum": [
+                "gold",
+                "silver",
+                "bronze",
+                "unknown"
+            ],
+            "description": "The connector quality rating as defined in https://docs.meltano.com/cloud/connectors#connector-quality."
+        },
         "domain_url": {
             "type": ["string", "null"],
             "format": "uri",

--- a/schemas/plugin_definitions/loaders.schema.json
+++ b/schemas/plugin_definitions/loaders.schema.json
@@ -36,6 +36,7 @@
                 "hidden": {},
                 "requires": {},
                 "maintenance_status": {},
+                "quality": {},
                 "domain_url": {},
                 "keywords": {},
                 "definition": {},

--- a/schemas/plugin_definitions/mappers.schema.json
+++ b/schemas/plugin_definitions/mappers.schema.json
@@ -31,6 +31,7 @@
                 "logo_url": {},
                 "requires": {},
                 "maintenance_status": {},
+                "quality": {},
                 "domain_url": {},
                 "keywords": {},
                 "definition": {},

--- a/schemas/plugin_definitions/orchestrators.schema.json
+++ b/schemas/plugin_definitions/orchestrators.schema.json
@@ -29,6 +29,7 @@
                 "logo_url": {},
                 "requires": {},
                 "maintenance_status": {},
+                "quality": {},
                 "domain_url": {},
                 "keywords": {},
                 "definition": {},

--- a/schemas/plugin_definitions/transformers.schema.json
+++ b/schemas/plugin_definitions/transformers.schema.json
@@ -29,6 +29,7 @@
                 "logo_url": {},
                 "requires": {},
                 "maintenance_status": {},
+                "quality": {},
                 "domain_url": {},
                 "keywords": {},
                 "definition": {},

--- a/schemas/plugin_definitions/transforms.schema.json
+++ b/schemas/plugin_definitions/transforms.schema.json
@@ -29,6 +29,7 @@
                 "package_name": {},
                 "vars": {},
                 "maintenance_status": {},
+                "quality": {},
                 "domain_url": {},
                 "keywords": {},
                 "definition": {},

--- a/schemas/plugin_definitions/utilities.schema.json
+++ b/schemas/plugin_definitions/utilities.schema.json
@@ -30,6 +30,7 @@
                 "logo_url": {},
                 "requires": {},
                 "maintenance_status": {},
+                "quality": {},
                 "domain_url": {},
                 "keywords": {},
                 "definition": {},

--- a/utility_scripts/api/make_files.py
+++ b/utility_scripts/api/make_files.py
@@ -24,6 +24,7 @@ SKIP_FIELDS = [
     "settings_preamble",
     "usage",
     "prereq",
+    "quality",
 ]
 
 SKIP_FIELDS_BY_TYPE = {


### PR DESCRIPTION
Related to https://github.com/meltano/hub/issues/1305

Uses the hub_utils `update_quality` command from https://github.com/pnadolny13/hub-utils/pull/45, see that for more implementation details.

- This is the first of 2 PRs. This one adds support for the quality attribute and the next will add it to every variant.
- Adds the quality attribute to all hub definition schema
- The api excludes the quality attribute
- This does not make it a required attribute but the follow on PR will add the attribute and make it required
- Some minor formatting changes that happen when my scripts read, then write out the files without making changes. This was going to happen no matter what because I need to read and write every file to add the quality attribute but I opted to do it in this PR to avoid noise in the other PR that will have the new attribute in ~1000 files.