### PR TITLE
fix: Use correct `pip_url` for TicketSwap `target-redshift`

### DIFF
--- a/_data/meltano/loaders/target-redshift/ticketswap.yml
+++ b/_data/meltano/loaders/target-redshift/ticketswap.yml
@@ -16,7 +16,7 @@ maintenance_status: active
 name: target-redshift
 namespace: target_redshift
 next_steps: ''
-pip_url: target-redshift
+pip_url: git+https://github.com/TicketSwap/target-redshift.git
 quality: silver
 repo: https://github.com/TicketSwap/target-redshift
 settings:


### PR DESCRIPTION
I've been helping someone on the Meltano Slack using `target-redshift` and noticed that the `pip_url` is pointing at [this pip package](https://pypi.org/project/target-redshift/), which (like the old default variant) hasn't been updated in over 4 years.

This means anyone trying to install `target-redshift` currently is probably not getting the version they think they're getting.