### PR TITLE
fix: Update superset utility pip URL to a working set of constraints

### DIFF
--- a/_data/meltano/utilities/superset/meltano.yml
+++ b/_data/meltano/utilities/superset/meltano.yml
@@ -94,8 +94,8 @@ next_steps: |
      ```
 
   Now when you (re)start Superset, you will be able to connect to a new type of database, like Snowflake in the example.
-pip_url: apache-superset==2.0.0 flask==2.0.3 werkzeug==2.0.3 jinja2==3.0.1 wtforms==2.3.3
-  git+https://github.com/meltano/superset-ext.git@main cryptography==3.4.7
+pip_url: apache-superset==3.1.1 flask==2.2.5 werkzeug==2.3.3 jinja2==3.0.1 wtforms==2.3.3
+  git+https://github.com/meltano/superset-ext.git@main cryptography==41.0.2
 repo: https://github.com/apache/superset
 settings:
 - description: The path to where the Superset config file is located.


### PR DESCRIPTION
A user in Slack helped us figure out an updated working set of constraints: https://meltano.slack.com/archives/C069CQNHDNF/p1709759032858189?thread_ts=1709745908.279289&cid=C069CQNHDNF