### PR TITLE
Update MongoDB Documentation for Replication Key

### DIFF
--- a/_data/meltano/extractors/tap-mongodb/meltanolabs.yml
+++ b/_data/meltano/extractors/tap-mongodb/meltanolabs.yml
@@ -185,7 +185,7 @@ settings_preamble: |
   ```yaml
   metadata:
     '*':
-      replication-key: _id
+      replication-key: replication_key
       replication-method: LOG_BASED
   ```
 


### PR DESCRIPTION
This pull request addresses an issue with the MongoDB documentation for the `replication-key` in Meltano. 
The current documentation suggests using `_id`, but it should be `replication_key` based on discussion in the Meltano Slack channel ([Link to Slack conversation](https://meltano.slack.com/archives/C068YB1BMD5/p1704909784358519)).

I'm new to Meltano, so feel free to provide any additional guidance or suggestions. 🫡