### PR TITLE
Google analytics refresh

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -190,7 +190,7 @@ extractors:
   tap-frontapp: singer-io
   tap-fulfil: fulfilio
   tap-fullstory: singer-io
-  tap-ga4: singer-io
+  tap-ga4: meltanolabs
   tap-gainsightpx: widen
   tap-genesys: airbyte
   tap-getlago: airbyte

--- a/_data/meltano/extractors/tap-ga4/connorflyn.yml
+++ b/_data/meltano/extractors/tap-ga4/connorflyn.yml
@@ -8,6 +8,7 @@ capabilities:
 description: App and website analytics platform hosted by Google (GA4)
 domain_url: https://developers.google.com/analytics/devguides/reporting/data/v1
 executable: tap-google-analytics
+hidden: true
 keywords:
 - meltano_sdk
 label: Google Analytics (GA4)

--- a/_data/meltano/extractors/tap-ga4/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-ga4/meltanolabs.yml
@@ -1,0 +1,97 @@
+capabilities:
+- about
+- catalog
+- discover
+- schema-flattening
+- state
+- stream-maps
+description: App and website analytics platform hosted by Google (GA4)
+domain_url: https://developers.google.com/analytics/devguides/reporting/data/v1
+executable: tap-google-analytics
+keywords:
+- api
+- meltano_sdk
+label: Google Analytics (GA4)
+logo_url: /assets/logos/extractors/ga4.png
+maintenance_status: active
+name: tap-ga4
+namespace: tap_ga4
+next_steps: ''
+pip_url: git+https://github.com/MeltanoLabs/tap-google-analytics.git
+quality: gold
+repo: https://github.com/MeltanoLabs/tap-google-analytics
+settings:
+- description: Google Analytics Client Secrets Dictionary
+  kind: object
+  label: Client Secrets
+  name: client_secrets
+- description: The last record date to sync
+  kind: date_iso8601
+  label: End Date
+  name: end_date
+- description: "'True' to enable schema flattening and automatically expand nested
+    properties."
+  kind: boolean
+  label: Flattening Enabled
+  name: flattening_enabled
+- description: The max depth to flatten schemas.
+  kind: integer
+  label: Flattening Max Depth
+  name: flattening_max_depth
+- description: File Path to Google Analytics Client Secrets
+  kind: password
+  label: Key File Location
+  name: key_file_location
+- description: Google Analytics Access Token
+  kind: password
+  label: OAuth Credentials Access Token
+  name: oauth_credentials.access_token
+- description: Google Analytics Client ID
+  kind: password
+  label: OAuth Credentials Client ID
+  name: oauth_credentials.client_id
+- description: Google Analytics Client Secret
+  kind: password
+  label: OAuth Credentials Client Secret
+  name: oauth_credentials.client_secret
+- description: Google Analytics Refresh Token
+  kind: password
+  label: OAuth Credentials Refresh Token
+  name: oauth_credentials.refresh_token
+- description: Google Analytics Property ID
+  kind: password
+  label: Property ID
+  name: property_id
+- description: Google Analytics Reports Definition
+  kind: string
+  label: Reports
+  name: reports
+- description: The earliest record date to sync
+  kind: date_iso8601
+  label: Start Date
+  name: start_date
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+settings_group_validation:
+- - property_id
+  - start_date
+  - client_secrets
+- - property_id
+  - start_date
+  - key_file_location
+- - property_id
+  - start_date
+  - oauth_credentials.access_token
+  - oauth_credentials.client_id
+  - oauth_credentials.client_secret
+  - oauth_credentials.refresh_token
+settings_preamble: ''
+usage: ''
+variant: meltanolabs

--- a/_data/meltano/extractors/tap-ga4/sehnem.yml
+++ b/_data/meltano/extractors/tap-ga4/sehnem.yml
@@ -8,6 +8,7 @@ capabilities:
 description: App and website analytics platform hosted by Google (GA4)
 domain_url: https://developers.google.com/analytics/devguides/reporting/data/v1
 executable: tap-google-analytics
+hidden: true
 keywords:
 - meltano_sdk
 label: Google Analytics (GA4)

--- a/_data/meltano/extractors/tap-google-analytics/meltano.yml
+++ b/_data/meltano/extractors/tap-google-analytics/meltano.yml
@@ -6,7 +6,7 @@ domain_url: https://developers.google.com/analytics/devguides/reporting/core/v4/
 hidden: true
 keywords:
 - api
-label: Google Analytics
+label: Google Analytics (Universal Analytics API - Deprecated)
 logo_url: /assets/logos/extractors/google-analytics.png
 maintenance_status: inactive
 name: tap-google-analytics

--- a/_data/meltano/extractors/tap-google-analytics/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-google-analytics/meltanolabs.yml
@@ -10,12 +10,12 @@ domain_url: https://developers.google.com/analytics/devguides/reporting/core/v4/
 keywords:
 - api
 - meltano_sdk
-label: Google Analytics
+label: Google Analytics (Universal Analytics API - Deprecated)
 logo_url: /assets/logos/extractors/google-analytics.png
 maintenance_status: active
 name: tap-google-analytics
 namespace: tap_google_analytics
-pip_url: git+https://github.com/MeltanoLabs/tap-google-analytics.git
+pip_url: git+https://github.com/MeltanoLabs/tap-google-analytics.git@main_deprecated_ua
 quality: gold
 repo: https://github.com/MeltanoLabs/tap-google-analytics
 settings:

--- a/_data/meltano/extractors/tap-google-analytics/saidtezel.yml
+++ b/_data/meltano/extractors/tap-google-analytics/saidtezel.yml
@@ -6,7 +6,7 @@ description: App and website analytics platform hosted by Google
 domain_url: https://developers.google.com/analytics/devguides/reporting/core/v4/
 keywords:
 - api
-label: Google Analytics
+label: Google Analytics (Universal Analytics API - Deprecated)
 logo_url: /assets/logos/extractors/google-analytics.png
 maintenance_status: unknown
 name: tap-google-analytics

--- a/_data/meltano/extractors/tap-google-analytics/transferwise.yml
+++ b/_data/meltano/extractors/tap-google-analytics/transferwise.yml
@@ -6,7 +6,7 @@ description: App and website analytics platform hosted by Google
 domain_url: https://developers.google.com/analytics/devguides/reporting/core/v4/
 keywords:
 - api
-label: Google Analytics
+label: Google Analytics (Universal Analytics API - Deprecated)
 logo_url: /assets/logos/extractors/google-analytics.png
 maintenance_status: active
 name: tap-google-analytics

--- a/_data/meltano/extractors/tap-google-analytics/zenkay.yml
+++ b/_data/meltano/extractors/tap-google-analytics/zenkay.yml
@@ -5,7 +5,7 @@ description: App and website analytics platform hosted by Google
 domain_url: https://developers.google.com/analytics/devguides/reporting/core/v4/
 keywords:
 - api
-label: Google Analytics
+label: Google Analytics (Universal Analytics API - Deprecated)
 logo_url: /assets/logos/extractors/google-analytics.png
 maintenance_status: unknown
 name: tap-google-analytics


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/1430

- Adds meltanolabs as a tap-ga4 variant and make it the default
- Hide the other ga4 variants that were forks and have now merged back into meltanolabs following https://github.com/MeltanoLabs/tap-google-analytics/pull/142
- Update the original tap-google-analytics variants to be labeled as Universal Analytics
- pin the UA tap-google-analytics meltanolabs variant to the main_deprecated_ua branch that was created before https://github.com/MeltanoLabs/tap-google-analytics/pull/142 was merged