### PR TITLE
Bump `tap-shopify` (`matatika` variant) from `v0.3.0` to `v0.3.1`

### DIFF
--- a/_data/meltano/extractors/tap-shopify/matatika.yml
+++ b/_data/meltano/extractors/tap-shopify/matatika.yml
@@ -15,7 +15,7 @@ logo_url: /assets/logos/extractors/shopify.png
 maintenance_status: active
 name: tap-shopify
 namespace: tap_shopify
-pip_url: git+https://github.com/Matatika/tap-shopify.git@v0.3.0
+pip_url: git+https://github.com/Matatika/tap-shopify.git@v0.3.1
 quality: gold
 repo: https://github.com/Matatika/tap-shopify
 settings:


### PR DESCRIPTION
https://github.com/Matatika/tap-shopify/releases/tag/v0.3.1