### PR TITLE
feat: Update `meltano add` examples to use new syntax

### DIFF
--- a/_data/meltano/loaders/target-postgres/datamill-co.yml
+++ b/_data/meltano/loaders/target-postgres/datamill-co.yml
@@ -198,5 +198,5 @@ usage: |
 
   This [Stack Overflow answer](https://stackoverflow.com/questions/26288042/error-installing-psycopg2-library-not-found-for-lssl)
   has specific recommendations on setting the `LDFLAGS` and/or `CPPFLAGS` environment variables.
-  Set those prior to running `meltano add loader target-postgres`.
+  Set those prior to running `meltano add loader target-postgres` (legacy) or `meltano add target-postgres` (Meltano 3.8+).
 variant: datamill-co

--- a/_data/meltano/loaders/target-postgres/meltano.yml
+++ b/_data/meltano/loaders/target-postgres/meltano.yml
@@ -78,5 +78,5 @@ usage: |
 
   This [Stack Overflow answer](https://stackoverflow.com/questions/26288042/error-installing-psycopg2-library-not-found-for-lssl)
   has specific recommendations on setting the `LDFLAGS` and/or `CPPFLAGS` environment variables.
-  Set those prior to running `meltano add loader target-postgres`.
+  Set those prior to running `meltano add loader target-postgres` (legacy) or `meltano add target-postgres` (Meltano 3.8+).
 variant: meltano

--- a/_data/meltano/loaders/target-postgres/transferwise.yml
+++ b/_data/meltano/loaders/target-postgres/transferwise.yml
@@ -174,5 +174,5 @@ usage: |
 
   This [Stack Overflow answer](https://stackoverflow.com/questions/26288042/error-installing-psycopg2-library-not-found-for-lssl)
   has specific recommendations on setting the `LDFLAGS` and/or `CPPFLAGS` environment variables.
-  Set those prior to running `meltano add loader target-postgres`.
+  Set those prior to running `meltano add loader target-postgres` (legacy) or `meltano add target-postgres` (Meltano 3.8+).
 variant: transferwise

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -4,10 +4,30 @@
       <div class="px-4 aside-inner space-y-4">
         <div>
           <p class="text-lg py-2">Install</p>
-          <code class="break-word bg-white-07 rounded p-2 text-sm"
-            >meltano add {{ plugin_type }} {{ name
-            }}<span v-if="!is_default"> --variant {{ variant }}</span></code
-          >
+          <div class="space-y-2">
+            <div class="flex border-b border-gray-200">
+              <button
+                @click="activeTab = 'legacy'"
+                :class="['px-2 py-1 text-xs font-medium border-b-2 transition-colors',
+                       activeTab === 'legacy' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700']"
+              >
+                Legacy
+              </button>
+              <button
+                @click="activeTab = 'modern'"
+                :class="['px-2 py-1 text-xs font-medium border-b-2 transition-colors',
+                       activeTab === 'modern' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700']"
+              >
+                v3.8+
+              </button>
+            </div>
+            <div v-if="activeTab === 'legacy'">
+              <code class="break-word bg-white-07 rounded p-2 text-sm">meltano add <span v-if="plugin_type === 'extractor' || plugin_type === 'loader' || plugin_type === 'utility'">{{ plugin_type }} </span><span v-else>--plugin-type {{ plugin_type }} </span>{{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code>
+            </div>
+            <div v-if="activeTab === 'modern'">
+              <code class="break-word bg-white-07 rounded p-2 text-sm">meltano add {{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code>
+            </div>
+          </div>
         </div>
         <div></div>
         <div>
@@ -278,6 +298,11 @@ export default {
     "pip_url",
     "ext_repo",
   ],
+  data() {
+    return {
+      activeTab: 'legacy'
+    };
+  },
   computed: {
     parsedEDKRepo() {
       // For some plugin variants, either the `variant` or `name` doesn't match the GH repo

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -7,17 +7,6 @@
           <div class="space-y-2">
             <div class="flex border-b border-gray-200">
               <button
-                @click="activeTab = 'legacy'"
-                :class="[
-                  'px-2 py-1 text-xs font-medium border-b-2 transition-colors',
-                  activeTab === 'legacy'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700',
-                ]"
-              >
-                Legacy
-              </button>
-              <button
                 @click="activeTab = 'modern'"
                 :class="[
                   'px-2 py-1 text-xs font-medium border-b-2 transition-colors',
@@ -27,6 +16,17 @@
                 ]"
               >
                 v3.8+
+              </button>
+              <button
+                @click="activeTab = 'legacy'"
+                :class="[
+                  'px-2 py-1 text-xs font-medium border-b-2 transition-colors',
+                  activeTab === 'legacy'
+                    ? 'border-blue-500 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700',
+                ]"
+              >
+                Legacy
               </button>
             </div>
             <div v-if="activeTab === 'legacy'">
@@ -322,7 +322,7 @@ export default {
   ],
   data() {
     return {
-      activeTab: "legacy",
+      activeTab: "modern",
     };
   },
   computed: {

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -8,24 +8,46 @@
             <div class="flex border-b border-gray-200">
               <button
                 @click="activeTab = 'legacy'"
-                :class="['px-2 py-1 text-xs font-medium border-b-2 transition-colors',
-                       activeTab === 'legacy' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700']"
+                :class="[
+                  'px-2 py-1 text-xs font-medium border-b-2 transition-colors',
+                  activeTab === 'legacy'
+                    ? 'border-blue-500 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700',
+                ]"
               >
                 Legacy
               </button>
               <button
                 @click="activeTab = 'modern'"
-                :class="['px-2 py-1 text-xs font-medium border-b-2 transition-colors',
-                       activeTab === 'modern' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700']"
+                :class="[
+                  'px-2 py-1 text-xs font-medium border-b-2 transition-colors',
+                  activeTab === 'modern'
+                    ? 'border-blue-500 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700',
+                ]"
               >
                 v3.8+
               </button>
             </div>
             <div v-if="activeTab === 'legacy'">
-              <code class="break-word bg-white-07 rounded p-2 text-sm">meltano add {{ plugin_type }} {{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code>
+              <code class="break-word bg-white-07 rounded p-2 text-sm"
+                >meltano add {{ plugin_type }} {{ name
+                }}<span v-if="!is_default"> --variant {{ variant }}</span></code
+              >
             </div>
             <div v-if="activeTab === 'modern'">
-              <code class="break-word bg-white-07 rounded p-2 text-sm">meltano add <span v-if="plugin_type === 'extractor' || plugin_type === 'loader' || plugin_type === 'utility'">{{ name }}</span><span v-else>--plugin-type {{ plugin_type }} {{ name }}</span><span v-if="!is_default"> --variant {{ variant }}</span></code>
+              <code class="break-word bg-white-07 rounded p-2 text-sm"
+                >meltano add
+                <span
+                  v-if="
+                    plugin_type === 'extractor' ||
+                    plugin_type === 'loader' ||
+                    plugin_type === 'utility'
+                  "
+                  >{{ name }}</span
+                ><span v-else>--plugin-type {{ plugin_type }} {{ name }}</span
+                ><span v-if="!is_default"> --variant {{ variant }}</span></code
+              >
             </div>
           </div>
         </div>
@@ -300,7 +322,7 @@ export default {
   ],
   data() {
     return {
-      activeTab: 'legacy'
+      activeTab: "legacy",
     };
   },
   computed: {

--- a/src/components/PluginSidebar.vue
+++ b/src/components/PluginSidebar.vue
@@ -22,10 +22,10 @@
               </button>
             </div>
             <div v-if="activeTab === 'legacy'">
-              <code class="break-word bg-white-07 rounded p-2 text-sm">meltano add <span v-if="plugin_type === 'extractor' || plugin_type === 'loader' || plugin_type === 'utility'">{{ plugin_type }} </span><span v-else>--plugin-type {{ plugin_type }} </span>{{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code>
+              <code class="break-word bg-white-07 rounded p-2 text-sm">meltano add {{ plugin_type }} {{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code>
             </div>
             <div v-if="activeTab === 'modern'">
-              <code class="break-word bg-white-07 rounded p-2 text-sm">meltano add {{ name }}<span v-if="!is_default"> --variant {{ variant }}</span></code>
+              <code class="break-word bg-white-07 rounded p-2 text-sm">meltano add <span v-if="plugin_type === 'extractor' || plugin_type === 'loader' || plugin_type === 'utility'">{{ name }}</span><span v-else>--plugin-type {{ plugin_type }} {{ name }}</span><span v-if="!is_default"> --variant {{ variant }}</span></code>
             </div>
           </div>
         </div>

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -256,9 +256,30 @@
                         </a>
                         :
                       </li>
-                      <pre
-                        class="prose rounded-md language-bash"
-                      ><code >meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
+                      <div class="space-y-2">
+                        <div class="flex border-b border-gray-200">
+                          <button
+                            @click="activeTab = 'legacy'"
+                            :class="['px-4 py-2 text-sm font-medium border-b-2 transition-colors',
+                                   activeTab === 'legacy' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700']"
+                          >
+                            Legacy (All versions)
+                          </button>
+                          <button
+                            @click="activeTab = 'modern'"
+                            :class="['px-4 py-2 text-sm font-medium border-b-2 transition-colors',
+                                   activeTab === 'modern' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700']"
+                          >
+                            Meltano 3.8+
+                          </button>
+                        </div>
+                        <div v-if="activeTab === 'legacy'">
+                          <pre class="prose rounded-md language-bash"><code>meltano add <span v-if="$page.plugins.pluginType === 'extractor' || $page.plugins.pluginType === 'loader' || $page.plugins.pluginType === 'utility'">{{ $page.plugins.pluginType }} </span><span v-else>--plugin-type {{ $page.plugins.pluginType }} </span>{{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
+                        </div>
+                        <div v-if="activeTab === 'modern'">
+                          <pre class="prose rounded-md language-bash"><code>meltano add {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
+                        </div>
+                      </div>
                       <span>
                         <li>
                           Configure the {{ $page.plugins.name }}
@@ -471,6 +492,11 @@ export default {
     PluginHelpSection,
     PluginCapabilitiesSection,
     PluginPrereqSection,
+  },
+  data() {
+    return {
+      activeTab: 'legacy'
+    };
   },
   computed: {
     filteredVariants() {

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -260,24 +260,36 @@
                         <div class="flex border-b border-gray-200">
                           <button
                             @click="activeTab = 'legacy'"
-                            :class="['px-4 py-2 text-sm font-medium border-b-2 transition-colors',
-                                   activeTab === 'legacy' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700']"
+                            :class="[
+                              'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
+                              activeTab === 'legacy'
+                                ? 'border-blue-500 text-blue-600'
+                                : 'border-transparent text-gray-500 hover:text-gray-700',
+                            ]"
                           >
                             Legacy (All versions)
                           </button>
                           <button
                             @click="activeTab = 'modern'"
-                            :class="['px-4 py-2 text-sm font-medium border-b-2 transition-colors',
-                                   activeTab === 'modern' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700']"
+                            :class="[
+                              'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
+                              activeTab === 'modern'
+                                ? 'border-blue-500 text-blue-600'
+                                : 'border-transparent text-gray-500 hover:text-gray-700',
+                            ]"
                           >
                             Meltano 3.8+
                           </button>
                         </div>
                         <div v-if="activeTab === 'legacy'">
-                          <pre class="prose rounded-md language-bash"><code>meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
+                          <pre
+                            class="prose rounded-md language-bash"
+                          ><code>meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
                         </div>
                         <div v-if="activeTab === 'modern'">
-                          <pre class="prose rounded-md language-bash"><code>meltano add <span v-if="$page.plugins.pluginType === 'extractor' || $page.plugins.pluginType === 'loader' || $page.plugins.pluginType === 'utility'">{{ $page.plugins.name }}</span><span v-else>--plugin-type {{ $page.plugins.pluginType }} {{ $page.plugins.name }}</span><span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
+                          <pre
+                            class="prose rounded-md language-bash"
+                          ><code>meltano add <span v-if="$page.plugins.pluginType === 'extractor' || $page.plugins.pluginType === 'loader' || $page.plugins.pluginType === 'utility'">{{ $page.plugins.name }}</span><span v-else>--plugin-type {{ $page.plugins.pluginType }} {{ $page.plugins.name }}</span><span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
                         </div>
                       </div>
                       <span>
@@ -495,7 +507,7 @@ export default {
   },
   data() {
     return {
-      activeTab: 'legacy'
+      activeTab: "legacy",
     };
   },
   computed: {

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -259,17 +259,6 @@
                       <div class="space-y-2">
                         <div class="flex border-b border-gray-200">
                           <button
-                            @click="activeTab = 'legacy'"
-                            :class="[
-                              'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
-                              activeTab === 'legacy'
-                                ? 'border-blue-500 text-blue-600'
-                                : 'border-transparent text-gray-500 hover:text-gray-700',
-                            ]"
-                          >
-                            Legacy (All versions)
-                          </button>
-                          <button
                             @click="activeTab = 'modern'"
                             :class="[
                               'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
@@ -279,6 +268,17 @@
                             ]"
                           >
                             Meltano 3.8+
+                          </button>
+                          <button
+                            @click="activeTab = 'legacy'"
+                            :class="[
+                              'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
+                              activeTab === 'legacy'
+                                ? 'border-blue-500 text-blue-600'
+                                : 'border-transparent text-gray-500 hover:text-gray-700',
+                            ]"
+                          >
+                            Legacy (All versions)
                           </button>
                         </div>
                         <div v-if="activeTab === 'legacy'">
@@ -507,7 +507,7 @@ export default {
   },
   data() {
     return {
-      activeTab: "legacy",
+      activeTab: "modern",
     };
   },
   computed: {

--- a/src/templates/Plugins.vue
+++ b/src/templates/Plugins.vue
@@ -274,10 +274,10 @@
                           </button>
                         </div>
                         <div v-if="activeTab === 'legacy'">
-                          <pre class="prose rounded-md language-bash"><code>meltano add <span v-if="$page.plugins.pluginType === 'extractor' || $page.plugins.pluginType === 'loader' || $page.plugins.pluginType === 'utility'">{{ $page.plugins.pluginType }} </span><span v-else>--plugin-type {{ $page.plugins.pluginType }} </span>{{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
+                          <pre class="prose rounded-md language-bash"><code>meltano add {{ $page.plugins.pluginType }} {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
                         </div>
                         <div v-if="activeTab === 'modern'">
-                          <pre class="prose rounded-md language-bash"><code>meltano add {{ $page.plugins.name }}<span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
+                          <pre class="prose rounded-md language-bash"><code>meltano add <span v-if="$page.plugins.pluginType === 'extractor' || $page.plugins.pluginType === 'loader' || $page.plugins.pluginType === 'utility'">{{ $page.plugins.name }}</span><span v-else>--plugin-type {{ $page.plugins.pluginType }} {{ $page.plugins.name }}</span><span v-if="!$page.plugins.isDefault"> --variant {{ $page.plugins.variant }}</span></code></pre>
                         </div>
                       </div>
                       <span>


### PR DESCRIPTION
Related:

- Waiting for https://github.com/meltano/meltano/pull/9317

### Extractors

https://deploy-preview-2040--meltano-hub.netlify.app/extractors/tap-geekbot/#getting-started

<img width="500" alt="Screenshot 2025-06-23 at 2 49 35 p m" src="https://github.com/user-attachments/assets/84ee446b-a379-4704-9e10-6247d43555e9" />
<img width="500" alt="Screenshot 2025-06-23 at 2 49 53 p m" src="https://github.com/user-attachments/assets/4e169172-b2b1-47d8-836d-83991ff3757f" />

### Utilities

https://deploy-preview-2040--meltano-hub.netlify.app/utilities/dbt-postgres#getting-started

<img width="500" alt="Screenshot 2025-06-23 at 2 50 44 p m" src="https://github.com/user-attachments/assets/440939fd-ad0a-461f-b517-e3cf0d4d8986" />
<img width="500" alt="Screenshot 2025-06-23 at 2 50 49 p m" src="https://github.com/user-attachments/assets/70afc0b6-05ac-4aa1-924e-4830f8d7b94e" />

### Legacy (orchestrators, etc.)

https://deploy-preview-2040--meltano-hub.netlify.app/orchestrators/airflow/#getting-started

<img width="500" alt="Screenshot 2025-06-23 at 2 51 01 p m" src="https://github.com/user-attachments/assets/58e83380-a8f7-4386-bbf4-77dc350952eb" />
<img width="500" alt="Screenshot 2025-06-23 at 2 51 08 p m" src="https://github.com/user-attachments/assets/6faaff0d-16d0-4a2b-aeb9-a85b585cdf0c" />
