### PR TITLE
update intercom settings

### DIFF
--- a/_data/meltano/extractors/tap-intercom/ticketswap.yml
+++ b/_data/meltano/extractors/tap-intercom/ticketswap.yml
@@ -69,10 +69,14 @@ settings:
   kind: integer
   label: Max Flattening Depth
   name: flattening_max_depth
-- description: The earliest record date to sync
-  kind: date_iso8601
+- description: The earliest record date to sync in unix timestamp format.
+  kind: integer
   label: Start Date
   name: start_date
+- description: Filters to apply to the API request (only for search endpoints)
+  kind: object
+  label: Filters
+  name: filters
 - description: User-defined config values to be used within map expressions.
   kind: object
   label: User Stream Map Configuration


### PR DESCRIPTION
- `start_date` is now in unix timestamp format
- added `filters` setting to allow for filters in POST body.