### PR TITLE
revert snowflake target to dev status and quality

### DIFF
--- a/_data/meltano/loaders/target-snowflake/meltanolabs.yml
+++ b/_data/meltano/loaders/target-snowflake/meltanolabs.yml
@@ -10,12 +10,12 @@ keywords:
 - database
 label: Snowflake
 logo_url: /assets/logos/loaders/snowflake.png
-maintenance_status: beta
+maintenance_status: development
 name: target-snowflake
 namespace: target_snowflake
 next_steps: ''
 pip_url: git+https://github.com/MeltanoLabs/target-snowflake.git
-quality: gold
+quality: unknown
 repo: https://github.com/MeltanoLabs/target-snowflake
 settings:
 - description: Your account identifier. See [Account Identifiers](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html).


### PR DESCRIPTION
Until some additional development is done this target isnt usable. The success % of projects trying this is very very low and I had a hard time running it so I doubt many people are getting it working.