### PR TITLE
Add new config fields for Target Clickhouse

### DIFF
--- a/_data/meltano/loaders/target-clickhouse/shaped-ai.yml
+++ b/_data/meltano/loaders/target-clickhouse/shaped-ai.yml
@@ -2,7 +2,7 @@ capabilities:
 - about
 - schema-flattening
 - stream-maps
-description: Clickhouse Database
+description: Loader for Clickhouse database.
 domain_url: https://www.clickhouse.com/
 executable: target-clickhouse
 keywords:
@@ -18,6 +18,14 @@ pip_url: git+https://github.com/shaped-ai/target-clickhouse.git
 quality: silver
 repo: https://github.com/shaped-ai/target-clickhouse
 settings:
+- description: The SQLAlchemy connection string for the ClickHouse database
+  kind: password
+  label: SQLAlchemy URL
+  name: sqlalchemy_url
+- description: The name of the table to write to. Defaults to stream name.
+  kind: string
+  label: Table Name
+  name: table_name
 - description: The default target database schema name to use for all streams.
   kind: string
   label: Default Target Schema
@@ -31,10 +39,6 @@ settings:
   kind: integer
   label: Flattening Max Depth
   name: flattening_max_depth
-- description: SQLAlchemy connection string
-  kind: password
-  label: SQLAlchemy URL
-  name: sqlalchemy_url
 - description: User-defined config values to be used within map expressions.
   kind: object
   label: Stream Map Config

--- a/_data/meltano/loaders/target-clickhouse/shaped-ai.yml
+++ b/_data/meltano/loaders/target-clickhouse/shaped-ai.yml
@@ -48,11 +48,11 @@ settings:
   kind: object
   label: Stream Maps
   name: stream_maps
-- description: 'True' to enable hard delete for activate_version operation.
+- description: "'True' to enable hard delete for activate_version operation."
   kind: boolean
   label: Hard Delete
   name: hard_delete
-- description: 'True' to include record metadata in tables.
+- description: "'True' to include record metadata in tables."
   kind: boolean
   label: Add Record Metadata
   name: add_record_metadata

--- a/_data/meltano/loaders/target-clickhouse/shaped-ai.yml
+++ b/_data/meltano/loaders/target-clickhouse/shaped-ai.yml
@@ -48,6 +48,14 @@ settings:
   kind: object
   label: Stream Maps
   name: stream_maps
+- description: 'True' to enable hard delete for `activate_version` operation.
+  kind: boolean
+  label: Hard Delete
+  name: hard_delete
+- description: 'True' to include record metadata in tables.
+  kind: boolean
+  label: Add Record Metadata
+  name: add_record_metadata
 settings_group_validation:
 - - sqlalchemy_url
 settings_preamble: ''

--- a/_data/meltano/loaders/target-clickhouse/shaped-ai.yml
+++ b/_data/meltano/loaders/target-clickhouse/shaped-ai.yml
@@ -48,7 +48,7 @@ settings:
   kind: object
   label: Stream Maps
   name: stream_maps
-- description: 'True' to enable hard delete for `activate_version` operation.
+- description: 'True' to enable hard delete for activate_version operation.
   kind: boolean
   label: Hard Delete
   name: hard_delete


### PR DESCRIPTION
Updates settings to include `table_name` key for overriding loader table name.