### PR TITLE
target-s3 crowemi.yml - add jsonl format

### DIFF
--- a/_data/meltano/loaders/target-s3/crowemi.yml
+++ b/_data/meltano/loaders/target-s3/crowemi.yml
@@ -142,7 +142,7 @@ settings:
     value: parquet
   - label: Json
     value: json
-  - label: Jsonl
+  - label: JSON Lines
     value: jsonl
 - description: A flag indicating whether to append _process_date to record.
   kind: boolean

--- a/_data/meltano/loaders/target-s3/crowemi.yml
+++ b/_data/meltano/loaders/target-s3/crowemi.yml
@@ -142,6 +142,8 @@ settings:
     value: parquet
   - label: Json
     value: json
+  - label: Jsonl
+    value: jsonl
 - description: A flag indicating whether to append _process_date to record.
   kind: boolean
   label: Include Process Date


### PR DESCRIPTION
Supported by the loader.
See the repo [target.py](https://github.com/crowemi/target-s3/blob/c6d00e2cb807cc8b79eae89638c37b7a40fad1d0/target_s3/target.py#L32).