### PR TITLE
ci: Use `UV_BUILD_CONSTRAINT` to use a working version of `setuptools`

### DIFF
--- a/.github/workflows/resources/meltano_install_build_constraints.txt
+++ b/.github/workflows/resources/meltano_install_build_constraints.txt
@@ -1,0 +1,1 @@
+setuptools<78

--- a/.github/workflows/test_meltano_add_install.yml
+++ b/.github/workflows/test_meltano_add_install.yml
@@ -72,4 +72,6 @@ jobs:
 
       - name: Test install
         working-directory: test-project
+        env:
+          UV_BUILD_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/meltano_install_build_constraints.txt
         run: meltano install

--- a/_data/meltano/extractors/tap-braintree/singer-io.yml
+++ b/_data/meltano/extractors/tap-braintree/singer-io.yml
@@ -1,6 +1,4 @@
 capabilities:
-- catalog
-- discover
 - state
 description: Online Payment Solutions
 domain_url: https://developer.paypal.com/braintree/docs/start/overview


### PR DESCRIPTION
Waiting for upstream's decision on whether to roll back so we can decide ourselves if we need this workaround or not.

## Related

- https://github.com/pypa/setuptools/pull/4870
- https://github.com/pypa/setuptools/issues/4910
