### PR TITLE
docs: add tap-ga4 report setting docs

### DIFF
--- a/_data/meltano/extractors/tap-ga4/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-ga4/meltanolabs.yml
@@ -62,10 +62,70 @@ settings:
   kind: password
   label: Property ID
   name: property_id
-- description: Google Analytics Reports Definition
+- description: |
+    Google Analytics Reports Definition.
+    The tap uses the [default reports definition](https://github.com/MeltanoLabs/tap-google-analytics/blob/main/tap_google_analytics/defaults/default_report_definition.json)
+    if this field is not provided.
+    A project-relative path to JSON file with the definition of the reports to be generated.
+
+    See <https://ga-dev-tools.google/ga4/dimensions-metrics-explorer/> for valid dimensions and metrics.
+
+    The JSON structure expected is as follows:
+
+    ```json
+    [
+      { "name" : "name of stream to be used",
+        "dimensions" :
+        [
+          "Google Analytics Dimension",
+          "Another Google Analytics Dimension",
+          // ... up to 7 dimensions per stream ...
+        ],
+        "metrics" :
+        [
+          "Google Analytics Metric",
+          "Another Google Analytics Metric",
+          // ... up to 10 metrics per stream ...
+        ]
+      },
+      // ... as many streams / reports as the user wants ...
+    ]
+    ```
+
+    For example, if you want to extract user stats per day in a `users_per_day` stream and session stats per day and country in a `sessions_per_country_day` stream:
+
+    ```json
+    [
+      { "name" : "users_per_day",
+        "dimensions" :
+        [
+          "date"
+        ],
+        "metrics" :
+        [
+          "newUsers",
+          "active1DayUsers"
+        ]
+      },
+      { "name" : "sessions_per_country_day",
+        "dimensions" :
+        [
+          "date",
+          "country"
+        ],
+        "metrics" :
+        [
+          "sessions",
+          "sessionsPerUser",
+          "avgSessionDuration"
+        ]
+      }
+    ]
+    ```
   kind: string
   label: Reports
   name: reports
+  placeholder: Ex. my_report_definition.json
 - description: The earliest record date to sync
   kind: date_iso8601
   label: Start Date


### PR DESCRIPTION
These docs existed on the UA version of the tap, I migrated them to the GA4 tap and updated them to match the new syntax. https://hub.meltano.com/extractors/tap-google-analytics#reports-setting