### PR TITLE
fix: `tap-googleads` OAuth credential settings

### DIFF
--- a/_data/meltano/extractors/tap-googleads/matatika.yml
+++ b/_data/meltano/extractors/tap-googleads/matatika.yml
@@ -102,10 +102,20 @@ settings:
   label: Login Customer ID
   name: login_customer_id
   sensitive: true
-- description: ''
+- description: https://developers.google.com/google-ads/api/docs/oauth/cloud-project#create_a_client_id_and_client_secret
   kind: string
-  label: OAuth Credentials
-  name: oauth_credentials
+  label: OAuth Client ID
+  name: oauth_credentials.client_id
+- description: https://developers.google.com/google-ads/api/docs/oauth/cloud-project#create_a_client_id_and_client_secret
+  kind: string
+  label: OAuth Client Secret
+  name: oauth_credentials.client_secret
+  sensitive: true
+- description: https://developers.google.com/google-ads/api/docs/get-started/make-first-call?authpath=user_authentication#fetch_a_refresh_token
+  kind: string
+  label: OAuth Refresh Token
+  name: oauth_credentials.refresh_token
+  sensitive: true
 - description: ISO start date for all of the streams that use date-based filtering.
     Defaults to 90 days before the current day.
   kind: date_iso8601
@@ -121,8 +131,8 @@ settings:
   label: Stream Maps
   name: stream_maps
 settings_group_validation:
-- - client_id
-  - client_secret
-  - developer_token
-  - refresh_token
+- - developer_token
+  - oauth_credentials.client_id
+  - oauth_credentials.client_secret
+  - oauth_credentials.refresh_token
 variant: matatika

--- a/_data/meltano/extractors/tap-googleads/matatika.yml
+++ b/_data/meltano/extractors/tap-googleads/matatika.yml
@@ -102,6 +102,10 @@ settings:
   label: Login Customer ID
   name: login_customer_id
   sensitive: true
+- hidden: true
+  kind: object
+  label: OAuth Credentials
+  name: oauth_credentials
 - description: https://developers.google.com/google-ads/api/docs/oauth/cloud-project#create_a_client_id_and_client_secret
   kind: string
   label: OAuth Client ID
@@ -131,6 +135,8 @@ settings:
   label: Stream Maps
   name: stream_maps
 settings_group_validation:
+- - developer_token
+  - oauth_credentials
 - - developer_token
   - oauth_credentials.client_id
   - oauth_credentials.client_secret


### PR DESCRIPTION
Define OAuth credentials as explicit settings. This allows them to be set in `meltano.yml` as

```yml
    config:
      oauth_credentials:
        client_id:
        client_secret:
        refresh_token:
```

```yml
    config:
      oauth_credentials.client_id:
      oauth_credentials.client_secret:
      oauth_credentials.refresh_token:
```

```yml
    config:
      oauth_credentials: '{"client_id": ..., "client_secret": ..., "refresh_token": ...}'
```

or in a `.env` as

```.env
TAP_GOOGLEADS_OAUTH_CREDENTIALS_CLIENT_ID=
TAP_GOOGLEADS_OAUTH_CREDENTIALS_CLIENT_SECRET=
TAP_GOOGLEADS_OAUTH_CREDENTIALS_REFRESH_TOKEN=

TAP_GOOGLEADS_OAUTH_CREDENTIALS='{"client_id": ..., "client_secret": ..., "refresh_token": ...}'
```

(previously `TAP_GOOGLEADS_OAUTH_CREDENTIALS=` didn't work anyway, as `oauth_credentials` setting was defined as `kind: string`)