### PR TITLE
Add missing `oauth_url` setting for `tap-zohosprints`

### DIFF
--- a/_data/meltano/extractors/tap-zohosprints/autoidm.yml
+++ b/_data/meltano/extractors/tap-zohosprints/autoidm.yml
@@ -21,6 +21,10 @@ settings:
   kind: string
   label: API URL
   name: api_url
+- description: The OAuth URL
+  kind: string
+  label: OAuth URL
+  name: oauth_url
 - description: Your client ID.
   kind: password
   label: Client ID


### PR DESCRIPTION
https://github.com/AutoIDM/tap-zohosprints/blob/52dc10d6912b74897ca5d62c55aa4ddd0b5fb333/tap_zohosprints/tap.py#L53-L55