### PR TITLE
chore: Update `tj-actions/changed-files` to patched version

### DIFF
--- a/.github/workflows/check-yaml-format.yml
+++ b/.github/workflows/check-yaml-format.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Get changed files in the docs folder
       id: changed-files
-      uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
       with:
         files: |
           _data/**/*.yml

--- a/.github/workflows/test_dispatcher.yml
+++ b/.github/workflows/test_dispatcher.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           json: "true"

--- a/.github/workflows/test_meltano_add_install.yml
+++ b/.github/workflows/test_meltano_add_install.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get changed plugins
         id: changed_plugins
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: _data/meltano/*/*/*.yml
           matrix: true


### PR DESCRIPTION
Even if `tj-actions` cannot be trusted to guard against security exploits in the future, by pinning the version to a commit we should be fine.