### PR TITLE
fix: app store variant for automattic and maintainer label

### DIFF
--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -99,7 +99,7 @@ autoidm:
   name: autoidm
   url: https://autoidm.com
 automattic:
-  label: automattic
+  label: Automattic
   name: automattic
   url: https://github.com/Automattic
 autotraderuk:

--- a/_data/meltano/extractors/tap-appstore/automattic.yml
+++ b/_data/meltano/extractors/tap-appstore/automattic.yml
@@ -39,4 +39,4 @@ settings_group_validation:
   - start_date
   - key_id
   - key_file
-variant: miroapp
+variant: automattic


### PR DESCRIPTION
I accidentally didnt update the variant value for the automattic variant from https://github.com/meltano/hub/pull/1652. This seems to have made that tap inaccessible. I also noticed the label should be uppercased for the maintainer.