### PR TITLE
Unpin meltanolabs target-postgres

### DIFF
--- a/_data/meltano/loaders/target-postgres/meltanolabs.yml
+++ b/_data/meltano/loaders/target-postgres/meltanolabs.yml
@@ -15,7 +15,7 @@ maintenance_status: active
 name: target-postgres
 namespace: target_postgres
 next_steps: ''
-pip_url: meltanolabs-target-postgres~=0.0.7
+pip_url: meltanolabs-target-postgres
 quality: gold
 repo: https://github.com/MeltanoLabs/target-postgres
 settings:


### PR DESCRIPTION
I noticed that this package was pinned to a specific version thats now outdated https://pypi.org/project/meltanolabs-target-postgres/. I think its best to release the version to be unpinned and let the user pin as needed.