### PR TITLE
bump dbt to 1.5.0

### DIFF
--- a/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
@@ -1,4 +1,3 @@
-capabilities: []
 commands:
   build:
     args: build

--- a/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
@@ -1,3 +1,4 @@
+capabilities: []
 commands:
   build:
     args: build
@@ -69,52 +70,14 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-bigquery:initialize
     ```
-pip_url: dbt-core~=1.3.0 dbt-bigquery~=1.3.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.0 dbt-bigquery~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-bigquery
 settings:
-- description: Whether to skip pre-invoke hooks which automatically run dbt clean
-    and deps
-  env: DBT_EXT_SKIP_PRE_INVOKE
-  kind: boolean
-  label: Skip Pre-invoke
-  name: skip_pre_invoke
-  value: false
-- env: DBT_EXT_TYPE
-  label: dbt Profile Type
-  name: type
-  value: bigquery
-- env: DBT_PROJECT_DIR
-  label: Project Directory
-  name: project_dir
-  value: $MELTANO_PROJECT_ROOT/transform
-- env: DBT_PROFILES_DIR
-  label: Profiles Directory
-  name: profiles_dir
-  value: $MELTANO_PROJECT_ROOT/transform/profiles/bigquery
 - description: |
     The auth method to use. One of: "oauth", "oauth-secrets", or "service-account"
   kind: string
   label: Authentication Method
   name: auth_method
-- aliases:
-  - database
-  description: |
-    The BigQuery project ID.
-  kind: string
-  label: Project
-  name: project
-- aliases:
-  - schema
-  description: |
-    The dataset to use.
-  kind: string
-  label: Dataset
-  name: dataset
-- description: |
-    The refresh token, if authenticating via oauth-secrets method.
-  kind: password
-  label: Refresh Token
-  name: refresh_token
 - aliases:
   - user
   description: |
@@ -129,16 +92,60 @@ settings:
   kind: password
   label: Client Secret
   name: client_secret
-- description: |
-    The token redirect URI
+- aliases:
+  - schema
+  description: |
+    The dataset to use.
   kind: string
-  label: Token URI
-  name: token_uri
+  label: Dataset
+  name: dataset
 - description: |
     The path to the `keyfile.json`` to use, if authenticating via service-account method.
   kind: string
   label: Keyfile
   name: keyfile
+- env: DBT_PROFILES_DIR
+  label: Profiles Directory
+  name: profiles_dir
+  value: $MELTANO_PROJECT_ROOT/transform/profiles/bigquery
+- aliases:
+  - database
+  description: |
+    The BigQuery project ID.
+  kind: string
+  label: Project
+  name: project
+- env: DBT_PROJECT_DIR
+  label: Project Directory
+  name: project_dir
+  value: $MELTANO_PROJECT_ROOT/transform
+- description: |
+    The refresh token, if authenticating via oauth-secrets method.
+  kind: password
+  label: Refresh Token
+  name: refresh_token
+- description: Whether to skip pre-invoke hooks which automatically run dbt clean
+    and deps
+  env: DBT_EXT_SKIP_PRE_INVOKE
+  kind: boolean
+  label: Skip Pre-invoke
+  name: skip_pre_invoke
+  value: false
+- env: DBT_TARGET_PATH
+  kind: string
+  label: Target Path
+  name: target_path
+  value: $MELTANO_PROJECT_ROOT/.meltano/transformers/dbt/target
+- description: |
+    The token redirect URI
+  kind: string
+  label: Token URI
+  name: token_uri
+- env: DBT_EXT_TYPE
+  label: dbt Profile Type
+  name: type
+  value: bigquery
+settings_group_validation: []
 settings_preamble: |
   Settings for dbt itself can be configured through [dbt_project.yml](https://docs.getdbt.com/reference/dbt_project.yml) as usual, which can be found at transform/dbt_project.yml in your Meltano project. dbt also has [adapter-specific documentation for BigQuery](https://docs.getdbt.com/reference/resource-configs/bigquery-configs).
 variant: dbt-labs

--- a/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
@@ -70,7 +70,7 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-bigquery:initialize
     ```
-pip_url: dbt-core~=1.5.0 dbt-bigquery~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.2 dbt-bigquery~=1.5.2 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-bigquery
 settings:
 - description: |

--- a/_data/meltano/utilities/dbt-duckdb/jwills.yml
+++ b/_data/meltano/utilities/dbt-duckdb/jwills.yml
@@ -1,4 +1,3 @@
-capabilities: []
 commands:
   build:
     args: build

--- a/_data/meltano/utilities/dbt-duckdb/jwills.yml
+++ b/_data/meltano/utilities/dbt-duckdb/jwills.yml
@@ -71,7 +71,7 @@ next_steps: |
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-duckdb:initialize
     ```
-pip_url: dbt-core~=1.5.0 dbt-duckdb~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.2 dbt-duckdb~=1.5.2 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/jwills/dbt-duckdb
 settings:
 - description: The path on your local filesystem where you would like the DuckDB database

--- a/_data/meltano/utilities/dbt-duckdb/jwills.yml
+++ b/_data/meltano/utilities/dbt-duckdb/jwills.yml
@@ -1,3 +1,4 @@
+capabilities: []
 commands:
   build:
     args: build
@@ -70,9 +71,28 @@ next_steps: |
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-duckdb:initialize
     ```
-pip_url: dbt-core~=1.3.0 dbt-duckdb~=1.3.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.0 dbt-duckdb~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/jwills/dbt-duckdb
 settings:
+- description: The path on your local filesystem where you would like the DuckDB database
+    file and it's associated write-ahead log to be written.
+  kind: string
+  label: Path
+  name: path
+  value: ${MELTANO_PROJECT_ROOT}/output/warehouse.duckdb
+- env: DBT_PROFILES_DIR
+  label: Profiles Directory
+  name: profiles_dir
+  value: $MELTANO_PROJECT_ROOT/transform/profiles/duckdb
+- env: DBT_PROJECT_DIR
+  label: Projects Directory
+  name: project_dir
+  value: $MELTANO_PROJECT_ROOT/transform
+- description: Specify the schema to write into.
+  kind: string
+  label: Schema
+  name: schema
+  value: main
 - description: Whether to skip pre-invoke hooks which automatically run dbt clean
     and deps
   env: DBT_EXT_SKIP_PRE_INVOKE
@@ -80,29 +100,16 @@ settings:
   label: Skip Pre-invoke
   name: skip_pre_invoke
   value: false
+- env: DBT_TARGET_PATH
+  kind: string
+  label: Target Path
+  name: target_path
+  value: $MELTANO_PROJECT_ROOT/.meltano/transformers/dbt/target
 - env: DBT_EXT_TYPE
   label: dbt Profile type
   name: type
   value: duckdb
-- env: DBT_PROJECT_DIR
-  label: Projects Directory
-  name: project_dir
-  value: $MELTANO_PROJECT_ROOT/transform
-- env: DBT_PROFILES_DIR
-  label: Profiles Directory
-  name: profiles_dir
-  value: $MELTANO_PROJECT_ROOT/transform/profiles/duckdb
-- description: The path on your local filesystem where you would like the DuckDB database
-    file and it's associated write-ahead log to be written.
-  kind: string
-  label: Path
-  name: path
-  value: ${MELTANO_PROJECT_ROOT}/output/warehouse.duckdb
-- description: Specify the schema to write into.
-  kind: string
-  label: Schema
-  name: schema
-  value: main
+settings_group_validation: []
 settings_preamble: |
   Settings for dbt itself can be configured through [dbt_project.yml](https://docs.getdbt.com/reference/dbt_project.yml) as usual, which can be found at transform/dbt_project.yml in your Meltano project.
 variant: jwills

--- a/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
@@ -1,4 +1,3 @@
-capabilities: []
 commands:
   build:
     args: build

--- a/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
@@ -1,3 +1,4 @@
+capabilities: []
 commands:
   build:
     args: build
@@ -68,38 +69,26 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-postgres:initialize
     ```
-pip_url: dbt-core~=1.3.0 dbt-postgres~=1.3.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.0 dbt-postgres~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-core
 settings:
-- description: Whether to skip pre-invoke hooks which automatically run dbt clean
-    and deps
-  env: DBT_EXT_SKIP_PRE_INVOKE
-  kind: boolean
-  label: Skip Pre-invoke
-  name: skip_pre_invoke
-  value: false
-- env: DBT_EXT_TYPE
-  label: dbt Profile type
-  name: type
-  value: postgres
-- env: DBT_PROJECT_DIR
-  label: Projects Directory
-  name: project_dir
-  value: $MELTANO_PROJECT_ROOT/transform
-- env: DBT_PROFILES_DIR
-  label: Profiles Directory
-  name: profiles_dir
-  value: $MELTANO_PROJECT_ROOT/transform/profiles/postgres
+- aliases:
+  - database
+  description: |
+    The db to connect to.
+  kind: string
+  label: Database
+  name: dbname
 - description: |
     The postgres host to connect to.
   kind: string
   label: Host
   name: host
 - description: |
-    The user to connect as.
-  kind: string
-  label: User
-  name: user
+    Seconds between TCP keepalive packets.
+  kind: integer
+  label: Keep Alives Idle
+  name: keepalives_idle
 - description: |
     The password to connect with.
   kind: password
@@ -110,38 +99,56 @@ settings:
   kind: integer
   label: Port
   name: port
-- aliases:
-  - database
-  description: |
-    The db to connect to.
-  kind: string
-  label: Database
-  name: dbname
-- description: |
-    The schema to use.
-  kind: string
-  label: Schema
-  name: schema
-- description: |
-    Seconds between TCP keepalive packets.
-  kind: integer
-  label: Keep Alives Idle
-  name: keepalives_idle
-- description: |
-    Overrides the default search path.
-  kind: string
-  label: Search Path
-  name: search_path
+- env: DBT_PROFILES_DIR
+  label: Profiles Directory
+  name: profiles_dir
+  value: $MELTANO_PROJECT_ROOT/transform/profiles/postgres
+- env: DBT_PROJECT_DIR
+  label: Projects Directory
+  name: project_dir
+  value: $MELTANO_PROJECT_ROOT/transform
 - description: |
     Role for dbt to assume when executing queries.
   kind: string
   label: Role
   name: role
 - description: |
+    The schema to use.
+  kind: string
+  label: Schema
+  name: schema
+- description: |
+    Overrides the default search path.
+  kind: string
+  label: Search Path
+  name: search_path
+- description: Whether to skip pre-invoke hooks which automatically run dbt clean
+    and deps
+  env: DBT_EXT_SKIP_PRE_INVOKE
+  kind: boolean
+  label: Skip Pre-invoke
+  name: skip_pre_invoke
+  value: false
+- description: |
     SSL Mode used to connect to the database.
   kind: array
   label: SSL Mode
   name: sslmode
+- env: DBT_TARGET_PATH
+  kind: string
+  label: Target Path
+  name: target_path
+  value: $MELTANO_PROJECT_ROOT/.meltano/transformers/dbt/target
+- env: DBT_EXT_TYPE
+  label: dbt Profile type
+  name: type
+  value: postgres
+- description: |
+    The user to connect as.
+  kind: string
+  label: User
+  name: user
+settings_group_validation: []
 settings_preamble: |
   Settings for dbt itself can be configured through [dbt_project.yml](https://docs.getdbt.com/reference/dbt_project.yml) as usual, which can be found at transform/dbt_project.yml in your Meltano project.  dbt also has [adapter-specific documentation for PostgreSQL](https://docs.getdbt.com/reference/resource-configs/postgres-configs).
 variant: dbt-labs

--- a/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
@@ -69,7 +69,7 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-postgres:initialize
     ```
-pip_url: dbt-core~=1.5.0 dbt-postgres~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.2 dbt-postgres~=1.5.2 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-core
 settings:
 - aliases:

--- a/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
@@ -1,4 +1,3 @@
-capabilities: []
 commands:
   build:
     args: build

--- a/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
@@ -70,7 +70,7 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-redshift:initialize
     ```
-pip_url: dbt-core~=1.5.0 dbt-redshift~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.2 dbt-redshift~=1.5.7 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-redshift
 settings:
 - description: |

--- a/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
@@ -1,3 +1,4 @@
+capabilities: []
 commands:
   build:
     args: build
@@ -69,28 +70,9 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-redshift:initialize
     ```
-pip_url: dbt-core~=1.3.0 dbt-redshift~=1.3.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.0 dbt-redshift~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-redshift
 settings:
-- description: Whether to skip pre-invoke hooks which automatically run dbt clean
-    and deps
-  env: DBT_EXT_SKIP_PRE_INVOKE
-  kind: boolean
-  label: Skip Pre-invoke
-  name: skip_pre_invoke
-  value: false
-- env: DBT_EXT_TYPE
-  label: dbt Profile type
-  name: type
-  value: redshift
-- env: DBT_PROJECT_DIR
-  label: Project Directory
-  name: project_dir
-  value: $MELTANO_PROJECT_ROOT/transform
-- env: DBT_PROFILES_DIR
-  label: Profiles Directory
-  name: profiles_dir
-  value: $MELTANO_PROJECT_ROOT/transform/profiles/redshift
 - description: |
     The auth method to use (to use iam, set to "iam".
     Omit to use password-based auth.)
@@ -98,30 +80,20 @@ settings:
   label: Authentication Method
   name: auth_method
 - description: |
+    Whether or not to automatically create entities.
+  kind: boolean
+  label: Autocreate
+  name: autocreate
+- description: |
     The cluster id.
   kind: string
   label: Cluster ID
   name: cluster_id
 - description: |
-    The host for the cluster.
-  kind: string
-  label: Host
-  name: host
-- description: |
-    The password, if using password-based auth.
-  kind: password
-  label: Password
-  name: password
-- description: |
-    The user to connect as.
-  kind: string
-  label: User
-  name: user
-- description: |
-    The port to connect to.
-  kind: integer
-  label: Port
-  name: port
+    Database groups to use.
+  kind: array
+  label: Databse Groups
+  name: db_groups
 - aliases:
   - database
   description: |
@@ -130,50 +102,85 @@ settings:
   label: Database
   name: dbname
 - description: |
-    The schema to use.
+    The host for the cluster.
   kind: string
-  label: Schema
-  name: schema
-- description: |
-    The IAM profile to use.
-  kind: string
-  label: IAM Profile
-  name: iam_profile
+  label: Host
+  name: host
 - description: |
     Duration of the IAM session.
   kind: integer
   label: IAM Duration Seconds
   name: iam_duration_seconds
 - description: |
-    Whether or not to automatically create entities.
-  kind: boolean
-  label: Autocreate
-  name: autocreate
-- description: |
-    Database groups to use.
-  kind: array
-  label: Databse Groups
-  name: db_groups
+    The IAM profile to use.
+  kind: string
+  label: IAM Profile
+  name: iam_profile
 - description: |
     Seconds between TCP keepalive packets
   kind: integer
   label: Keep Alives Idle
   name: keepalives_idle
 - description: |
-    The search path to use (use of this setting is not recommended)
-  kind: string
-  label: Search Path
-  name: search_path
+    The password, if using password-based auth.
+  kind: password
+  label: Password
+  name: password
 - description: |
-    SSL MOde used to connect to Redshift.
-  kind: array
-  label: SSL Mode
-  name: sslmode
+    The port to connect to.
+  kind: integer
+  label: Port
+  name: port
+- env: DBT_PROFILES_DIR
+  label: Profiles Directory
+  name: profiles_dir
+  value: $MELTANO_PROJECT_ROOT/transform/profiles/redshift
+- env: DBT_PROJECT_DIR
+  label: Project Directory
+  name: project_dir
+  value: $MELTANO_PROJECT_ROOT/transform
 - description: |
     Enables cross-database sources.
   kind: boolean
   label: RA3 Node
   name: ra3_node
+- description: |
+    The schema to use.
+  kind: string
+  label: Schema
+  name: schema
+- description: |
+    The search path to use (use of this setting is not recommended)
+  kind: string
+  label: Search Path
+  name: search_path
+- description: Whether to skip pre-invoke hooks which automatically run dbt clean
+    and deps
+  env: DBT_EXT_SKIP_PRE_INVOKE
+  kind: boolean
+  label: Skip Pre-invoke
+  name: skip_pre_invoke
+  value: false
+- description: |
+    SSL MOde used to connect to Redshift.
+  kind: array
+  label: SSL Mode
+  name: sslmode
+- env: DBT_TARGET_PATH
+  kind: string
+  label: Target Path
+  name: target_path
+  value: $MELTANO_PROJECT_ROOT/.meltano/transformers/dbt/target
+- env: DBT_EXT_TYPE
+  label: dbt Profile type
+  name: type
+  value: redshift
+- description: |
+    The user to connect as.
+  kind: string
+  label: User
+  name: user
+settings_group_validation: []
 settings_preamble: |
   Settings for dbt itself can be configured through [dbt_project.yml](https://docs.getdbt.com/reference/dbt_project.yml) as usual, which can be found at transform/dbt_project.yml in your Meltano project. dbt also has [adapter-specific documentation for Redshift](https://docs.getdbt.com/reference/resource-configs/redshift-configs).
 variant: dbt-labs

--- a/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
@@ -1,4 +1,3 @@
-capabilities: []
 commands:
   build:
     args: build

--- a/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
@@ -70,7 +70,7 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-snowflake:initialize
     ```
-pip_url: dbt-core~=1.5.0 dbt-snowflake~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.2 dbt-snowflake~=1.5.2 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-snowflake
 settings:
 - description: The snowflake account to connect to.

--- a/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
@@ -1,3 +1,4 @@
+capabilities: []
 commands:
   build:
     args: build
@@ -69,9 +70,37 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-snowflake:initialize
     ```
-pip_url: dbt-core~=1.3.0 dbt-snowflake~=1.3.0 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.5.0 dbt-snowflake~=1.5.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-snowflake
 settings:
+- description: The snowflake account to connect to.
+  kind: string
+  label: Account
+  name: account
+- description: The database to create models in.
+  kind: string
+  label: Database
+  name: database
+- description: The user password to authenticate with.
+  kind: password
+  label: Password
+  name: password
+- env: DBT_PROFILES_DIR
+  label: Profiles Directory
+  name: profiles_dir
+  value: $MELTANO_PROJECT_ROOT/transform/profiles/snowflake
+- env: DBT_PROJECT_DIR
+  label: Projects Directory
+  name: project_dir
+  value: $MELTANO_PROJECT_ROOT/transform
+- description: The user role to assume.
+  kind: string
+  label: Role
+  name: role
+- description: The schema to build models into by default.
+  kind: string
+  label: Schema
+  name: schema
 - description: Whether to skip pre-invoke hooks which automatically run dbt clean
     and deps
   env: DBT_EXT_SKIP_PRE_INVOKE
@@ -79,46 +108,24 @@ settings:
   label: Skip Pre-invoke
   name: skip_pre_invoke
   value: false
+- env: DBT_TARGET_PATH
+  kind: string
+  label: Target Path
+  name: target_path
+  value: $MELTANO_PROJECT_ROOT/.meltano/transformers/dbt/target
 - env: DBT_EXT_TYPE
   label: dbt Profile type
   name: type
   value: snowflake
-- env: DBT_PROJECT_DIR
-  label: Projects Directory
-  name: project_dir
-  value: $MELTANO_PROJECT_ROOT/transform
-- env: DBT_PROFILES_DIR
-  label: Profiles Directory
-  name: profiles_dir
-  value: $MELTANO_PROJECT_ROOT/transform/profiles/snowflake
-- description: The snowflake account to connect to.
-  kind: string
-  label: Account
-  name: account
 - description: The user to connect as.
   kind: string
   label: User
   name: user
-- description: The user password to authenticate with.
-  kind: password
-  label: Password
-  name: password
-- description: The user role to assume.
-  kind: string
-  label: Role
-  name: role
 - description: The compute warehouse to use when building models.
   kind: string
   label: Warehouse
   name: warehouse
-- description: The database to create models in.
-  kind: string
-  label: Database
-  name: database
-- description: The schema to build models into by default.
-  kind: string
-  label: Schema
-  name: schema
+settings_group_validation: []
 settings_preamble: |
   Settings for dbt itself can be configured through [dbt_project.yml](https://docs.getdbt.com/reference/dbt_project.yml) as usual, which can be found at transform/dbt_project.yml in your Meltano project. dbt also has [adapter-specific documentation for Snowflake](https://docs.getdbt.com/reference/resource-configs/snowflake-configs).
 variant: dbt-labs


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/1404

- I had to add DBT_TARGET_PATH as setting thats exposed as an env because I was getting this deprecation warning
```
Extension executing `dbt run`...
20:13:26  Running with dbt=1.5.2
20:13:26  [WARNING]: Deprecated functionality
The `target-path` config in `dbt_project.yml` has been deprecated, and will no
longer be supported in a future version of dbt-core. If you wish to write dbt
artifacts to a custom directory, please use the --target-path CLI flag or
DBT_TARGET_PATH env var instead.
20:13:26  Registered adapter: postgres=1.5.2
```
- reformat 