### PR TITLE
fix: Add SDK keyword for all Airbyte wrapper plugins

### DIFF
--- a/_data/meltano/extractors/tap-3plcentral/airbyte.yml
+++ b/_data/meltano/extractors/tap-3plcentral/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.extensiv.com/extensiv-3pl-warehouse-manager
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Extensiv 3PL Warehouse Manager
 logo_url: /assets/logos/extractors/3plcentral.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-activecampaign/airbyte.yml
+++ b/_data/meltano/extractors/tap-activecampaign/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.activecampaign.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: ActiveCampaign
 logo_url: /assets/logos/extractors/activecampaign.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-adjust/airbyte.yml
+++ b/_data/meltano/extractors/tap-adjust/airbyte.yml
@@ -11,6 +11,7 @@ domain_url: https://www.adjust.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Adjust
 logo_url: /assets/logos/extractors/adjust.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-aha/airbyte.yml
+++ b/_data/meltano/extractors/tap-aha/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.aha.io/api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Aha
 logo_url: /assets/logos/extractors/aha.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-airtable/airbyte.yml
+++ b/_data/meltano/extractors/tap-airtable/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://airtable.com/api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Airtable
 logo_url: /assets/logos/extractors/airtable.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-alpha-vantage/airbyte.yml
+++ b/_data/meltano/extractors/tap-alpha-vantage/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.alphavantage.co/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Alpha Vantage
 logo_url: /assets/logos/extractors/alpha-vantage.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-amazon-sqs/airbyte.yml
+++ b/_data/meltano/extractors/tap-amazon-sqs/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://aws.amazon.com/sqs/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Amazon SQS
 logo_url: /assets/logos/extractors/amazon-sqs.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-amplitude/airbyte.yml
+++ b/_data/meltano/extractors/tap-amplitude/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://amplitude.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Amplitude
 logo_url: /assets/logos/extractors/amplitude.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-apify/airbyte.yml
+++ b/_data/meltano/extractors/tap-apify/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://apify.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Apify
 logo_url: /assets/logos/extractors/apify.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-appfollow/airbyte.yml
+++ b/_data/meltano/extractors/tap-appfollow/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://appfollow.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: AppFollow
 logo_url: /assets/logos/extractors/appfollow.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-appsflyer/airbyte.yml
+++ b/_data/meltano/extractors/tap-appsflyer/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.appsflyer.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: AppsFlyer
 logo_url: /assets/logos/extractors/appsflyer.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-asana/airbyte.yml
+++ b/_data/meltano/extractors/tap-asana/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://asana.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Asana
 logo_url: /assets/logos/extractors/asana.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-ashby/airbyte.yml
+++ b/_data/meltano/extractors/tap-ashby/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.ashbyhq.com/reference/introduction
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Ashby
 logo_url: /assets/logos/extractors/ashby.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-auth0/airbyte.yml
+++ b/_data/meltano/extractors/tap-auth0/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://auth0.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Auth0
 logo_url: /assets/logos/extractors/auth0.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-aws-cloudtrail/airbyte.yml
+++ b/_data/meltano/extractors/tap-aws-cloudtrail/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://aws.amazon.com/cloudtrail/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: AWS CloudTrail
 logo_url: /assets/logos/extractors/aws-cloudtrail.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-azure-table/airbyte.yml
+++ b/_data/meltano/extractors/tap-azure-table/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://azure.microsoft.com/en-us/products/storage/tables/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Azure Table
 logo_url: /assets/logos/extractors/azure-table.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-babelforce/airbyte.yml
+++ b/_data/meltano/extractors/tap-babelforce/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.babelforce.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Babelforce
 logo_url: /assets/logos/extractors/babelforce.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-bamboohr/airbyte.yml
+++ b/_data/meltano/extractors/tap-bamboohr/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.bamboohr.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: BambooHR
 logo_url: /assets/logos/extractors/bamboohr.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-bigcommerce/airbyte.yml
+++ b/_data/meltano/extractors/tap-bigcommerce/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.bigcommerce.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: BigCommerce
 logo_url: /assets/logos/extractors/bigcommerce.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-bigquery/airbyte.yml
+++ b/_data/meltano/extractors/tap-bigquery/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://cloud.google.com/bigquery
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: BigQuery
 logo_url: /assets/logos/extractors/bigquery.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-bing-ads/airbyte.yml
+++ b/_data/meltano/extractors/tap-bing-ads/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.microsoft.com/en-us/advertising/guides/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Bing Ads
 logo_url: /assets/logos/extractors/bing-ads.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-braintree/airbyte.yml
+++ b/_data/meltano/extractors/tap-braintree/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.paypal.com/braintree/docs/start/overview
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Braintree
 logo_url: /assets/logos/extractors/braintree.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-braze/airbyte.yml
+++ b/_data/meltano/extractors/tap-braze/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.braze.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Braze
 logo_url: /assets/logos/extractors/braze.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-breezometer/airbyte.yml
+++ b/_data/meltano/extractors/tap-breezometer/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.breezometer.com/api-documentation/air-quality-api/v2/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Breezometer
 logo_url: /assets/logos/extractors/breezometer.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-callrail/airbyte.yml
+++ b/_data/meltano/extractors/tap-callrail/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://apidocs.callrail.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Callrail
 logo_url: /assets/logos/extractors/callrail.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-cart/airbyte.yml
+++ b/_data/meltano/extractors/tap-cart/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.cart.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Cart.com
 logo_url: /assets/logos/extractors/cart.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-chargebee/airbyte.yml
+++ b/_data/meltano/extractors/tap-chargebee/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://apidocs.chargebee.com/docs/api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Chargebee
 logo_url: /assets/logos/extractors/chargebee.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-chargify/airbyte.yml
+++ b/_data/meltano/extractors/tap-chargify/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://reference.chargify.com/v1/basics/introduction
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Chargify
 logo_url: /assets/logos/extractors/chargify.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-chartmogul/airbyte.yml
+++ b/_data/meltano/extractors/tap-chartmogul/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://chartmogul.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: ChartMogul
 logo_url: /assets/logos/extractors/chartmogul.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-clickhouse/airbyte.yml
+++ b/_data/meltano/extractors/tap-clickhouse/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://clickhouse.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: ClickHouse
 logo_url: /assets/logos/extractors/clickhouse.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-clickup/airbyte.yml
+++ b/_data/meltano/extractors/tap-clickup/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://clickup.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Clickup
 logo_url: /assets/logos/extractors/clickup.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-clockify/airbyte.yml
+++ b/_data/meltano/extractors/tap-clockify/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://clockify.me/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Clockify
 logo_url: /assets/logos/extractors/clockify.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-closeio/airbyte.yml
+++ b/_data/meltano/extractors/tap-closeio/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://close.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Close
 logo_url: /assets/logos/extractors/closeio.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-cockroachdb/airbyte.yml
+++ b/_data/meltano/extractors/tap-cockroachdb/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://github.com/cockroachdb/cockroach
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: CockroachDB
 logo_url: /assets/logos/extractors/cockroachdb.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-coda/airbyte.yml
+++ b/_data/meltano/extractors/tap-coda/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://coda.io/account#apiSettings
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Coda
 logo_url: /assets/logos/extractors/coda.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-coin-api/airbyte.yml
+++ b/_data/meltano/extractors/tap-coin-api/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.coinapi.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: CoinAPI
 logo_url: /assets/logos/extractors/coin-api.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-coingecko/airbyte.yml
+++ b/_data/meltano/extractors/tap-coingecko/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.coingecko.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Coingecko
 logo_url: /assets/logos/extractors/coingecko.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-coinmarketcap/airbyte.yml
+++ b/_data/meltano/extractors/tap-coinmarketcap/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://coinmarketcap.com/api/documentation/v1/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Coinmarketcap
 logo_url: /assets/logos/extractors/coinmarketcap.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-commercetools/airbyte.yml
+++ b/_data/meltano/extractors/tap-commercetools/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://commercetools.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: commercetools
 logo_url: /assets/logos/extractors/commercetools.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-configcat/airbyte.yml
+++ b/_data/meltano/extractors/tap-configcat/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.configcat.com/docs/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: ConfigCat
 logo_url: /assets/logos/extractors/configcat.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-confluence/airbyte.yml
+++ b/_data/meltano/extractors/tap-confluence/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.atlassian.com/software/confluence
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Confluence
 logo_url: /assets/logos/extractors/confluence.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-convertkit/airbyte.yml
+++ b/_data/meltano/extractors/tap-convertkit/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.convertkit.com/#getting-started
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: ConvertKit
 logo_url: /assets/logos/extractors/convertkit.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-convex/airbyte.yml
+++ b/_data/meltano/extractors/tap-convex/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.convex.dev/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Convex
 logo_url: /assets/logos/extractors/convex.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-copper/airbyte.yml
+++ b/_data/meltano/extractors/tap-copper/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.copper.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Copper
 logo_url: /assets/logos/extractors/copper.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-courier/airbyte.yml
+++ b/_data/meltano/extractors/tap-courier/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.courier.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Courier
 logo_url: /assets/logos/extractors/courier.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-datadog/airbyte.yml
+++ b/_data/meltano/extractors/tap-datadog/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.datadoghq.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Datadog
 logo_url: /assets/logos/extractors/datadog.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-datascope/airbyte.yml
+++ b/_data/meltano/extractors/tap-datascope/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://dscope.github.io/docs/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Datascope
 logo_url: /assets/logos/extractors/datascope.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-dataverse/airbyte.yml
+++ b/_data/meltano/extractors/tap-dataverse/airbyte.yml
@@ -11,6 +11,7 @@ domain_url:
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Microsoft Dataverse
 logo_url: /assets/logos/extractors/dataverse.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-db2/airbyte.yml
+++ b/_data/meltano/extractors/tap-db2/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.ibm.com/analytics/db2
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: IBM Db2
 logo_url: /assets/logos/extractors/db2.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-delighted/airbyte.yml
+++ b/_data/meltano/extractors/tap-delighted/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://delighted.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Delighted
 logo_url: /assets/logos/extractors/delighted.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-dixa/airbyte.yml
+++ b/_data/meltano/extractors/tap-dixa/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.dixa.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: dixa
 logo_url: /assets/logos/extractors/dixa.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-dockerhub/airbyte.yml
+++ b/_data/meltano/extractors/tap-dockerhub/airbyte.yml
@@ -11,6 +11,7 @@ domain_url: https://hub.docker.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Docker Hub
 logo_url: /assets/logos/extractors/dockerhub.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-drift/airbyte.yml
+++ b/_data/meltano/extractors/tap-drift/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.drift.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Drift
 logo_url: /assets/logos/extractors/drift.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-dv-360/airbyte.yml
+++ b/_data/meltano/extractors/tap-dv-360/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://marketingplatform.google.com/about/display-video-360/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Display & Video 360
 logo_url: /assets/logos/extractors/dv-360.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-dynamodb/airbyte.yml
+++ b/_data/meltano/extractors/tap-dynamodb/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://aws.amazon.com/dynamodb/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: DynamoDB
 logo_url: /assets/logos/extractors/dynamodb.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-elasticsearch/airbyte.yml
+++ b/_data/meltano/extractors/tap-elasticsearch/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.elastic.co/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Elasticsearch
 logo_url: /assets/logos/extractors/elasticsearch.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-emailoctopus/airbyte.yml
+++ b/_data/meltano/extractors/tap-emailoctopus/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://emailoctopus.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Emailoctopus
 logo_url: /assets/logos/extractors/emailoctopus.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-exchangeratesapi/airbyte.yml
+++ b/_data/meltano/extractors/tap-exchangeratesapi/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://exchangeratesapi.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Exchangeratesapi.io
 logo_url: /assets/logos/extractors/exchangeratesapi.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-facebook-pages/airbyte.yml
+++ b/_data/meltano/extractors/tap-facebook-pages/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.facebook.com/docs/pages/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Facebook Pages
 logo_url: /assets/logos/extractors/facebook-pages.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-facebook/airbyte.yml
+++ b/_data/meltano/extractors/tap-facebook/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.facebook.com/docs/marketing-apis
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Facebook Ads
 logo_url: /assets/logos/extractors/facebook.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-faker/airbyte.yml
+++ b/_data/meltano/extractors/tap-faker/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://mimesis.name/en/master/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Faker - Mimesis
 logo_url: /assets/logos/extractors/faker.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-fastbill/airbyte.yml
+++ b/_data/meltano/extractors/tap-fastbill/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.fastbill.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Fastbill
 logo_url: /assets/logos/extractors/fastbill.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-fauna/airbyte.yml
+++ b/_data/meltano/extractors/tap-fauna/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://fauna.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Fauna
 logo_url: /assets/logos/extractors/fauna.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-feed/airbyte.yml
+++ b/_data/meltano/extractors/tap-feed/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://en.wikipedia.org/wiki/RSS
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Feed
 logo_url: /assets/logos/extractors/feed.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-file/airbyte.yml
+++ b/_data/meltano/extractors/tap-file/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.facebook.com/docs/pages/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: File
 logo_url: /assets/logos/extractors/file.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-firebolt/airbyte.yml
+++ b/_data/meltano/extractors/tap-firebolt/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.firebolt.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Firebolt
 logo_url: /assets/logos/extractors/firebolt.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-flexport/airbyte.yml
+++ b/_data/meltano/extractors/tap-flexport/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.flexport.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Flexport
 logo_url: /assets/logos/extractors/flexport.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-freshdesk/airbyte.yml
+++ b/_data/meltano/extractors/tap-freshdesk/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://freshdesk.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Freshdesk
 logo_url: /assets/logos/extractors/freshdesk.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-freshsales/airbyte.yml
+++ b/_data/meltano/extractors/tap-freshsales/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.freshworks.com/crm/sales/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Freshsales
 logo_url: /assets/logos/extractors/freshsales.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-freshservice/airbyte.yml
+++ b/_data/meltano/extractors/tap-freshservice/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://freshservice.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Freshservice
 logo_url: /assets/logos/extractors/freshservice.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-genesys/airbyte.yml
+++ b/_data/meltano/extractors/tap-genesys/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.genesys.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Genesys
 logo_url: /assets/logos/extractors/genesys.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-getlago/airbyte.yml
+++ b/_data/meltano/extractors/tap-getlago/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://doc.getlago.com/docs/guide/intro/welcome
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Lago
 logo_url: /assets/logos/extractors/getlago.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-getpocket/airbyte.yml
+++ b/_data/meltano/extractors/tap-getpocket/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://getpocket.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Pocket
 logo_url: /assets/logos/extractors/getpocket.svg
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-github/airbyte.yml
+++ b/_data/meltano/extractors/tap-github/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.github.com/en/rest
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: GitHub
 logo_url: /assets/logos/extractors/github.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-gitlab/airbyte.yml
+++ b/_data/meltano/extractors/tap-gitlab/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.gitlab.com/ee/api/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: GitLab
 logo_url: /assets/logos/extractors/gitlab.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-glassfrog/airbyte.yml
+++ b/_data/meltano/extractors/tap-glassfrog/airbyte.yml
@@ -11,6 +11,7 @@ domain_url: https://www.glassfrog.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: GlassFrog
 logo_url: /assets/logos/extractors/glassfrog.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-gnews/airbyte.yml
+++ b/_data/meltano/extractors/tap-gnews/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://gnews.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: GNews
 logo_url: /assets/logos/extractors/gnews.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-gocardless/airbyte.yml
+++ b/_data/meltano/extractors/tap-gocardless/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://gocardless.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: GoCardless
 logo_url: /assets/logos/extractors/gocardless.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-gong/airbyte.yml
+++ b/_data/meltano/extractors/tap-gong/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.gong.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Gong
 logo_url: /assets/logos/extractors/gong.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-google-directory/airbyte.yml
+++ b/_data/meltano/extractors/tap-google-directory/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.google.com/admin-sdk/directory/v1/guides
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Google Directory
 logo_url: /assets/logos/extractors/google-directory.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-google-pagespeed-insights/airbyte.yml
+++ b/_data/meltano/extractors/tap-google-pagespeed-insights/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.google.com/speed/docs/insights/v5/get-started
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Google PageSpeed Insights
 logo_url: /assets/logos/extractors/google-pagespeed-insights.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-google-search-console/airbyte.yml
+++ b/_data/meltano/extractors/tap-google-search-console/airbyte.yml
@@ -11,6 +11,7 @@ domain_url:
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Google Search Console
 logo_url: /assets/logos/extractors/google-search-console.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-google-sheets/airbyte.yml
+++ b/_data/meltano/extractors/tap-google-sheets/airbyte.yml
@@ -11,6 +11,7 @@ domain_url:
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Google Sheets
 logo_url: /assets/logos/extractors/google-sheets.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-google-webfonts/airbyte.yml
+++ b/_data/meltano/extractors/tap-google-webfonts/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.google.com/fonts/docs/developer_api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Google Webfonts
 logo_url: /assets/logos/extractors/google-webfonts.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-google-workspace-admin-reports/airbyte.yml
+++ b/_data/meltano/extractors/tap-google-workspace-admin-reports/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.google.com/admin-sdk/reports/v1/get-start/overvie
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Google Workspace Admin Reports
 logo_url: /assets/logos/extractors/google-workspace-admin-reports.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-googleads/airbyte.yml
+++ b/_data/meltano/extractors/tap-googleads/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://ads.google.com
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Google Ads
 logo_url: /assets/logos/extractors/googleads.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-greenhouse/airbyte.yml
+++ b/_data/meltano/extractors/tap-greenhouse/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.greenhouse.io/harvest.html
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Greenhouse
 logo_url: /assets/logos/extractors/greenhouse.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-gridly/airbyte.yml
+++ b/_data/meltano/extractors/tap-gridly/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.gridly.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Gridly
 logo_url: /assets/logos/extractors/gridly.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-gutendex/airbyte.yml
+++ b/_data/meltano/extractors/tap-gutendex/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://gutendex.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Gutendex
 logo_url: /assets/logos/extractors/gutendex.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-harvest/airbyte.yml
+++ b/_data/meltano/extractors/tap-harvest/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://help.getharvest.com/api-v2/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Harvest
 logo_url: /assets/logos/extractors/harvest.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-hellobaton/airbyte.yml
+++ b/_data/meltano/extractors/tap-hellobaton/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://app.hellobaton.com/api/redoc/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Baton
 logo_url: /assets/logos/extractors/hellobaton.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-hubplanner/airbyte.yml
+++ b/_data/meltano/extractors/tap-hubplanner/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://hubplanner.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Hub Planner
 logo_url: /assets/logos/extractors/hubplanner.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-hubspot/airbyte.yml
+++ b/_data/meltano/extractors/tap-hubspot/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://legacydocs.hubspot.com/docs/overview
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Hubspot
 logo_url: /assets/logos/extractors/hubspot.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-insightly/airbyte.yml
+++ b/_data/meltano/extractors/tap-insightly/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.insightly.com/v3.1/Help
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Insightly
 logo_url: /assets/logos/extractors/insightly.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-instagram/airbyte.yml
+++ b/_data/meltano/extractors/tap-instagram/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.facebook.com/docs/instagram-api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Instagram
 logo_url: /assets/logos/extractors/instagram.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-intercom/airbyte.yml
+++ b/_data/meltano/extractors/tap-intercom/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.intercom.com/intercom-api-reference/v1.4/referenc
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Intercom
 logo_url: /assets/logos/extractors/intercom.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-intruder/airbyte.yml
+++ b/_data/meltano/extractors/tap-intruder/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.intruder.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Intruder
 logo_url: /assets/logos/extractors/intruder.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-ip2whois/airbyte.yml
+++ b/_data/meltano/extractors/tap-ip2whois/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.ip2whois.com/developers-api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: IP2WHOIS
 logo_url: /assets/logos/extractors/ip2whois.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-iterable/airbyte.yml
+++ b/_data/meltano/extractors/tap-iterable/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.iterable.com/api/docs
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Iterable
 logo_url: /assets/logos/extractors/iterable.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-jira/airbyte.yml
+++ b/_data/meltano/extractors/tap-jira/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Jira
 logo_url: /assets/logos/extractors/jira.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-k6-cloud/airbyte.yml
+++ b/_data/meltano/extractors/tap-k6-cloud/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://k6.io/docs/cloud/cloud-reference/cloud-rest-api/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: K6 Cloud
 logo_url: /assets/logos/extractors/k6-cloud.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-kafka/airbyte.yml
+++ b/_data/meltano/extractors/tap-kafka/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://kafka.apache.org/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Apache Kafka
 logo_url: /assets/logos/extractors/kafka.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-klarna/airbyte.yml
+++ b/_data/meltano/extractors/tap-klarna/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.klarna.com/us/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Klarna
 logo_url: /assets/logos/extractors/klarna.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-klaviyo/airbyte.yml
+++ b/_data/meltano/extractors/tap-klaviyo/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://apidocs.klaviyo.com/reference/metrics
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Klaviyo
 logo_url: /assets/logos/extractors/klaviyo.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-kyriba/airbyte.yml
+++ b/_data/meltano/extractors/tap-kyriba/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.kyriba.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Kyriba
 logo_url: /assets/logos/extractors/kyriba.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-launchdarkly/airbyte.yml
+++ b/_data/meltano/extractors/tap-launchdarkly/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://apidocs.launchdarkly.com/#section/Overview
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Launchdarkly
 logo_url: /assets/logos/extractors/launchdarkly.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-lemlist/airbyte.yml
+++ b/_data/meltano/extractors/tap-lemlist/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.lemlist.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Lemlist
 logo_url: /assets/logos/extractors/lemlist.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-lever/airbyte.yml
+++ b/_data/meltano/extractors/tap-lever/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://hire.lever.co/developer/documentation
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Lever
 logo_url: /assets/logos/extractors/lever.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-linkedin-ads/airbyte.yml
+++ b/_data/meltano/extractors/tap-linkedin-ads/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.microsoft.com/en-us/linkedin/marketing/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Linkedin Ads
 logo_url: /assets/logos/extractors/linkedin-ads.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-linkedin-pages/airbyte.yml
+++ b/_data/meltano/extractors/tap-linkedin-pages/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://business.linkedin.com/marketing-solutions/linkedin-pages
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Linkedin Pages
 logo_url: /assets/logos/extractors/linkedin-pages.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-linnworks/airbyte.yml
+++ b/_data/meltano/extractors/tap-linnworks/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.linnworks.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Linnworks
 logo_url: /assets/logos/extractors/linnworks.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-lokalise/airbyte.yml
+++ b/_data/meltano/extractors/tap-lokalise/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://lokalise.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Lokalise
 logo_url: /assets/logos/extractors/lokalise.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-looker/airbyte.yml
+++ b/_data/meltano/extractors/tap-looker/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.looker.com/reference/api-and-integration/api-reference/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Looker
 logo_url: /assets/logos/extractors/looker.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mailchimp/airbyte.yml
+++ b/_data/meltano/extractors/tap-mailchimp/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://mailchimp.com/developer/marketing/api/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Mailchimp
 logo_url: /assets/logos/extractors/mailchimp.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mailerlite/airbyte.yml
+++ b/_data/meltano/extractors/tap-mailerlite/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.mailerlite.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Mailerlite
 logo_url: /assets/logos/extractors/mailerlite.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mailersend/airbyte.yml
+++ b/_data/meltano/extractors/tap-mailersend/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.mailersend.com/#mailersend-api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Mailersend
 logo_url: /assets/logos/extractors/mailersend.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mailgun/airbyte.yml
+++ b/_data/meltano/extractors/tap-mailgun/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://documentation.mailgun.com/en/latest/api_reference.html
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Mailgun
 logo_url: /assets/logos/extractors/mailgun.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mailjet/airbyte.yml
+++ b/_data/meltano/extractors/tap-mailjet/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.mailjet.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Mailjet
 logo_url: /assets/logos/extractors/mailjet.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-marketo/airbyte.yml
+++ b/_data/meltano/extractors/tap-marketo/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.marketo.com/rest-api/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Marketo
 logo_url: /assets/logos/extractors/marketo.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-metabase/airbyte.yml
+++ b/_data/meltano/extractors/tap-metabase/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.metabase.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Metabase
 logo_url: /assets/logos/extractors/metabase.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mixpanel/airbyte.yml
+++ b/_data/meltano/extractors/tap-mixpanel/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://mixpanel.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Mixpanel
 logo_url: /assets/logos/extractors/mixpanel.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-monday/airbyte.yml
+++ b/_data/meltano/extractors/tap-monday/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.developer.monday.com/docs
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Monday.com
 logo_url: /assets/logos/extractors/monday.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mongodb/airbyte.yml
+++ b/_data/meltano/extractors/tap-mongodb/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: document-based
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: MongoDB
 logo_url: /assets/logos/extractors/mongodb.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-ms-teams/airbyte.yml
+++ b/_data/meltano/extractors/tap-ms-teams/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.microsoft.com/en-us/graph/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Microsoft Teams
 logo_url: /assets/logos/extractors/ms-teams.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mssql/airbyte.yml
+++ b/_data/meltano/extractors/tap-mssql/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.microsoft.com/en-us/sql-server/sql-server-2019
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Microsoft SQL Server
 logo_url: /assets/logos/extractors/mssql.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-my-hours/airbyte.yml
+++ b/_data/meltano/extractors/tap-my-hours/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://myhours.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: My Hours
 logo_url: /assets/logos/extractors/my-hours.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-mysql/airbyte.yml
+++ b/_data/meltano/extractors/tap-mysql/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.mysql.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: MySQL / MariaDB
 logo_url: /assets/logos/extractors/mysql.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-n8n/airbyte.yml
+++ b/_data/meltano/extractors/tap-n8n/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.n8n.io/api/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: n8n
 logo_url: /assets/logos/extractors/n8n.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-nasa/airbyte.yml
+++ b/_data/meltano/extractors/tap-nasa/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://github.com/nasa/apod-api#docs-
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: NASA
 logo_url: /assets/logos/extractors/nasa.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-netsuite/airbyte.yml
+++ b/_data/meltano/extractors/tap-netsuite/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.netsuite.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: NetSuite
 logo_url: /assets/logos/extractors/netsuite.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-notion/airbyte.yml
+++ b/_data/meltano/extractors/tap-notion/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.notion.so/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Notion
 logo_url: /assets/logos/extractors/notion.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-nytimes/airbyte.yml
+++ b/_data/meltano/extractors/tap-nytimes/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.nytimes.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Nytimes
 logo_url: /assets/logos/extractors/nytimes.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-okta/airbyte.yml
+++ b/_data/meltano/extractors/tap-okta/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.okta.com/docs/reference/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Okta
 logo_url: /assets/logos/extractors/okta.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-omnisend/airbyte.yml
+++ b/_data/meltano/extractors/tap-omnisend/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api-docs.omnisend.com/reference/intro
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Omnisend
 logo_url: /assets/logos/extractors/omnisend.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-onesignal/airbyte.yml
+++ b/_data/meltano/extractors/tap-onesignal/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://onesignal.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: OneSignal
 logo_url: /assets/logos/extractors/onesignal.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-openweathermap/airbyte.yml
+++ b/_data/meltano/extractors/tap-openweathermap/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://openweathermap.org/api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: OpenWeatherMap
 logo_url: /assets/logos/extractors/openweathermap.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-oracle/airbyte.yml
+++ b/_data/meltano/extractors/tap-oracle/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.oracle.com/database/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Oracle DB
 logo_url: /assets/logos/extractors/oracle.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-orb/airbyte.yml
+++ b/_data/meltano/extractors/tap-orb/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.withorb.com/docs/orb-docs/api-reference
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Orb
 logo_url: /assets/logos/extractors/orb.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-orbit/airbyte.yml
+++ b/_data/meltano/extractors/tap-orbit/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.orbit.love/reference
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Orbit
 logo_url: /assets/logos/extractors/orbit.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-oura/airbyte.yml
+++ b/_data/meltano/extractors/tap-oura/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://ouraring.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Oura Ring
 logo_url: /assets/logos/extractors/oura.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-outreach/airbyte.yml
+++ b/_data/meltano/extractors/tap-outreach/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.outreach.io/api/v2/docs
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Outreach
 logo_url: /assets/logos/extractors/outreach.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-pardot/airbyte.yml
+++ b/_data/meltano/extractors/tap-pardot/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.pardot.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Pardot
 logo_url: /assets/logos/extractors/pardot.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-partnerstack/airbyte.yml
+++ b/_data/meltano/extractors/tap-partnerstack/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.partnerstack.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: PartnerStack
 logo_url: /assets/logos/extractors/partnerstack.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-paypal/airbyte.yml
+++ b/_data/meltano/extractors/tap-paypal/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.paypal.com/us/home
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: PayPal
 logo_url: /assets/logos/extractors/paypal.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-paystack/airbyte.yml
+++ b/_data/meltano/extractors/tap-paystack/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://paystack.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Paystack
 logo_url: /assets/logos/extractors/paystack.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-persistiq/airbyte.yml
+++ b/_data/meltano/extractors/tap-persistiq/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://apidocs.persistiq.com/#introduction
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: PersistIQ
 logo_url: /assets/logos/extractors/persistiq.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-pexels-api/airbyte.yml
+++ b/_data/meltano/extractors/tap-pexels-api/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.pexels.com/api/documentation
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Pexels Api
 logo_url: /assets/logos/extractors/pexels-api.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-pinterest-ads/airbyte.yml
+++ b/_data/meltano/extractors/tap-pinterest-ads/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.pinterest.com/docs/api/v5/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Pinterest Ads
 logo_url: /assets/logos/extractors/pinterest-ads.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-pipedrive/airbyte.yml
+++ b/_data/meltano/extractors/tap-pipedrive/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.pipedrive.com/docs/api/v1
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Pipedrive
 logo_url: /assets/logos/extractors/pipedrive.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-pivotal-tracker/airbyte.yml
+++ b/_data/meltano/extractors/tap-pivotal-tracker/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.pivotaltracker.com/help/api/rest/v5#top
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: PivotalTracker
 logo_url: /assets/logos/extractors/pivotal-tracker.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-plaid/airbyte.yml
+++ b/_data/meltano/extractors/tap-plaid/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://plaid.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Plaid
 logo_url: /assets/logos/extractors/plaid.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-plausible/airbyte.yml
+++ b/_data/meltano/extractors/tap-plausible/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://plausible.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Plausible
 logo_url: /assets/logos/extractors/plausible.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-pokeapi/airbyte.yml
+++ b/_data/meltano/extractors/tap-pokeapi/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://pokeapi.co/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Pokeapi
 logo_url: /assets/logos/extractors/pokeapi.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-polygon-stock-api/airbyte.yml
+++ b/_data/meltano/extractors/tap-polygon-stock-api/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://polygon.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Polygon Stock API
 logo_url: /assets/logos/extractors/polygon-stock-api.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-postgres/airbyte.yml
+++ b/_data/meltano/extractors/tap-postgres/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.postgresql.org/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: PostgreSQL
 logo_url: /assets/logos/extractors/postgres.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-posthog/airbyte.yml
+++ b/_data/meltano/extractors/tap-posthog/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://posthog.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: PostHog
 logo_url: /assets/logos/extractors/posthog.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-postmark/airbyte.yml
+++ b/_data/meltano/extractors/tap-postmark/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://postmarkapp.com/developer
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Postmark
 logo_url: /assets/logos/extractors/postmark.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-prestashop/airbyte.yml
+++ b/_data/meltano/extractors/tap-prestashop/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.prestashop.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: PrestaShop
 logo_url: /assets/logos/extractors/prestashop.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-primetric/airbyte.yml
+++ b/_data/meltano/extractors/tap-primetric/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.primetric.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Primetric
 logo_url: /assets/logos/extractors/primetric.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-public-apis/airbyte.yml
+++ b/_data/meltano/extractors/tap-public-apis/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.publicapis.org/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Public APIs
 logo_url: /assets/logos/extractors/public-apis.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-punk-api/airbyte.yml
+++ b/_data/meltano/extractors/tap-punk-api/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://punkapi.com/documentation/v2
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Punk API
 logo_url: /assets/logos/extractors/punk-api.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-pypi/airbyte.yml
+++ b/_data/meltano/extractors/tap-pypi/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://pypi.org/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: PyPI
 logo_url: /assets/logos/extractors/pypi.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-qonto/airbyte.yml
+++ b/_data/meltano/extractors/tap-qonto/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://qonto.com/en
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Qonto
 logo_url: /assets/logos/extractors/qonto.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-qualaroo/airbyte.yml
+++ b/_data/meltano/extractors/tap-qualaroo/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://qualaroo.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Qualaroo
 logo_url: /assets/logos/extractors/qualaroo.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-rd-station-marketing/airbyte.yml
+++ b/_data/meltano/extractors/tap-rd-station-marketing/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.rdstation.com/en/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Rd Station Marketing
 logo_url: /assets/logos/extractors/rd-station-marketing.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-recharge/airbyte.yml
+++ b/_data/meltano/extractors/tap-recharge/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://rechargepayments.com/developers/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: ReCharge
 logo_url: /assets/logos/extractors/recharge.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-recreation/airbyte.yml
+++ b/_data/meltano/extractors/tap-recreation/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://ridb.recreation.gov/landing
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Recreation
 logo_url: /assets/logos/extractors/recreation.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-recruitee/airbyte.yml
+++ b/_data/meltano/extractors/tap-recruitee/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://recruitee.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Recruitee
 logo_url: /assets/logos/extractors/recruitee.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-recurly/airbyte.yml
+++ b/_data/meltano/extractors/tap-recurly/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://recurly.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Recurly
 logo_url: /assets/logos/extractors/recurly.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-redshift/airbyte.yml
+++ b/_data/meltano/extractors/tap-redshift/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://aws.amazon.com/redshift/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Redshift
 logo_url: /assets/logos/extractors/redshift.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-reply-io/airbyte.yml
+++ b/_data/meltano/extractors/tap-reply-io/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://apidocs.reply.io/#intro
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Reply Io
 logo_url: /assets/logos/extractors/reply-io.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-retently/airbyte.yml
+++ b/_data/meltano/extractors/tap-retently/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.retently.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Retently
 logo_url: /assets/logos/extractors/retently.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-rki-covid/airbyte.yml
+++ b/_data/meltano/extractors/tap-rki-covid/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.corona-zahlen.org/docs/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Robert Koch-Institut COVID-19
 logo_url: /assets/logos/extractors/rki-covid.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-rocket-chat/airbyte.yml
+++ b/_data/meltano/extractors/tap-rocket-chat/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.rocket.chat/reference/api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Rocket Chat
 logo_url: /assets/logos/extractors/rocket-chat.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-s3/airbyte.yml
+++ b/_data/meltano/extractors/tap-s3/airbyte.yml
@@ -11,6 +11,7 @@ executable: tap-airbyte
 keywords:
 - aws
 - airbyte_protocol
+- meltano_sdk
 label: S3
 logo_url: /assets/logos/extractors/s3-csv.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-salesforce/airbyte.yml
+++ b/_data/meltano/extractors/tap-salesforce/airbyte.yml
@@ -11,6 +11,7 @@ domain_url:
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Salesforce
 logo_url: /assets/logos/extractors/salesforce.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-salesloft/airbyte.yml
+++ b/_data/meltano/extractors/tap-salesloft/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://salesloft.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Salesloft
 logo_url: /assets/logos/extractors/salesloft.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-sap-fieldglass/airbyte.yml
+++ b/_data/meltano/extractors/tap-sap-fieldglass/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.sap.com/api/activeWorkerDownload/resource
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: SAP Fieldglass
 logo_url: /assets/logos/extractors/sap-fieldglass.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-search-metrics/airbyte.yml
+++ b/_data/meltano/extractors/tap-search-metrics/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.searchmetrics.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Searchmetrics
 logo_url: /assets/logos/extractors/searchmetrics.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-secoda/airbyte.yml
+++ b/_data/meltano/extractors/tap-secoda/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.secoda.co/secoda-api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Secoda
 logo_url: /assets/logos/extractors/secoda.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-sendgrid/airbyte.yml
+++ b/_data/meltano/extractors/tap-sendgrid/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.sendgrid.com/docs/for-developers/sending-email/api-gett
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: SendGrid
 logo_url: /assets/logos/extractors/sendgrid.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-sendinblue/airbyte.yml
+++ b/_data/meltano/extractors/tap-sendinblue/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.sendinblue.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Sendinblue
 logo_url: /assets/logos/extractors/sendinblue.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-senseforce/airbyte.yml
+++ b/_data/meltano/extractors/tap-senseforce/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://manual.senseforce.io/manual/sf-platform/dataset-builder
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Senseforce
 logo_url: /assets/logos/extractors/senseforce.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-sentry/airbyte.yml
+++ b/_data/meltano/extractors/tap-sentry/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://sentry.io/api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Sentry
 logo_url: /assets/logos/extractors/sentry.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-sftp/airbyte.yml
+++ b/_data/meltano/extractors/tap-sftp/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: SFTP
 logo_url: /assets/logos/extractors/sftp.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-shopify/airbyte.yml
+++ b/_data/meltano/extractors/tap-shopify/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://shopify.dev/docs/admin-api/rest/reference
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Shopify
 logo_url: /assets/logos/extractors/shopify.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-shortio/airbyte.yml
+++ b/_data/meltano/extractors/tap-shortio/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://short.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Searchmetrics
 logo_url: /assets/logos/extractors/shortio.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-slack/airbyte.yml
+++ b/_data/meltano/extractors/tap-slack/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://slack.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Slack
 logo_url: /assets/logos/extractors/slack.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-smaily/airbyte.yml
+++ b/_data/meltano/extractors/tap-smaily/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://smaily.com/help/api/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Smaily
 logo_url: /assets/logos/extractors/smaily.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-smartengage/airbyte.yml
+++ b/_data/meltano/extractors/tap-smartengage/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://smartengage.com/docs/#smartengage-api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: SmartEngage
 logo_url: /assets/logos/extractors/smartengage.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-smartsheet/airbyte.yml
+++ b/_data/meltano/extractors/tap-smartsheet/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: Smartsheet enables project management professionals to streamline wo
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Smartsheet
 logo_url: /assets/logos/extractors/smartsheet.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-snapchat-ads/airbyte.yml
+++ b/_data/meltano/extractors/tap-snapchat-ads/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.snapchat.com/docs/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Snapchat Marketing
 logo_url: /assets/logos/extractors/snapchat-ads.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-snowflake/airbyte.yml
+++ b/_data/meltano/extractors/tap-snowflake/airbyte.yml
@@ -11,6 +11,7 @@ executable: tap-airbyte
 keywords:
 - database
 - airbyte_protocol
+- meltano_sdk
 label: Snowflake
 logo_url: /assets/logos/extractors/snowflake.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-sonar-cloud/airbyte.yml
+++ b/_data/meltano/extractors/tap-sonar-cloud/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://sonarcloud.io/web_api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Sonar Cloud
 logo_url: /assets/logos/extractors/sonar-cloud.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-spacex-api/airbyte.yml
+++ b/_data/meltano/extractors/tap-spacex-api/airbyte.yml
@@ -11,6 +11,7 @@ domain_url: https://github.com/r-spacex/SpaceX-API
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Spacex API
 logo_url: /assets/logos/extractors/spacex-api.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-square/airbyte.yml
+++ b/_data/meltano/extractors/tap-square/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.squareup.com/us/en
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Square
 logo_url: /assets/logos/extractors/square.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-statuspage/airbyte.yml
+++ b/_data/meltano/extractors/tap-statuspage/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.atlassian.com/software/statuspage
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Statuspage
 logo_url: /assets/logos/extractors/statuspage.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-strava/airbyte.yml
+++ b/_data/meltano/extractors/tap-strava/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.strava.com/docs/reference/#api-models-DetailedAth
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Strava
 logo_url: /assets/logos/extractors/strava.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-stripe/airbyte.yml
+++ b/_data/meltano/extractors/tap-stripe/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://stripe.com/docs/api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Stripe
 logo_url: /assets/logos/extractors/stripe.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-survey-sparrow/airbyte.yml
+++ b/_data/meltano/extractors/tap-survey-sparrow/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.surveysparrow.com/rest-apis
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Survey Sparrow
 logo_url: /assets/logos/extractors/survey-sparrow.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-surveycto/airbyte.yml
+++ b/_data/meltano/extractors/tap-surveycto/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.surveycto.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: SurveyCTO
 logo_url: /assets/logos/extractors/surveycto.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-surveymonkey/airbyte.yml
+++ b/_data/meltano/extractors/tap-surveymonkey/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.surveymonkey.com/api/v3/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: SurveyMonkey
 logo_url: /assets/logos/extractors/surveymonkey.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-talkdesk-explore/airbyte.yml
+++ b/_data/meltano/extractors/tap-talkdesk-explore/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.talkdesk.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Talkdesk Explore API
 logo_url: /assets/logos/extractors/talkdesk-explore.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-tempo/airbyte.yml
+++ b/_data/meltano/extractors/tap-tempo/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.tempo.io/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Tempo
 logo_url: /assets/logos/extractors/tempo.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-the-guardian-api/airbyte.yml
+++ b/_data/meltano/extractors/tap-the-guardian-api/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://open-platform.theguardian.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: The Guardian Api
 logo_url: /assets/logos/extractors/the-guardian-api.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-tidb/airbyte.yml
+++ b/_data/meltano/extractors/tap-tidb/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://github.com/pingcap/tidb
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: TiDB
 logo_url: /assets/logos/extractors/tidb.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-tiktok/airbyte.yml
+++ b/_data/meltano/extractors/tap-tiktok/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://ads.tiktok.com/marketing_api/homepage
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: TikTok Ads
 logo_url: /assets/logos/extractors/tiktok.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-timely/airbyte.yml
+++ b/_data/meltano/extractors/tap-timely/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://timelyapp.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Timely
 logo_url: /assets/logos/extractors/timely.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-tmdb/airbyte.yml
+++ b/_data/meltano/extractors/tap-tmdb/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.themoviedb.org/3/getting-started
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: The Movie Database
 logo_url: /assets/logos/extractors/tmdb.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-toggl/airbyte.yml
+++ b/_data/meltano/extractors/tap-toggl/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.toggl.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Toggl
 logo_url: /assets/logos/extractors/toggl.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-trello/airbyte.yml
+++ b/_data/meltano/extractors/tap-trello/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.atlassian.com/cloud/trello/rest/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Trello
 logo_url: /assets/logos/extractors/trello.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-tvmaze-schedule/airbyte.yml
+++ b/_data/meltano/extractors/tap-tvmaze-schedule/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.tvmaze.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Tvmaze Schedule
 logo_url: /assets/logos/extractors/tvmaze-schedule.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-twilio/airbyte.yml
+++ b/_data/meltano/extractors/tap-twilio/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.twilio.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Twilio
 logo_url: /assets/logos/extractors/twilio.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-twitter/airbyte.yml
+++ b/_data/meltano/extractors/tap-twitter/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.twitter.com
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Twitter
 logo_url: /assets/logos/extractors/twitter.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-tyntec-sms/airbyte.yml
+++ b/_data/meltano/extractors/tap-tyntec-sms/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://api.tyntec.com/reference/sms/current.html#sms-api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Tyntec SMS
 logo_url: /assets/logos/extractors/tyntec-sms.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-typeform/airbyte.yml
+++ b/_data/meltano/extractors/tap-typeform/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.typeform.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Typeform
 logo_url: /assets/logos/extractors/typeform.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-us-census/airbyte.yml
+++ b/_data/meltano/extractors/tap-us-census/airbyte.yml
@@ -11,6 +11,7 @@ domain_url:
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: US Census
 logo_url: /assets/logos/extractors/us-census.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-vantage/airbyte.yml
+++ b/_data/meltano/extractors/tap-vantage/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://vantage.readme.io/reference/general
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Vantage
 logo_url: /assets/logos/extractors/vantage.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-visma-economic/airbyte.yml
+++ b/_data/meltano/extractors/tap-visma-economic/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.visma.com/api/e-conomic/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Visma Economic
 logo_url: /assets/logos/extractors/visma-economic.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-vitally/airbyte.yml
+++ b/_data/meltano/extractors/tap-vitally/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://docs.vitally.io/pushing-data-to-vitally/rest-api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Vitally
 logo_url: /assets/logos/extractors/vitally.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-waiteraid/airbyte.yml
+++ b/_data/meltano/extractors/tap-waiteraid/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://app.waiteraid.com/api-docs/index.html#auth_call
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Waiteraid
 logo_url: /assets/logos/extractors/waiteraid.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-weatherstack/airbyte.yml
+++ b/_data/meltano/extractors/tap-weatherstack/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://weatherstack.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Weatherstack
 logo_url: /assets/logos/extractors/weatherstack.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-webflow/airbyte.yml
+++ b/_data/meltano/extractors/tap-webflow/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://webflow.com
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Webflow
 logo_url: /assets/logos/extractors/webflow.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-whisky-hunter/airbyte.yml
+++ b/_data/meltano/extractors/tap-whisky-hunter/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://whiskyhunter.net/api/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Whiskey Hunter API
 logo_url: /assets/logos/extractors/whisky-hunter.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-wikipedia-pageviews/airbyte.yml
+++ b/_data/meltano/extractors/tap-wikipedia-pageviews/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://wikimedia.org/api/rest_v1/#/Pageviews%20data
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Wikipedia Pageviews
 logo_url: /assets/logos/extractors/wikipedia-pageviews.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-woocommerce/airbyte.yml
+++ b/_data/meltano/extractors/tap-woocommerce/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: http://woocommerce.github.io/woocommerce-rest-api-docs/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: WooCommerce
 logo_url: /assets/logos/extractors/woocommerce.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-workable/airbyte.yml
+++ b/_data/meltano/extractors/tap-workable/airbyte.yml
@@ -11,6 +11,7 @@ domain_url:
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Workable
 logo_url: /assets/logos/extractors/workable.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-workramp/airbyte.yml
+++ b/_data/meltano/extractors/tap-workramp/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.workramp.com/products/enterprise/integrations/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Workramp
 logo_url: /assets/logos/extractors/workramp.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-wrike/airbyte.yml
+++ b/_data/meltano/extractors/tap-wrike/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.wrike.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Wrike
 logo_url: /assets/logos/extractors/wrike.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-xero/airbyte.yml
+++ b/_data/meltano/extractors/tap-xero/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.xero.com/documentation/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Xero
 logo_url: /assets/logos/extractors/xero.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-xkcd/airbyte.yml
+++ b/_data/meltano/extractors/tap-xkcd/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://xkcd.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: XKCD
 logo_url: /assets/logos/extractors/xkcd.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-yandex-metrica/airbyte.yml
+++ b/_data/meltano/extractors/tap-yandex-metrica/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://metrica.yandex.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Yandex.Metrica
 logo_url: /assets/logos/extractors/yandex-metrica.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-younium/airbyte.yml
+++ b/_data/meltano/extractors/tap-younium/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.younium.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Younium
 logo_url: /assets/logos/extractors/younium.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-youtube-analytics/airbyte.yml
+++ b/_data/meltano/extractors/tap-youtube-analytics/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.google.com/youtube/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: YouTube Analytics
 logo_url: /assets/logos/extractors/youtube-analytics.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zapier-supported-storage/airbyte.yml
+++ b/_data/meltano/extractors/tap-zapier-supported-storage/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://store.zapier.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zapier Supported Storage
 logo_url: /assets/logos/extractors/zapier-supported-storage.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zendesk-chat/airbyte.yml
+++ b/_data/meltano/extractors/tap-zendesk-chat/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.zendesk.com/rest_api/docs/chat/introduction
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zendesk Chat
 logo_url: /assets/logos/extractors/zendesk-chat.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zendesk-sell/airbyte.yml
+++ b/_data/meltano/extractors/tap-zendesk-sell/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.getbase.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zendesk Sell
 logo_url: /assets/logos/extractors/zendesk-sell.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zendesk-sunshine/airbyte.yml
+++ b/_data/meltano/extractors/tap-zendesk-sunshine/airbyte.yml
@@ -11,6 +11,7 @@ domain_url:
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zendesk Sunshine
 logo_url: /assets/logos/extractors/zendesk-sunshine.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zendesk-talk/airbyte.yml
+++ b/_data/meltano/extractors/tap-zendesk-talk/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.zendesk.com/api-reference/voice/talk-api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zendesk Talk
 logo_url: /assets/logos/extractors/zendesk-talk.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zendesk/airbyte.yml
+++ b/_data/meltano/extractors/tap-zendesk/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developer.zendesk.com/rest_api
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zendesk (Support)
 logo_url: /assets/logos/extractors/zendesk.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zenefits/airbyte.yml
+++ b/_data/meltano/extractors/tap-zenefits/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://developers.zenefits.com/docs/overview
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zenefits
 logo_url: /assets/logos/extractors/zenefits.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zenloop/airbyte.yml
+++ b/_data/meltano/extractors/tap-zenloop/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.zenloop.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zenloop
 logo_url: /assets/logos/extractors/zenloop.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zoho-crm/airbyte.yml
+++ b/_data/meltano/extractors/tap-zoho-crm/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.zoho.com/crm/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zoho CRM
 logo_url: /assets/logos/extractors/zoho-crm.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zoom/airbyte.yml
+++ b/_data/meltano/extractors/tap-zoom/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://marketplace.zoom.us/docs/api-reference/introduction
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zoom
 logo_url: /assets/logos/extractors/zoom.png
 maintenance_status: beta

--- a/_data/meltano/extractors/tap-zuora/airbyte.yml
+++ b/_data/meltano/extractors/tap-zuora/airbyte.yml
@@ -10,6 +10,7 @@ domain_url: https://www.zuora.com/
 executable: tap-airbyte
 keywords:
 - airbyte_protocol
+- meltano_sdk
 label: Zuora
 logo_url: /assets/logos/extractors/zuora.png
 maintenance_status: beta


### PR DESCRIPTION
The Airbyte wrapper plugin is built with the SDK and exposes SDK settings - it would therefore benefit from #1709.