### PR TITLE
fix: Remove unused `flatten_records` setting for `target-s3`

### DIFF
--- a/_data/meltano/loaders/target-s3/crowemi.yml
+++ b/_data/meltano/loaders/target-s3/crowemi.yml
@@ -113,10 +113,6 @@ settings:
     value: aws
   sensitive: true
   value: aws
-- description: A flag indictating to flatten records.
-  kind: boolean
-  label: Flatten Records
-  name: flatten_records
 - description: "'True' to enable schema flattening and automatically expand nested
     properties."
   kind: boolean


### PR DESCRIPTION
This setting is no longer used by the target: https://github.com/search?q=repo%3Acrowemi%2Ftarget-s3+flatten_records&type=code (removed in [this PR](https://github.com/crowemi/target-s3/pull/28))