### PR TITLE
Update new_plugin.yml template file

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/new_plugin.yml
@@ -28,7 +28,7 @@ body:
       - files
 
 - type: input
-  id: name
+  id: repository_url
   attributes:
     label: Repository URL
     description: The URL for the repository that contains the plugin code
@@ -37,7 +37,7 @@ body:
     required: true
 
 - type: input
-  id: name
+  id: extension_repository_url
   attributes:
     label: Extension Repository URL
     description: The URL for the plugin extension repository. Only for utility plugins.


### PR DESCRIPTION
The template is showing this error message:

<img width="420" alt="image" src="https://github.com/meltano/hub/assets/18130317/fb4366a1-1ea5-4deb-93a0-08f9e3d8c1f5">

Which in turn prevents GitHub from correctly show the page from the _create an issue to add a new plugin_ coming from [this](https://hub.meltano.com/add-a-tap/) page!