### PR TITLE
fix: Split search terms

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -137,10 +137,12 @@ export default {
               plugin.node.label,
               plugin.node.keywords?.join(" "),
             ];
-            return pluginTextFields
-              .join(" ")
+            const searchIn = pluginTextFields.join(" ").toLowerCase();
+            return this.search
               .toLowerCase()
-              .includes(this.search.toLowerCase().trim());
+              .trim()
+              .split(" ")
+              .every((searchTerm) => searchIn.includes(searchTerm));
           })
           .sort((a, b) => {
             // First compare by pluginType


### PR DESCRIPTION
Quick and dirty fix to allow each term in the search box to be matched independently instead of searching for the full string.

## Before

<img width="520" alt="Screenshot 2024-03-06 at 10 35 31 a m" src="https://github.com/meltano/hub/assets/16805946/f242df84-1c34-423e-88bb-d78408f504bc">

## After

<img width="527" alt="Screenshot 2024-03-06 at 10 35 56 a m" src="https://github.com/meltano/hub/assets/16805946/a1678b31-3d5f-449e-bb27-a94311a36b33">
