### PR TITLE
demote tap-parquet quality badge

### DIFF
--- a/_data/meltano/extractors/tap-parquet/dataops-tk.yml
+++ b/_data/meltano/extractors/tap-parquet/dataops-tk.yml
@@ -13,7 +13,7 @@ maintenance_status: unknown
 name: tap-parquet
 namespace: tap_parquet
 pip_url: git+https://github.com/dataops-tk/tap-parquet.git
-quality: gold
+quality: bronze
 repo: https://github.com/dataops-tk/tap-parquet
 settings:
 - description: "Determines how much historical data will be extracted. Please be aware\n\


### PR DESCRIPTION
The tap has usage volume and is SDK based but on the other hand its on SDK version 0.1.0, hasnt had commits in a long time, isnt a partner owned connector, and is unknown maintenance status so it should be at least silver and probably bronze like I've update it for now.