### PR TITLE
feat: :sparkles: add ticketswap hubspot tap

### DIFF
--- a/_data/meltano/extractors/tap-hubspot/ticketswap.yml
+++ b/_data/meltano/extractors/tap-hubspot/ticketswap.yml
@@ -1,0 +1,79 @@
+capabilities:
+- about
+- batch
+- catalog
+- discover
+- schema-flattening
+- state
+- stream-maps
+description: A Hubspot tap containing custom properties in the deals stream.
+domain_url: ticketswap.com
+executable: tap-hubspot
+keywords:
+- meltano_sdk
+label: Hubspot
+logo_url: /assets/logos/extractors/hubspot.png
+maintenance_status: active
+name: tap-hubspot
+namespace: tap_hubspot
+next_steps: ''
+pip_url: git+https://github.com/TicketSwap/tap-hubspot.git
+quality: unknown
+repo: https://github.com/TicketSwap/tap-hubspot
+settings:
+- description: PRIVATE Access Token for Hubspot API
+  kind: password
+  label: Access Token
+  name: access_token
+- description: Compression format to use for batch files.
+  kind: options
+  label: Batch Config Encoding Compression
+  name: batch_config.encoding.compression
+  options:
+  - label: Gzip
+    value: gzip
+  - label: None
+    value: none
+- description: Format to use for batch files.
+  kind: options
+  label: Batch Config Encoding Format
+  name: batch_config.encoding.format
+  options:
+  - label: Jsonl
+    value: jsonl
+- description: Prefix to use when writing batch files.
+  kind: string
+  label: Batch Config Storage Prefix
+  name: batch_config.storage.prefix
+- description: Root path to use when writing batch files.
+  kind: string
+  label: Batch Config Storage Root
+  name: batch_config.storage.root
+- description: "'True' to enable schema flattening and automatically expand nested
+    properties."
+  kind: boolean
+  label: Flattening Enabled
+  name: flattening_enabled
+- description: The max depth to flatten schemas.
+  kind: integer
+  label: Flattening Max Depth
+  name: flattening_max_depth
+- description: The earliest record date to sync
+  kind: date_iso8601
+  label: Start Date
+  name: start_date
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+settings_group_validation:
+- - access_token
+  - start_date
+settings_preamble: ''
+usage: ''
+variant: ticketswap


### PR DESCRIPTION
A forked tap from the potloc variant containing the custom properties we need in the deals stream.