### PR TITLE
fix: new lint failures after package upgrades

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -6,8 +6,8 @@
 // To restart press CTRL + C in terminal and run `gridsome develop`
 
 const fs = require("fs");
-const yaml = require("js-yaml");
 const path = require("path");
+const yaml = require("js-yaml");
 const marked = require("marked");
 const buildJSONApi = require("./src/api/plugins");
 

--- a/src/api/plugins.js
+++ b/src/api/plugins.js
@@ -1,6 +1,6 @@
-const write = require("write");
 const path = require("path");
 const fs = require("fs");
+const write = require("write");
 const yaml = require("js-yaml");
 const { gql } = require("graphql-tag");
 


### PR DESCRIPTION
Other PRs are getting failed linting CI jobs I think because the dependencies changed and are slightly more strict now. I refreshed mine locally and was able to see the linter fail, I fixed those failures here.