### PR TITLE
acarter24 to default tap-freshdesk

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -182,7 +182,7 @@ extractors:
   tap-fortnox: hotgluexyz
   tap-freshbooks: hotgluexyz
   tap-freshcaller: hotgluexyz
-  tap-freshdesk: singer-io
+  tap-freshdesk: acarter24
   tap-freshsales: airbyte
   tap-freshservice: airbyte
   tap-freshworks: hotgluexyz


### PR DESCRIPTION
Related to the slack thread https://meltano.slack.com/archives/C01TCRBBJD7/p1685044339846299.

The singer io variant doesnt support discovery or catalogs which is a bit weird so a user had failing select commands. The acarter24 variant is SDK based and looks to have most of the same stream coverage.