### PR TITLE
fix: REST API MSDK - Type mismatch

### DIFF
--- a/_data/meltano/extractors/tap-rest-api-msdk/widen.yml
+++ b/_data/meltano/extractors/tap-rest-api-msdk/widen.yml
@@ -62,7 +62,7 @@ settings:
 - description: 'An additional extension (seconds) to the backoff time over and above
     a jitter value - use where an API is not precise in its backoff times. Optional:
     Defaults to `0`.'
-  kind: string
+  kind: integer
   label: Backoff Time Extension
   name: backoff_time_extension
   value: 0


### PR DESCRIPTION
`2024-09-10 16:58:24,317 | ERROR    | tap-rest-api-msdk    | Config validation error: '0' is not of type 'integer', 'null'`

The default value is an integer and this error message tipped me off that the kind should be integer so it can cast properly from env vars.