### PR TITLE
chore: mysql remove references to incorrect defaults

### DIFF
--- a/_data/meltano/extractors/tap-mysql/transferwise.yml
+++ b/_data/meltano/extractors/tap-mysql/transferwise.yml
@@ -15,12 +15,9 @@ pip_url: pipelinewise-tap-mysql
 prereq: |
   #### Known limitations
 
-  Note that this extractor is incompatible with the default `datamill-co` [variants](https://docs.meltano.com/concepts/plugins#variants)
+  Note that this extractor is incompatible with the `datamill-co` [variants](https://docs.meltano.com/concepts/plugins#variants)
   of [`target-postgres`](/loaders/postgres--datamill-co) and [`target-snowflake`](/loaders/snowflake--datamill-co),
   because they don't support stream names that include the source schema in addition to the table name: `<schema>-<table>`, e.g. `public-accounts`.
-
-  Instead, use the `transferwise` variants that were made to be used with this extractor:
-  [`target-postgres`](/loaders/postgres--transferwise) and [`target-snowflake`](/loaders/snowflake--transferwise).
 repo: https://github.com/transferwise/pipelinewise-tap-mysql
 settings:
 - description: The MySQL/MariaDB hostname.


### PR DESCRIPTION
- it referred to datamill as the default which isnt true anymore
- it referenced specific variants that feels like its ripe for becoming outdated