### PR TITLE
Add `private_key` setting to `target-snowflake--meltanolabs`

### DIFF
--- a/_data/meltano/loaders/target-snowflake/meltanolabs.yml
+++ b/_data/meltano/loaders/target-snowflake/meltanolabs.yml
@@ -93,7 +93,12 @@ settings:
   label: Private Key Passphrase
   name: private_key_passphrase
   sensitive: true
-- description: Path to file containing private key.
+- description: Private key contents. For KeyPair authentication either `private_key` or `private_key_path` must be provided.
+  kind: password
+  label: Private Key
+  name: private_key
+  sensitive: true
+- description: Path to file containing private key. For KeyPair authentication either `private_key` or `private_key_path` must be provided.
   kind: password
   label: Private Key Path
   name: private_key_path


### PR DESCRIPTION
New `private_key` setting definition, as per [this PR](https://github.com/MeltanoLabs/target-snowflake/pull/260). Will require a new PyPI release.