### PR TITLE
default tap-mysql to full table replication

### DIFF
--- a/_data/meltano/extractors/tap-mysql/transferwise.yml
+++ b/_data/meltano/extractors/tap-mysql/transferwise.yml
@@ -9,15 +9,16 @@ keywords:
 label: MySQL/MariaDB
 logo_url: /assets/logos/extractors/mysql.png
 maintenance_status: active
+metadata:
+  '*':
+    replication-method: FULL_TABLE
 name: tap-mysql
 namespace: tap_mysql
 pip_url: pipelinewise-tap-mysql
 prereq: |
-  #### Known limitations
-
-  Note that this extractor is incompatible with the `datamill-co` [variants](https://docs.meltano.com/concepts/plugins#variants)
-  of [`target-postgres`](/loaders/postgres--datamill-co) and [`target-snowflake`](/loaders/snowflake--datamill-co),
-  because they don't support stream names that include the source schema in addition to the table name: `<schema>-<table>`, e.g. `public-accounts`.
+  ### Usage Notes
+  This tap is configured to use `FULL_TABLE` replication by default.
+  See the [setting metadata documentation](https://docs.meltano.com/guide/integration#setting-metadata) for more details and instructions on using `INCREMENTAL` replication.
 quality: silver
 repo: https://github.com/transferwise/pipelinewise-tap-mysql
 settings:
@@ -89,6 +90,26 @@ settings:
   - SET @@session.wait_timeout=28800
   - SET @@session.net_read_timeout=3600
   - SET @@session.innodb_lock_wait_timeout=3600
+settings_preamble: |
+  #### Setup
+
+  ## Incremental Replication
+
+  ```yaml
+  - name: tap-mysql
+    variant: transferwise
+    pip_url: pipelinewise-tap-mysql
+    config:
+      user: meltano
+    select:
+    - <my_schema>-<my_table>.*
+    metadata:
+      <my_schema>-<my_table>:
+        replication-method: INCREMENTAL
+        replication_key: key
+        key_properties:
+        - key
+  ```
 settings_group_validation:
 - - host
   - port


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/1366

- defaults to full table replication, this is what the [SDK does](https://github.com/meltano/sdk/blob/d372080fbfcbcd1f529ed3839c8e34f3a6aa0cc8/singer_sdk/streams/core.py#L600) also. The non-default stitch variant has this override as well https://github.com/meltano/hub/blob/076778ffd00b008ca1ede120358cb6659db6fb58/_data/meltano/extractors/tap-mysql/singer-io.yml#L12 but it never got added to transferwise.
- add a note to warn that its full table
- document a simple incremental config

This tap causes a lot of messages in slack because it doesnt have a default replication method and when it fails the message says `Exception: only INCREMENTAL, LOG_BASED, and FULL TABLE replication methods are supported` which is totally confusing because the actual value is `FULL_TABLE` with an underscore.

I explored the idea of adding docs to all of these transferwise taps but all the others have a `default_replication_method` setting and raise appropriate errors so it doesnt seem necessary. 