### PR TITLE
Remove settings not listed in tap-rest-api-msdk readme

### DIFF
--- a/_data/meltano/extractors/tap-rest-api-msdk/widen.yml
+++ b/_data/meltano/extractors/tap-rest-api-msdk/widen.yml
@@ -72,30 +72,6 @@ settings:
   kind: string
   label: Backoff Type
   name: backoff_type
-- description: Compression format to use for batch files.
-  kind: options
-  label: Batch Config Encoding Compression
-  name: batch_config.encoding.compression
-  options:
-  - label: Gzip
-    value: gzip
-  - label: None
-    value: none
-- description: Format to use for batch files.
-  kind: options
-  label: Batch Config Encoding Format
-  name: batch_config.encoding.format
-  options:
-  - label: Jsonl
-    value: jsonl
-- description: Prefix to use when writing batch files.
-  kind: string
-  label: Batch Config Storage Prefix
-  name: batch_config.storage.prefix
-- description: Root path to use when writing batch files.
-  kind: string
-  label: Batch Config Storage Root
-  name: batch_config.storage.root
 - description: Used for the Bearer Authentication method, which uses a token as part
     of the authorization header for authentication.
   kind: password
@@ -125,15 +101,6 @@ settings:
   label: Except Keys
   name: except_keys
   value: []
-- description: "'True' to enable schema flattening and automatically expand nested
-    properties."
-  kind: boolean
-  label: Flattening Enabled
-  name: flattening_enabled
-- description: The max depth to flatten schemas.
-  kind: integer
-  label: Flattening Max Depth
-  name: flattening_max_depth
 - description: Used for the OAuth2 authentication method. The grant_type is required
     to describe the OAuth2 flow. Flows support by this tap include client_credentials,
     refresh_token, password.
@@ -285,15 +252,6 @@ settings:
   label: Store Raw JSON Message
   name: store_raw_json_message
   value: false
-- description: User-defined config values to be used within map expressions.
-  kind: object
-  label: Stream Map Config
-  name: stream_map_config
-- description: Config object for stream maps capability. For more information check
-    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
-  kind: object
-  label: Stream Maps
-  name: stream_maps
 - description: |
     An array of streams, designed for separate paths using thesame base url.
 


### PR DESCRIPTION
Several settings listed in the Meltano Hub docs do not actually exist for `tap-rest-api-msdk`. This PR reconciles the settings [listed in the tap's README](https://github.com/Widen/tap-rest-api-msdk/blob/main/README.md) with Meltano Hub docs.