### PR TITLE
Updated the `tables` option description of tap-s3-csv (Steve Clarke variant)

### DIFF
--- a/_data/meltano/extractors/tap-s3-csv/s7clarke10.yml
+++ b/_data/meltano/extractors/tap-s3-csv/s7clarke10.yml
@@ -68,27 +68,35 @@ settings:
   name: table_suffix
 - description: "An array that consists of one or more objects that describe how to
     find files and emit records. Required - `table_name` and `search_pattern`. Optional
-    - `key_properties`, `search_prefix`, `date_overrides`, `delimiter`, `remove_character`,
-    `string_overrides`, `guess_types`, `encoding`.\n- `search_prefix` - This is a
-    prefix to apply after the bucket, but before the file search pattern, to allow
-    you to find files in \"directories\" below the bucket. - `search_pattern` - This
-    is an escaped regular expression that the tap will use to find files in the bucket
-    + prefix. It's a bit strange, since this is an escaped string inside of an escaped
-    string, any backslashes in the RegEx will need to be double-escaped. - `table_name`
-    - This value is a string of your choosing, and will be used to name the stream
-    that records are emitted under for files matching content. - `key_properties`
-    - These are the \"primary keys\" of the CSV files, to be used by the target for
-    deduplication and primary key definitions downstream in the destination. - `date_overrides`
-    - Specifies field names in the files that are supposed to be parsed as a datetime.
-    The tap doesn't attempt to automatically determine if a field is a datetime, so
-    this will make it explicit in the discovered schema. - `delimiter` - This allows
-    you to specify a custom delimiter, such as `\\t` or `|`, if that applies to your
-    files. - `string_overrides` - Specifies field names in the files that should be
-    parsed as a string regardless of what was discovered. - `guess_types` - (default
-    `True`) By default, column data types will be determined via scanning the first
-    file in a table_spec. Set this to `False` to disable this and set all columns
-    to `string`. - `remove_character` - Specifies a character which can be removed
-    from each line in the the file e.g. `\"\\\"\"` will remove all double-quotes.
+    - `key_properties`, `search_prefix`, `datatype_overrides`, `date_overrides`,
+    `delimiter`, `remove_character`, `string_overrides`, `guess_types`, `encoding`.\n
+    - `search_prefix` - This is a prefix to apply after the bucket, but before the file
+    search pattern, to allow you to find files in \"directories\" below the bucket.\n
+    - `search_pattern` - This is an escaped regular expression that the tap will use to
+    find files in the bucket + prefix. It's a bit strange, since this is an escaped
+    string inside of an escaped string, any backslashes in the RegEx will need to be
+    double-escaped.\n
+    - `table_name` - This value is a string of your choosing, and will be used to name
+    the stream that records are emitted under for files matching content.\n
+    - `key_properties` - These are the \"primary keys\" of the CSV files, to be used by
+    the target for deduplication and primary key definitions downstream in the
+    destination.\n
+    - `datatype_overrides` - A object / dictionary of header names in the file and any
+    override datatype other than string you with to set as the datatype. Example config:
+    \"datatype_overrides\":{\"administration_number\":\"integer\",\"percentage\":
+    \"number\",\"grade\":\"integer\"}.\n
+    - `date_overrides` - Specifies field names in the files that are supposed to be
+    parsed as a datetime. The tap doesn't attempt to automatically determine if a field
+    is a datetime, so this will make it explicit in the discovered schema.\n
+    - `delimiter` - This allows you to specify a custom delimiter, such as `\\t` or `|`,
+    if that applies to your files.\n
+    - `string_overrides` - DEPRECATED: Specifies field names in the files that should be
+    parsed as a string regardless of what was discovered.\n
+    - `guess_types` - DEPRECATED: (default `True`) By default, column data types will be
+    determined via scanning the first file in a table_spec. Set this to `False` to
+    disable this and set all columns to `string`.\n
+    - `remove_character` - Specifies a character which can be removed from each line in
+    the the file e.g. `\"\\\"\"` will remove all double-quotes.\n
     - `encoding` - The encoding to use to read these files from [codecs -> Standard
     Encodings](https://docs.python.org/3/library/codecs.html#standard-encodings)"
   kind: array


### PR DESCRIPTION
### Changes

**Depreciated**
- string_overrides
- guess_types

**New**

**datatype_overrides**: A object / dictionary of header names in the file and any override datatype other than string you with to set as the datatype. Example config - ``` "datatype_overrides":{"administration_number":"integer","percentage":"number","grade":"integer"}```.