### PR TITLE
fix: Code block content overflowing

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -247,7 +247,6 @@ font-family: 'Plus Jakarta Sans', sans-serif;
 }
 
 pre[class*="language-"] {
-  overflow-x: scroll !important;
   width: 100%;
 }
 

--- a/src/components/PluginCommandsSection.vue
+++ b/src/components/PluginCommandsSection.vue
@@ -32,7 +32,7 @@ export default {
 </script>
 
 <style>
-pre {
+span > pre {
   display: inline-block;
 }
 </style>

--- a/src/components/PluginPrereqSection.vue
+++ b/src/components/PluginPrereqSection.vue
@@ -23,5 +23,3 @@ export default {
   props: ["plugin", "plugin_type"],
 };
 </script>
-
-<style></style>


### PR DESCRIPTION
For example: https://hub.meltano.com/extractors/tap-slack/#prereqs

Code blocks overflow their container
![image](https://github.com/meltano/hub/assets/60552974/142f90f6-2941-4603-a0db-3992ee3f24f3)

Horizontal scrollbar show for non-overflowing content
![image](https://github.com/meltano/hub/assets/60552974/b109c548-bf2f-4c81-9477-4729c26ac11d)

This PR address both these issues.