### PR TITLE
Pin `tap-googleads` to `v0.4.0`

### DIFF
--- a/_data/meltano/extractors/tap-googleads/matatika.yml
+++ b/_data/meltano/extractors/tap-googleads/matatika.yml
@@ -15,7 +15,7 @@ logo_url: /assets/logos/extractors/googleads.png
 maintenance_status: active
 name: tap-googleads
 namespace: tap_googleads
-pip_url: git+https://github.com/Matatika/tap-googleads.git
+pip_url: git+https://github.com/Matatika/tap-googleads.git@v0.4.0
 quality: gold
 repo: https://github.com/Matatika/tap-googleads
 settings:


### PR DESCRIPTION
https://github.com/Matatika/tap-googleads/releases/tag/v0.4.0