### PR TITLE
fix: Update `streams` example to use correct url

### DIFF
--- a/_data/meltano/extractors/tap-smoke-test/meltano.yml
+++ b/_data/meltano/extractors/tap-smoke-test/meltano.yml
@@ -56,7 +56,7 @@ settings:
     ```yaml
     streams:
     - stream_name: animals
-      input_filename: https://github.com/meltano/tap-smoke-test/blob/main/demo-data/animals-data.jsonl
+      input_filename: https://raw.githubusercontent.com/meltano/tap-smoke-test/main/demo-data/animals-data.jsonl
     ```
   kind: array
   label: Streams


### PR DESCRIPTION
The previous URL linked to the github page for the jsonl file, not the file itself. If you try to use the example provided for one of your streams, you'll get the following error after running `meltano config tap-smoke-test test`:

```bash
(meltano-dev-3.10) braedon ~/meltano/meltano/projects/test-project $ meltano config tap-smoke-test test
2023-06-16T17:58:08.240554Z [info     ] The default environment 'dev' will be ignored for `meltano config`. To configure a specific environment, please use the option `--environment=<environment name>`.
Need help fixing this problem? Visit http://melta.no/ for troubleshooting steps, or to
join our friendly Slack community.

Plugin configuration is invalid
Catalog discovery failed: command ['/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/bin/tap-smoke-test', '--config', '/Users/braedon/meltano/meltano/projects/test-project/.meltano/run/tap-smoke-test/tap.d7561f96-21cc-44bb-ba6d-5e75fa674f00.config.json', '--discover'] returned 1 with stderr:
 Traceback (most recent call last):
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/bin/tap-smoke-test", line 8, in <module>
    sys.exit(TapSmokeTest.cli())
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/click/core.py", line 1054, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/click/core.py", line 920, in make_context
    self.parse_args(ctx, args)
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/click/core.py", line 1378, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/click/core.py", line 2360, in handle_parse_result
    value = self.process_value(ctx, value)
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/click/core.py", line 2322, in process_value
    value = self.callback(ctx, self, value)
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/singer_sdk/tap_base.py", line 513, in cb_discover
    tap = cls(
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/singer_sdk/tap_base.py", line 104, in __init__
    self.mapper.register_raw_streams_from_catalog(self.catalog)
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/singer_sdk/tap_base.py", line 167, in catalog
    self._catalog = self.input_catalog or self._singer_catalog
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/singer_sdk/tap_base.py", line 311, in _singer_catalog
    for stream in self.streams.values()
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/singer_sdk/tap_base.py", line 129, in streams
    for stream in self.load_streams():
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/singer_sdk/tap_base.py", line 344, in load_streams
    for stream in self.discover_streams():
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/tap_smoke_test/tap.py", line 81, in discover_streams
    stream = FromJSONLStream(tap=self, name=s["stream_name"])
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/singer_sdk/streams/core.py", line 165, in __init__
    if not self.schema:
  File "/Users/braedon/meltano/meltano/projects/test-project/.meltano/extractors/tap-smoke-test/venv/lib/python3.10/site-packages/tap_smoke_test/streams.py", line 46, in schema
    record = json.loads(entry)
  File "/Users/braedon/.pyenv/versions/3.10.12/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/Users/braedon/.pyenv/versions/3.10.12/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Users/braedon/.pyenv/versions/3.10.12/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
