### PR TITLE
refactor: update target-redshift maintenance status and default

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -634,7 +634,7 @@ loaders:
   target-parquet: automattic
   target-pinecone: meltanolabs
   target-postgres: meltanolabs
-  target-redshift: transferwise
+  target-redshift: ticketswap
   target-s3: crowemi
   target-s3-avro: faumel
   target-s3-csv: transferwise

--- a/_data/meltano/loaders/target-redshift/transferwise.yml
+++ b/_data/meltano/loaders/target-redshift/transferwise.yml
@@ -12,7 +12,7 @@ keywords:
 - database
 label: Amazon Redshift
 logo_url: /assets/logos/loaders/redshift.png
-maintenance_status: active
+maintenance_status: inactive
 name: target-redshift
 namespace: target_redshift
 pip_url: pipelinewise-target-redshift


### PR DESCRIPTION
the transferwise redshift target is unmaintained, so updating that. would argue that the ticketswap variant should be default because of maintenance status and built with meltano sdk