### PR TITLE
fix: singer-io/tap-braintree doesn't support `--discover`

### DIFF
--- a/_data/meltano/extractors/tap-braintree/singer-io.yml
+++ b/_data/meltano/extractors/tap-braintree/singer-io.yml
@@ -1,6 +1,4 @@
 capabilities:
-- catalog
-- discover
 - state
 description: Online Payment Solutions
 domain_url: https://developer.paypal.com/braintree/docs/start/overview


### PR DESCRIPTION
## Links

- Slack: https://meltano.slack.com/archives/C069CQNHDNF/p1742575659442029
- Linen: https://discuss.meltano.com/t/27117159/hi-all-i-am-trying-to-run-tap-braintree-to-extract-data-and-#b303b441-1ec4-437d-8421-2bc32068b57e

## Related

- https://github.com/meltano/hub/pull/1948
- Upstream PR: https://github.com/singer-io/tap-braintree/pull/50
