### PR TITLE
Add new `ora_python_driver_type` setting to s7clarke10/tap-oracle

### DIFF
--- a/_data/meltano/extractors/tap-oracle/s7clarke10.yml
+++ b/_data/meltano/extractors/tap-oracle/s7clarke10.yml
@@ -98,6 +98,7 @@ settings:
     value: thin
   - label: oracleDB (SQL Client)
     value: thick
+  value: cx
 - description: A boolean whether to use ORA_ROWSCN to bookmark progress in case replication
     is interrupted. ORA_ROWSCN returns an Oracle SCN which is a System Change Number.
     This is a unique identifier for a particular change (i.e. a transaction). Default,

--- a/_data/meltano/extractors/tap-oracle/s7clarke10.yml
+++ b/_data/meltano/extractors/tap-oracle/s7clarke10.yml
@@ -88,8 +88,16 @@ settings:
   name: scn_window_size
 - description: Determines which Oracle Library Driver and mode is used by tap-oracle.
     cx=CX_Oracle, thin=oracleDB (No SQL Client), thick=oracleDB (SQL Client). Default, cx.
+  kind: options
   label: Oracle Python Driver Type / Mode
   name: ora_python_driver_type
+  options:
+  - label: CX Oracle
+    value: cx
+  - label: oracleDB (No SQL Client)
+    value: thin
+  - label: oracleDB (SQL Client)
+    value: thick
 - description: A boolean whether to use ORA_ROWSCN to bookmark progress in case replication
     is interrupted. ORA_ROWSCN returns an Oracle SCN which is a System Change Number.
     This is a unique identifier for a particular change (i.e. a transaction). Default,

--- a/_data/meltano/extractors/tap-oracle/s7clarke10.yml
+++ b/_data/meltano/extractors/tap-oracle/s7clarke10.yml
@@ -82,10 +82,14 @@ settings:
     service_name.
   label: SID
   name: sid
-- description: The scan window size when using log based replication. Default, None.
-  kind: integer
-  label: Scn Window Size
-  name: scn_window_size
+- description: Your Oracle SID. If connecting directly to an instance, otherwise use
+    service_name.
+  label: SID
+  name: sid
+- description: Determines which Oracle Library Driver and mode is used by tap-oracle.
+    cx=CX_Oracle, thin=oracleDB (No SQL Client), thick=oracleDB (SQL Client). Default, cx.
+  label: Oracle Python Driver Type / Mode
+  name: ora_python_driver_type
 - description: A boolean whether to use ORA_ROWSCN to bookmark progress in case replication
     is interrupted. ORA_ROWSCN returns an Oracle SCN which is a System Change Number.
     This is a unique identifier for a particular change (i.e. a transaction). Default,

--- a/_data/meltano/extractors/tap-oracle/s7clarke10.yml
+++ b/_data/meltano/extractors/tap-oracle/s7clarke10.yml
@@ -82,10 +82,10 @@ settings:
     service_name.
   label: SID
   name: sid
-- description: Your Oracle SID. If connecting directly to an instance, otherwise use
-    service_name.
-  label: SID
-  name: sid
+- description: The scan window size when using log based replication. Default, None.
+  kind: integer
+  label: Scn Window Size
+  name: scn_window_size
 - description: Determines which Oracle Library Driver and mode is used by tap-oracle.
     cx=CX_Oracle, thin=oracleDB (No SQL Client), thick=oracleDB (SQL Client). Default, cx.
   label: Oracle Python Driver Type / Mode


### PR DESCRIPTION
Determines which Oracle Library Driver and mode is used by tap-oracle. Values:
-  cx=CX_Oracle
-  thin=oracleDB (No SQL Client)
-  thick=oracleDB (SQL Client). 

Default, cx.

This now supports tap-oracle on a MacOS which doesn't support an Oracle Client.