### PR TITLE
chore: Bump Airflow to 2.8.1

### DIFF
--- a/_data/meltano/utilities/airflow/apache.yml
+++ b/_data/meltano/utilities/airflow/apache.yml
@@ -51,8 +51,8 @@ next_steps: |
      By default, the UI will be available at at [`http://localhost:8080`](http://localhost:8080). You can change this using the `webserver.web_server_port` setting documented below.
 
   1. Start Scheduler or execute Airflow commands directly using the instructions in [the Meltano docs](https://docs.meltano.com/guide/orchestration#starting-the-airflow-scheduler).
-pip_url: git+https://github.com/meltano/airflow-ext.git@main apache-airflow==2.3.3
-  --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.3.3/constraints-no-providers-${MELTANO__PYTHON_VERSION}.txt
+pip_url: git+https://github.com/meltano/airflow-ext.git@main apache-airflow==2.8.1
+  --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-no-providers-${MELTANO__PYTHON_VERSION}.txt
 repo: https://github.com/apache/airflow
 settings:
 - env: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN


### PR DESCRIPTION
* https://github.com/meltano/airflow-ext/issues/48
* https://github.com/apache/airflow/releases/tag/2.8.1
