### PR TITLE
chore: Bump dbt utilities to use `dbt-core` 1.7.*

### DIFF
--- a/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
@@ -69,7 +69,7 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-bigquery:initialize
     ```
-pip_url: dbt-core~=1.5.2 dbt-bigquery~=1.5.2 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.7.0 dbt-bigquery~=1.7.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-bigquery
 settings:
 - description: |

--- a/_data/meltano/utilities/dbt-duckdb/jwills.yml
+++ b/_data/meltano/utilities/dbt-duckdb/jwills.yml
@@ -70,7 +70,7 @@ next_steps: |
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-duckdb:initialize
     ```
-pip_url: dbt-core~=1.5.2 dbt-duckdb~=1.5.2 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.7.0 dbt-duckdb~=1.7.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/jwills/dbt-duckdb
 settings:
 - description: The path on your local filesystem where you would like the DuckDB database

--- a/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
@@ -68,7 +68,7 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-postgres:initialize
     ```
-pip_url: dbt-core~=1.5.2 dbt-postgres~=1.5.2 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.7.0 dbt-postgres~=1.7.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-core
 settings:
 - aliases:

--- a/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
@@ -69,7 +69,7 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-redshift:initialize
     ```
-pip_url: dbt-core~=1.5.2 dbt-redshift~=1.5.7 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.7.0 dbt-redshift~=1.7.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-redshift
 settings:
 - description: |

--- a/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
@@ -69,7 +69,7 @@ next_steps: |-
     # create a starter dbt_project.yml file, a profiles.yml file, and models directory
     meltano invoke dbt-snowflake:initialize
     ```
-pip_url: dbt-core~=1.5.2 dbt-snowflake~=1.5.2 git+https://github.com/meltano/dbt-ext.git@main
+pip_url: dbt-core~=1.7.0 dbt-snowflake~=1.7.0 git+https://github.com/meltano/dbt-ext.git@main
 repo: https://github.com/dbt-labs/dbt-snowflake
 settings:
 - description: The snowflake account to connect to.


### PR DESCRIPTION
* Related: https://github.com/meltano/hub/issues/1642
* Did not update the legacy transformer plugins
* Updated all dbt adapter utility plugins to use `1.7.*` for both `dbt-core` and the corresponding adapter package.