### PR TITLE
fix: allow unsafe fork PR checkout in test dispatcher

### DIFF
--- a/.github/workflows/test_dispatcher.yml
+++ b/.github/workflows/test_dispatcher.yml
@@ -32,6 +32,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Get changed files
         id: changed_files
@@ -58,6 +59,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Install yq
         env:


### PR DESCRIPTION
## Summary
- `actions/checkout` v7 (#2286) now blocks checking out a fork PR's head SHA under `pull_request_target`/`workflow_run` by default, which broke community plugin submissions like #2295.
- `test_dispatcher.yml` needs to check out the fork's head to read the changed plugin manifest, so this opts back in via `allow-unsafe-pr-checkout: true` on both checkout steps.
- This is safe here: the job only parses YAML with `yq` and diffs filenames — it never builds or executes fork code — and both steps already use `persist-credentials: false` with read-only job permissions (`contents: read`, `pull-requests: read`).

Fixes #2295

## Test plan
- [ ] Confirm `test_dispatcher.yml` runs successfully on a fork PR touching `_data/meltano/*/*/*.yml` (e.g. re-trigger #2295)