### PR TITLE
Auto-expand SDK settings detail section from link

### DIFF
--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -85,7 +85,13 @@
       </span>
 
       <div v-if="sdkSettings().length > 0">
-        <details :open="sdkSettings().some(setting => '#' + setting.name.replace(/\./g, '-') + '-setting' === this.$route.hash)">
+        <details
+          :open="
+            sdkSettings().some(
+              (setting) => '#' + setting.name.replace(/\./g, '-') + '-setting' === this.$route.hash
+            )
+          "
+        >
           <summary class="text-2xl pb-4 pt-4 font-bold font-hg">
             Expand To Show SDK Settings
           </summary>

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -85,7 +85,7 @@
       </span>
 
       <div v-if="sdkSettings().length > 0">
-        <details>
+        <details :open="sdkSettings().some(setting => '#' + setting.name.replace(/\./g, '-') + '-setting' === this.$route.hash)">
           <summary class="text-2xl pb-4 pt-4 font-bold font-hg">
             Expand To Show SDK Settings
           </summary>

--- a/src/components/PluginSettingsSection.vue
+++ b/src/components/PluginSettingsSection.vue
@@ -10,7 +10,7 @@
       </p>
       <ul class="list-disc list-inside pl-4">
         <li v-for="(setting, index) in definedSettings()" v-bind:key="index">
-          <a :href="'#' + setting.name.replace(/\./g, '-') + '-setting'"
+          <a :href="getSettingHref(setting)"
             ><code>{{ setting.name }}</code></a
           >
         </li>
@@ -20,7 +20,7 @@
           <summary class="text-xl pb-4 pt-4 font-bold font-hg">Expand To Show SDK Settings</summary>
           <ul class="list-disc list-inside pl-4">
             <li v-for="(setting, index) in sdkSettings()" v-bind:key="index">
-              <a :href="'#' + setting.name.replace(/\./g, '-') + '-setting'"
+              <a :href="getSettingHref(setting)"
                 ><code>{{ setting.name }}</code></a
               >
             </li>
@@ -86,11 +86,7 @@
 
       <div v-if="sdkSettings().length > 0">
         <details
-          :open="
-            sdkSettings().some(
-              (setting) => '#' + setting.name.replace(/\./g, '-') + '-setting' === this.$route.hash
-            )
-          "
+          :open="sdkSettings().some((setting) => getSettingHref(setting) === this.$route.hash)"
         >
           <summary class="text-2xl pb-4 pt-4 font-bold font-hg">
             Expand To Show SDK Settings
@@ -165,6 +161,9 @@ export default {
     },
     sdkSettings() {
       return this.settings.filter((setting) => this.hardcodedValues.includes(setting.name));
+    },
+    getSettingHref(setting) {
+      return `#${setting.name.replace(/\./g, "-")}-setting`;
     },
   },
 };


### PR DESCRIPTION
From #1706:

> I chose to collapse all SDK settings in both sections by default. The one downside I found is that if you click on one of the SDK settings in the first list it brings you down to the collapsed detailed SDK settings section but doesnt expand it for you. Not the worst but it would be ideal if it could automatically expand in that situation.

cc @pnadolny13