### PR TITLE
fix: Use PyPI version to install MeltanoLabs target-postgres

### DIFF
--- a/_data/meltano/loaders/target-postgres/meltanolabs.yml
+++ b/_data/meltano/loaders/target-postgres/meltanolabs.yml
@@ -15,7 +15,7 @@ maintenance_status: active
 name: target-postgres
 namespace: target_postgres
 next_steps: ''
-pip_url: git+https://github.com/MeltanoLabs/target-postgres.git
+pip_url: meltanolabs-target-postgres~=0.0.7
 quality: gold
 repo: https://github.com/MeltanoLabs/target-postgres
 settings:


### PR DESCRIPTION
We should try to consider `main` to be potentially unstable and direct users to install from a wheel rather than from a direct git URL to avoid build-time issues such as https://github.com/MeltanoLabs/target-postgres/issues/179