### PR TITLE
Include required start_date setting

### DIFF
--- a/_data/meltano/extractors/tap-google-search-console/singer-io.yml
+++ b/_data/meltano/extractors/tap-google-search-console/singer-io.yml
@@ -38,9 +38,13 @@ settings:
 - description: The user agent to send along with the API requests.
   label: User Agent
   name: user_agent
+- description: The start date of sync in UTC format for all streams.
+  label: Start Date
+  name: start_date
 settings_group_validation:
 - - refresh_token
   - client_secret
   - client_id
   - user_agent
+  - start_date
 variant: singer-io


### PR DESCRIPTION
The start_date is missing here. When we try to add start_date as an environment variable TAP_GOOGLE_SEARCH_CONSOLE_START_DATE="2019-01-01T00:00:00Z" it is not taken up. Currently it has to be defined in meltano.yaml to take effect.