### PR TITLE
fix: remove app_id from google-play after update

### DIFF
--- a/_data/meltano/extractors/tap-google-play/edgarrmondragon.yml
+++ b/_data/meltano/extractors/tap-google-play/edgarrmondragon.yml
@@ -77,8 +77,7 @@ settings:
   kind: object
   label: Stream Maps
   name: stream_maps
-settings_group_validation:
-- - app_id
+settings_group_validation: []
 settings_preamble: ''
 usage: ''
 variant: edgarrmondragon


### PR DESCRIPTION
After https://github.com/edgarrmondragon/tap-google-play/pull/30 the tap no longer requires the app_id config.