### PR TITLE
fix: SSA Delimiter Docs

### DIFF
--- a/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
+++ b/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
@@ -54,7 +54,7 @@ settings:
     - selected: (optional) Should this table be synced. Defaults to true. Setting to false will skip this table on a sync run.
     - worksheet_name: (optional) the worksheet name to pull from in the targeted xls file(s). Only required when format is excel
     - delimiter: (optional) the delimiter to use when format is 'csv' e.g. ','. You can leave delimiter blank or set it to 'detect' to leverage the csv "Sniffer" for auto-detecting delimiter.
-    - quotechar: (optional) the character used to surround values that may contain delimiters - defaults to a double quote '"'
+    - quotechar: (optional) the character used to surround values that may contain delimiters. - defaults to a double quote '"' when not using the auto detecting feature i.e. delimiter is defined and not equal to `detect`.
     - json_path: (optional) the JSON key under which the list of objets to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
 
     For example:

--- a/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
+++ b/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
@@ -53,7 +53,7 @@ settings:
     - prefer_number_vs_integer: (optional) If the discovery mode sampling process sees only integer values for a field, should number be used anyway so that floats are not considered errors? The default is false but true can help in situations where floats only appear rarely in sources and may not be detected through discovery sampling.
     - selected: (optional) Should this table be synced. Defaults to true. Setting to false will skip this table on a sync run.
     - worksheet_name: (optional) the worksheet name to pull from in the targeted xls file(s). Only required when format is excel
-    - delimiter: (optional) the delimiter to use when format is 'csv'. Defaults to a comma ',' but you can set delimiter to 'detect' to leverage the csv "Sniffer" for auto-detecting delimiter.
+    - delimiter: (optional) the delimiter to use when format is 'csv' e.g. ','. You can leave delimiter blank or set it to 'detect' to leverage the csv "Sniffer" for auto-detecting delimiter.
     - quotechar: (optional) the character used to surround values that may contain delimiters - defaults to a double quote '"'
     - json_path: (optional) the JSON key under which the list of objets to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
 

--- a/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
+++ b/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
@@ -54,7 +54,7 @@ settings:
     - selected: (optional) Should this table be synced. Defaults to true. Setting to false will skip this table on a sync run.
     - worksheet_name: (optional) the worksheet name to pull from in the targeted xls file(s). Only required when format is excel
     - delimiter: (optional) the delimiter to use when format is 'csv' e.g. ','. You can leave delimiter blank or set it to 'detect' to leverage the csv "Sniffer" for auto-detecting delimiter.
-    - quotechar: (optional) the character used to surround values that may contain delimiters. - defaults to a double quote '"' when not using the auto detecting feature i.e. delimiter is defined and not equal to `detect`.
+    - quotechar: (optional) the character used to surround values that may contain delimiters - defaults to a double quote '"' when not using the auto detecting feature i.e. delimiter is defined and not equal to `detect`.
     - json_path: (optional) the JSON key under which the list of objets to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
 
     For example:

--- a/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
+++ b/_data/meltano/extractors/tap-spreadsheets-anywhere/ets.yml
@@ -53,8 +53,8 @@ settings:
     - prefer_number_vs_integer: (optional) If the discovery mode sampling process sees only integer values for a field, should number be used anyway so that floats are not considered errors? The default is false but true can help in situations where floats only appear rarely in sources and may not be detected through discovery sampling.
     - selected: (optional) Should this table be synced. Defaults to true. Setting to false will skip this table on a sync run.
     - worksheet_name: (optional) the worksheet name to pull from in the targeted xls file(s). Only required when format is excel
-    - delimiter: (optional) the delimiter to use when format is 'csv' e.g. ','. You can leave delimiter blank or set it to 'detect' to leverage the csv "Sniffer" for auto-detecting delimiter.
-    - quotechar: (optional) the character used to surround values that may contain delimiters - defaults to a double quote '"' when not using the auto detecting feature i.e. delimiter is defined and not equal to `detect`.
+    - delimiter: (optional) the delimiter to use when format is 'csv', for example ','. You can leave delimiter blank or set it to 'detect' to leverage the csv "Sniffer" for auto-detecting delimiter.
+    - quotechar: (optional) the character used to surround values that may contain delimiters - defaults to a double quote '"' when not using the auto detecting feature. That is, delimiter is defined and not equal to `detect`.
     - json_path: (optional) the JSON key under which the list of objets to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
 
     For example:


### PR DESCRIPTION
I ran into this today. The docs say that leaving this blank defaults to a comma but thats not true based on the code https://github.com/ets/tap-spreadsheets-anywhere/blob/0b8b905a025e394dc937324c32860c6c4b5a01d8/tap_spreadsheets_anywhere/csv_handler.py#L31