### PR TITLE
chore: Use non-package mode with Poetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "12:00"
       timezone: "Etc/UTC"
     reviewers: [meltano/engineering]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.poetry]
-name = "meltano-hub"
-version = "0.1.0"
+package-mode = false
 description = "Meltano hub contains the definition of all meltano taps, targets, utilities, etc."
 authors = ["Meltano Team"]
 


### PR DESCRIPTION
* See https://python-poetry.org/docs/basic-usage/#operating-modes
* https://python-poetry.org/docs/pyproject#package-mode
* Added in [Poetry 1.8.0](https://github.com/python-poetry/poetry/releases/tag/1.8.0)
