### PR TITLE
feat: separate default sdk settings for readability

### DIFF
--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -9,12 +9,24 @@
         find the setting you're looking for, click on any setting name from the list:
       </p>
       <ul class="list-disc list-inside pl-4">
-        <li v-for="(setting, index) in settings" v-bind:key="index">
+        <li v-for="(setting, index) in definedSettings()" v-bind:key="index">
           <a :href="'#' + setting.name.replace(/\./g, '-') + '-setting'"
             ><code>{{ setting.name }}</code></a
           >
         </li>
       </ul>
+      <div v-if="sdkSettings().length > 0">
+        <details>
+          <summary class="text-xl pb-4 pt-4 font-bold font-hg">Expand To Show SDK Settings</summary>
+          <ul class="list-disc list-inside pl-4">
+            <li v-for="(setting, index) in sdkSettings()" v-bind:key="index">
+              <a :href="'#' + setting.name.replace(/\./g, '-') + '-setting'"
+                ><code>{{ setting.name }}</code></a
+              >
+            </li>
+          </ul>
+        </details>
+      </div>
       <p>
         You can also list these settings using
         <a href="https://docs.meltano.com/reference/command-line-interface#config">
@@ -42,7 +54,7 @@
         >
         that defines the settings for this plugin.
       </p>
-      <span class="mt-6" v-for="(setting, index) in settings" v-bind:key="index">
+      <span class="mt-6" v-for="(setting, index) in definedSettings()" v-bind:key="index">
         <p class="mt-3 text-xl" :id="setting.name.replace(/\./g, '-') + '-setting'">
           <code>{{ setting.label }} ({{ setting.name }})</code>
         </p>
@@ -71,6 +83,42 @@
           class="prose language-bash rounded-md"
         ><code >meltano config {{ name }} set {{ setting.name.replace(".", " ") }} [value]</code></pre>
       </span>
+
+      
+    <div v-if="sdkSettings().length > 0">
+      <details>
+        <summary class="text-2xl pb-4 pt-4 font-bold font-hg">Expand To Show SDK Settings</summary>
+        <span class="mt-6" v-for="(setting, index) in sdkSettings()" v-bind:key="index">
+          <p class="mt-3 text-xl" :id="setting.name.replace(/\./g, '-') + '-setting'">
+            <code>{{ setting.label }} ({{ setting.name }})</code>
+          </p>
+          <ul class="list-inside list-disc pl-4 text-sm">
+            <li>
+              Environment variable:
+              <code>{{
+                `${name.replaceAll("-", "_").toUpperCase()}_${setting.name
+                  .replaceAll(".", "_")
+                  .toUpperCase()}`
+              }}</code>
+            </li>
+            <li v-if="setting.value">
+              Default Value: <code>{{ setting.value }}</code>
+            </li>
+          </ul>
+          <div
+            class="prose mt-3 bg-slate-100 p-2"
+            v-if="setting.description"
+            v-html="setting.description_rendered"
+          ></div>
+          <span v-else>[No description provided.]</span>
+          <br />
+          <p>Configure this setting directly using the following Meltano command:</p>
+          <pre
+            class="prose language-bash rounded-md"
+          ><code >meltano config {{ name }} set {{ setting.name.replace(".", " ") }} [value]</code></pre>
+        </span>
+      </details>
+    </div>
     </span>
     <span v-else
       >This plugin currently has no settings defined. If you know the settings required by this
@@ -83,6 +131,39 @@
 export default {
   name: "PluginSettingsSection",
   props: ["settings", "plugin_type_plural", "preamble", "name", "variant"],
+  data() {
+    return {
+      hardcodedValues: [
+          "stream_maps",
+          "stream_map_config",
+          "faker_config.locale",
+          "faker_config.seed",
+          "batch_config.encoding.compression",
+          "batch_config.encoding.format",
+          "batch_config.storage.prefix",
+          "batch_config.storage.root",
+          "flattening_enabled",
+          "flattening_max_depth",
+          "default_target_schema",
+          "add_record_metadata",
+          "hard_delete",
+          "validate_records",
+          "load_method",
+      ]
+    };
+  },
+  methods: {
+    definedSettings() {
+      return this.settings.filter(setting => {
+        return !this.hardcodedValues.includes(setting.name);
+      });
+    },
+    sdkSettings() {
+      return this.settings.filter(setting => {
+        return this.hardcodedValues.includes(setting.name);
+      });
+    }
+  }
 };
 </script>
 

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -84,41 +84,42 @@
         ><code >meltano config {{ name }} set {{ setting.name.replace(".", " ") }} [value]</code></pre>
       </span>
 
-      
-    <div v-if="sdkSettings().length > 0">
-      <details>
-        <summary class="text-2xl pb-4 pt-4 font-bold font-hg">Expand To Show SDK Settings</summary>
-        <span class="mt-6" v-for="(setting, index) in sdkSettings()" v-bind:key="index">
-          <p class="mt-3 text-xl" :id="setting.name.replace(/\./g, '-') + '-setting'">
-            <code>{{ setting.label }} ({{ setting.name }})</code>
-          </p>
-          <ul class="list-inside list-disc pl-4 text-sm">
-            <li>
-              Environment variable:
-              <code>{{
-                `${name.replaceAll("-", "_").toUpperCase()}_${setting.name
-                  .replaceAll(".", "_")
-                  .toUpperCase()}`
-              }}</code>
-            </li>
-            <li v-if="setting.value">
-              Default Value: <code>{{ setting.value }}</code>
-            </li>
-          </ul>
-          <div
-            class="prose mt-3 bg-slate-100 p-2"
-            v-if="setting.description"
-            v-html="setting.description_rendered"
-          ></div>
-          <span v-else>[No description provided.]</span>
-          <br />
-          <p>Configure this setting directly using the following Meltano command:</p>
-          <pre
-            class="prose language-bash rounded-md"
-          ><code >meltano config {{ name }} set {{ setting.name.replace(".", " ") }} [value]</code></pre>
-        </span>
-      </details>
-    </div>
+      <div v-if="sdkSettings().length > 0">
+        <details>
+          <summary class="text-2xl pb-4 pt-4 font-bold font-hg">
+            Expand To Show SDK Settings
+          </summary>
+          <span class="mt-6" v-for="(setting, index) in sdkSettings()" v-bind:key="index">
+            <p class="mt-3 text-xl" :id="setting.name.replace(/\./g, '-') + '-setting'">
+              <code>{{ setting.label }} ({{ setting.name }})</code>
+            </p>
+            <ul class="list-inside list-disc pl-4 text-sm">
+              <li>
+                Environment variable:
+                <code>{{
+                  `${name.replaceAll("-", "_").toUpperCase()}_${setting.name
+                    .replaceAll(".", "_")
+                    .toUpperCase()}`
+                }}</code>
+              </li>
+              <li v-if="setting.value">
+                Default Value: <code>{{ setting.value }}</code>
+              </li>
+            </ul>
+            <div
+              class="prose mt-3 bg-slate-100 p-2"
+              v-if="setting.description"
+              v-html="setting.description_rendered"
+            ></div>
+            <span v-else>[No description provided.]</span>
+            <br />
+            <p>Configure this setting directly using the following Meltano command:</p>
+            <pre
+              class="prose language-bash rounded-md"
+            ><code >meltano config {{ name }} set {{ setting.name.replace(".", " ") }} [value]</code></pre>
+          </span>
+        </details>
+      </div>
     </span>
     <span v-else
       >This plugin currently has no settings defined. If you know the settings required by this
@@ -134,36 +135,32 @@ export default {
   data() {
     return {
       hardcodedValues: [
-          "stream_maps",
-          "stream_map_config",
-          "faker_config.locale",
-          "faker_config.seed",
-          "batch_config.encoding.compression",
-          "batch_config.encoding.format",
-          "batch_config.storage.prefix",
-          "batch_config.storage.root",
-          "flattening_enabled",
-          "flattening_max_depth",
-          "default_target_schema",
-          "add_record_metadata",
-          "hard_delete",
-          "validate_records",
-          "load_method",
-      ]
+        "stream_maps",
+        "stream_map_config",
+        "faker_config.locale",
+        "faker_config.seed",
+        "batch_config.encoding.compression",
+        "batch_config.encoding.format",
+        "batch_config.storage.prefix",
+        "batch_config.storage.root",
+        "flattening_enabled",
+        "flattening_max_depth",
+        "default_target_schema",
+        "add_record_metadata",
+        "hard_delete",
+        "validate_records",
+        "load_method",
+      ],
     };
   },
   methods: {
     definedSettings() {
-      return this.settings.filter(setting => {
-        return !this.hardcodedValues.includes(setting.name);
-      });
+      return this.settings.filter((setting) => !this.hardcodedValues.includes(setting.name));
     },
     sdkSettings() {
-      return this.settings.filter(setting => {
-        return this.hardcodedValues.includes(setting.name);
-      });
-    }
-  }
+      return this.settings.filter((setting) => this.hardcodedValues.includes(setting.name));
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/1545

The growth of default SDK settings is a good thing for consistency but makes the UX worse here because there are so many settings to understand. As suggested in the issue, I took a first iteration on separating defined settings and SDK default settings. I did it for the main list of setting and the detailed descriptions for each.

Implementation notes:
- I just chose to use a hardcoded list of settings that we know are from the SDK. I figured that we add new default settings so infrequently that we can just add them here as needed.
- I wasnt able to get the check for the `meltano_sdk` keyword to work for some reason. Someone else can give it a shot but keywords was always coming through empty for me
- I chose to collapse all SDK settings in both sections by default. The one downside I found is that if you click on one of the SDK settings in the first list it brings you down to the collapsed detailed SDK settings section but doesnt expand it for you. Not the worst but it would be ideal if it could automatically expand in that situation.

cc @ReubenFrankel 