### PR TITLE
fix: Change kind of `port` in TicketSwap target-redshift to `string`

### DIFF
--- a/_data/meltano/loaders/target-redshift/ticketswap.yml
+++ b/_data/meltano/loaders/target-redshift/ticketswap.yml
@@ -85,10 +85,10 @@ settings:
   sensitive: true
 - description: The port on which redshift is awaiting connection. Note if sqlalchemy_url
     is set this will be ignored.
-  kind: integer
+  kind: string
   label: Port
   name: port
-  value: 5432
+  value: "5432"
 - description: SQLAlchemy connection string. This will override using host, user,
     password, port, dialect, and all ssl settings. Note that you must escape password
     special characters properly. See 


### PR DESCRIPTION
The setting in the target's codebase is declared as `string`, but as `integer` here in the Hub metadata. This changes the latter.

https://github.com/TicketSwap/target-redshift/blob/caee498660ccbf0025c82f54b7889c17516e59f5/target_redshift/target.py#L82-L90

@tobiascadee let me know if you'd prefer to change this in the target's original settings :)