### PR TITLE
Update gthesheep.yml

### DIFF
--- a/_data/meltano/extractors/tap-monday/gthesheep.yml
+++ b/_data/meltano/extractors/tap-monday/gthesheep.yml
@@ -20,7 +20,6 @@ quality: silver
 repo: https://github.com/gthesheep/tap-monday
 settings:
 - description: The token to authenticate against the API service
-  kind: password
   label: Auth Token
   name: auth_token
   sensitive: true


### PR DESCRIPTION
Filing PR following the suggested response to an error when using `tap-monday`.

```
% meltano config tap-monday test
2024-07-12T23:20:51.442699Z [info     ] The default environment 'dev' will be ignored for `meltano config`. To configure a specific environment, please use the option `--environment=<environment name>`.
2024-07-12T23:20:51.459163Z [warning  ] `kind: password` is deprecated for setting definitions in favour of `sensitive: true`, and is currently in use by the following settings of extractor 'tap-monday': 'auth_token'. Please open an issue or pull request to update the plugin definition on Meltano Hub at https://github.com/meltano/hub/blob/main/_data/meltano/extractors/tap-monday/gthesheep.yml.
Need help fixing this problem? Visit http://melta.no/ for troubleshooting steps, or to
join our friendly Slack community.

Plugin configuration is invalid
KeyError: 'data'
```

It appears the `kind: password` entry is not needed anymore, since `sensitive: true` was already set.