### PR TITLE
feat: Add Python 3.14 as a support Python version to dbt utilities

### DIFF
--- a/_data/meltano/utilities/dbt-athena/dbt-athena.yml
+++ b/_data/meltano/utilities/dbt-athena/dbt-athena.yml
@@ -216,4 +216,5 @@ supported_python_versions:
 - '3.11'
 - '3.12'
 - '3.13'
+- '3.14'
 variant: dbt-athena

--- a/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-bigquery/dbt-labs.yml
@@ -154,4 +154,5 @@ supported_python_versions:
 - '3.11'
 - '3.12'
 - '3.13'
+- '3.14'
 variant: dbt-labs

--- a/_data/meltano/utilities/dbt-duckdb/jwills.yml
+++ b/_data/meltano/utilities/dbt-duckdb/jwills.yml
@@ -116,4 +116,5 @@ supported_python_versions:
 - '3.11'
 - '3.12'
 - '3.13'
+- '3.14'
 variant: jwills

--- a/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-postgres/dbt-labs.yml
@@ -156,4 +156,5 @@ supported_python_versions:
 - '3.11'
 - '3.12'
 - '3.13'
+- '3.14'
 variant: dbt-labs

--- a/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-redshift/dbt-labs.yml
@@ -188,4 +188,5 @@ supported_python_versions:
 - '3.11'
 - '3.12'
 - '3.13'
+- '3.14'
 variant: dbt-labs

--- a/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
+++ b/_data/meltano/utilities/dbt-snowflake/dbt-labs.yml
@@ -143,4 +143,5 @@ supported_python_versions:
 - '3.11'
 - '3.12'
 - '3.13'
+- '3.14'
 variant: dbt-labs


### PR DESCRIPTION
Follows https://github.com/dbt-labs/dbt-core/releases/tag/v1.12.0
