### PR TITLE
Pin `tap-shopify` (`matatika` variant) to `v0.2.0`

### DIFF
--- a/_data/meltano/extractors/tap-shopify/matatika.yml
+++ b/_data/meltano/extractors/tap-shopify/matatika.yml
@@ -15,7 +15,7 @@ logo_url: /assets/logos/extractors/shopify.png
 maintenance_status: active
 name: tap-shopify
 namespace: tap_shopify
-pip_url: git+https://github.com/Matatika/tap-shopify.git
+pip_url: git+https://github.com/Matatika/tap-shopify.git@v0.2.0
 quality: gold
 repo: https://github.com/Matatika/tap-shopify
 settings:


### PR DESCRIPTION
https://github.com/Matatika/tap-shopify/releases/tag/v0.2.0