### PR TITLE
enable metadata refresh schedules

### DIFF
--- a/.github/workflows/metadata-extract.yml
+++ b/.github/workflows/metadata-extract.yml
@@ -11,8 +11,8 @@ on:
         options:
           - 'preview'
           - 'production'
-  # schedule:
-  #   - cron: '0 0 * * *' # Run at midnight UTC
+  schedule:
+    - cron: '0 9 * * 1' # Run at midnight UTC on Mondays
 
 jobs:
   get_variants_list:

--- a/.github/workflows/metadata-refresh.yml
+++ b/.github/workflows/metadata-refresh.yml
@@ -11,8 +11,8 @@ on:
         options:
           - 'preview'
           - 'production'
-  # schedule:
-  #   - cron: '0 0 * * *' # Run at midnight UTC
+  schedule:
+    - cron: '0 12 * * 1' # Run at midnight UTC on Mondays
 
 jobs:
 


### PR DESCRIPTION
I've been manually running these jobs but I sometimes forget so it would be good to have them run at least once a week.

- 9 UTC on mondays the extract job runs
- 12 UTC on mondays the refresh job runs to create a PR with changes from the extracted data

I think I could use the [workflow_run](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) event to trigger the refresh job but I didnt know how environments were passed down if at all and didnt have time to mess testing it out, this will do the job.