### PR TITLE
Make the MeltanoLabs variant of `target-csv` the default

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -611,7 +611,7 @@ loaders:
   target-cassandra: coeff
   target-chromadb: meltanolabs
   target-clickhouse: shaped-ai
-  target-csv: hotgluexyz
+  target-csv: meltanolabs
   target-datadotworld: datadotworld
   target-duckdb: jwills
   target-elasticsearch: dtmirizzi


### PR DESCRIPTION
The hotglue variant has some issues with column alignment in some cases,
which the MeltanoLabs variant seem to  handle correctly.
