### PR TITLE
Adding new config settings `conn_properties` and `enable_tds_logging` to tap-mssql (Rob Winters variant)

### DIFF
--- a/_data/meltano/extractors/tap-mssql/wintersrd.yml
+++ b/_data/meltano/extractors/tap-mssql/wintersrd.yml
@@ -31,9 +31,24 @@ settings:
   label: Cursor Array Size
   name: cursor_array_size
   value: 1
+- description: |
+    The "conn_properties" allows specific configuration of database settings via SQL set statements to send to the database
+    instance upon connection establishment. Can be a string or another kind of iterable of strings.
+    If you want to connect Azure SQL Server instances e.g. PDW you will need to adjust the connection setting for that version of MSSQL.
+    Please refer to the github repo page for details on these settings.
+  label: Connection Properties
+  name: conn_properties
 - description: Your MSSQL database name.
   label: Database
   name: database
+- description: |
+    When set it will dump out the underlying TDS driver logs. Useful for diagnosing issues if
+    you are having connection issues to SQL Server databases. WARNING! this does dump a lot of information and may
+    log secure data, should be only used in Development environments.
+  kind: boolean
+  label: Enable TDS Logging
+  name: enable_tds_logging
+  value: false
 - description: A comma separated list of databases to filter for.
   label: Filter Databases
   name: filter_dbs


### PR DESCRIPTION
New setting for the wintersrd variant of tap-mssql.

Optional:

The `"conn_properties"` allows specific tweaking of database settings via SQL set statements to send to the database instance upon connection establishment. Can be a string or another kind of iterable of strings.

The default values set if this [settings](https://pymssql.readthedocs.io/en/stable/ref/_mssql.html) is not defined are:

```json
"SET ARITHABORT ON; SET CONCAT_NULL_YIELDS_NULL ON; SET ANSI_NULLS ON; SET ANSI_NULL_DFLT_ON ON; SET ANSI_PADDING ON; SET ANSI_WARNINGS ON; SET ANSI_NULL_DFLT_ON ON; SET CURSOR_CLOSE_ON_COMMIT ON; SET QUOTED_IDENTIFIER ON; SET TEXTSIZE 2147483647;"
```

Example: override the built-in session properties supplied by pymssql by default, because one of the default settings (CURSOR_CLOSE_ON_COMMIT) is not available on PDW


```json
{
  "conn_properties": "SET ARITHABORT ON; SET CONCAT_NULL_YIELDS_NULL ON; SET ANSI_NULLS ON; SET ANSI_NULL_DFLT_ON ON; SET ANSI_PADDING ON; SET ANSI_WARNINGS ON; SET ANSI_NULL_DFLT_ON ON; SET QUOTED_IDENTIFIER ON; SET TEXTSIZE 2147483647;"
}
```

Optional:

The `"enable_tds_logging"` When set it will dump out the underlying TDS driver logs. Useful for diagnosing issues if you are having connection issues to SQL Server databases. WARNING! this
does dump a lot of information and may log secure data, should be only used in Development
environments.

```json
{
  "enable_tds_logging": true
}
```