### PR TITLE
fix: Fragment links blocked by search autofocus

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -7,7 +7,7 @@
       placeholder="Search 600+ connectors and tools"
       class="search-bar text-black text-sm bg-transparent pl-4 border-solid border-blue border rounded-[9999px] py-1.5 w-full placeholder:text-par placeholder:font-light font-ibm focus-visible:outline-0"
       ref="searchBar"
-      autofocus
+      :autofocus="!this.$route.hash"
       :value="search"
       @input="search = $event.target.value"
       @focus="searchFocused = true"


### PR DESCRIPTION
#1718 introduced an obscure bug in which the search autofocus blocks URL fragment links, such that a link to (for example) `#settings` doesn't auto-scroll to the section on load.

https://hub.meltano.com/extractors/tap-auth0#settings

This seems to only cause an issue for fast connections or when running locally.