### PR TITLE
fix: singer-io/tap-fixerio doesn't support `--discover`

### DIFF
--- a/_data/meltano/extractors/tap-fixerio/singer-io.yml
+++ b/_data/meltano/extractors/tap-fixerio/singer-io.yml
@@ -1,5 +1,4 @@
 capabilities:
-- discover
 - state
 description: Foreign Exchnage Rates API
 domain_url: https://fixer.io/documentation


### PR DESCRIPTION
https://meltano.slack.com/archives/C069CQNHDNF/p1739436908773209