### PR TITLE
Add tap-livetennisapi (livetennisapi variant)

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -306,6 +306,7 @@ extractors:
   tap-listrak: dbt-labs
   tap-livechat: pathlight
   tap-liveperson: singer-io
+  tap-livetennisapi: livetennisapi
   tap-lokalise: airbyte
   tap-looker: singer-io
   tap-lookml: singer-io

--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -734,6 +734,10 @@ lgrosjean:
   label: Leo Grosjean
   name: lgrosjean
   url: https://github.com/lgrosjean
+livetennisapi:
+  label: Live Tennis API
+  name: livetennisapi
+  url: https://github.com/livetennisapi
 loeakaodas:
   label: Andrey
   name: loeakaodas

--- a/_data/meltano/extractors/tap-livetennisapi/livetennisapi.yml
+++ b/_data/meltano/extractors/tap-livetennisapi/livetennisapi.yml
@@ -1,0 +1,139 @@
+capabilities:
+- about
+- activate-version
+- batch
+- catalog
+- discover
+- schema-flattening
+- state
+- stream-maps
+- structured-logging
+description: Live tennis scores and data API
+domain_url: https://livetennisapi.com
+executable: tap-livetennisapi
+keywords:
+- meltano_sdk
+- api
+- sports
+- tennis
+label: Live Tennis API
+logo_url: /assets/logos/extractors/livetennisapi.svg
+maintenance_status: active
+name: tap-livetennisapi
+namespace: tap_livetennisapi
+pip_url: git+https://github.com/livetennisapi/tap-livetennisapi.git
+quality: unknown
+repo: https://github.com/livetennisapi/tap-livetennisapi
+settings:
+- description: Live Tennis API key, sent as `Authorization Bearer <key>`. A free
+    key is self-serve at https://livetennisapi.com/subscribe/free (30 requests/minute,
+    100/day). The match_history stream needs a BASIC or higher key, or any Historical
+    Data API plan.
+  kind: password
+  label: API Key
+  name: api_key
+  sensitive: true
+- description: Base URL of the Live Tennis API (override for testing).
+  kind: string
+  label: API URL
+  name: api_url
+  value: https://api.livetennisapi.com/api/public/v1
+- description: Compression format to use for batch files.
+  kind: options
+  label: Batch Compression Format
+  name: batch_config.encoding.compression
+  options:
+  - label: GZIP
+    value: gzip
+  - label: None
+    value: none
+- description: Format to use for batch files.
+  kind: options
+  label: Batch Encoding Format
+  name: batch_config.encoding.format
+  options:
+  - label: JSONL
+    value: jsonl
+  - label: Parquet
+    value: parquet
+- description: Prefix to use when writing batch files.
+  kind: string
+  label: Batch Storage Prefix
+  name: batch_config.storage.prefix
+- description: Root path to use when writing batch files.
+  kind: string
+  label: Batch Storage Root
+  name: batch_config.storage.root
+- description: 'One or more LCID locale strings to produce localized output for:
+    https://faker.readthedocs.io/en/master/#localization'
+  kind: array
+  label: Faker Locale
+  name: faker_config.locale
+- description: 'Value to seed the Faker generator for deterministic output:
+    https://faker.readthedocs.io/en/master/#seeding-the-generator'
+  kind: string
+  label: Faker Seed
+  name: faker_config.seed
+- description: "'True' to enable schema flattening and automatically expand nested
+    properties."
+  kind: boolean
+  label: Enable Schema Flattening
+  name: flattening_enabled
+- description: The max depth to flatten schemas.
+  kind: integer
+  label: Max Flattening Depth
+  name: flattening_max_depth
+- description: The maximum length of a flattened key.
+  kind: integer
+  label: Max Key Length
+  name: flattening_max_key_length
+- description: The separator to use when flattening keys.
+  kind: string
+  label: Flattening Separator
+  name: flattening_separator
+- description: Optional name search for the players stream (the `search` query
+    parameter of GET /players). Omit to sync the unfiltered player listing, ranked
+    players first.
+  kind: string
+  label: Player Search
+  name: player_search
+- description: Earliest play date for the match_history stream's incremental `from`
+    filter (ISO-8601). The completed-match tape starts January 2023. Ignored by the
+    players, fixtures and live_matches streams, which are point-in-time surfaces.
+  kind: date_iso8601
+  label: Start Date
+  name: start_date
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: User Stream Map Configuration
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check
+    out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+- description: Optional tour filter applied to the fixtures, live_matches and
+    match_history streams (the API's grouped vocabulary; each value includes its
+    doubles draws). Omit for all tours.
+  kind: options
+  label: Tour
+  name: tour
+  options:
+  - label: ATP
+    value: atp
+  - label: WTA
+    value: wta
+  - label: Challenger
+    value: challenger
+  - label: ITF
+    value: itf
+  - label: Juniors
+    value: juniors
+settings_group_validation:
+- - api_key
+supported_python_versions:
+- '3.10'
+- '3.11'
+- '3.12'
+- '3.13'
+variant: livetennisapi

--- a/static/assets/logos/extractors/livetennisapi.svg
+++ b/static/assets/logos/extractors/livetennisapi.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" role="img" aria-label="Live Tennis API">
+  <defs>
+    <linearGradient id="lt-t" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#13241b"/><stop offset="1" stop-color="#0a120e"/></linearGradient>
+    <radialGradient id="lt-b" cx="0.36" cy="0.30" r="0.85"><stop offset="0" stop-color="#7bf2a6"/><stop offset="0.55" stop-color="#3ee07a"/><stop offset="1" stop-color="#189a52"/></radialGradient>
+  </defs>
+  <rect x="1.5" y="1.5" width="45" height="45" rx="12" fill="url(#lt-t)" stroke="#22402f" stroke-width="1"/>
+  <circle cx="24" cy="24" r="13" fill="url(#lt-b)"/>
+  <path d="M14.8 15.2 C 20.4 19.5, 20.4 28.5, 14.8 32.8" fill="none" stroke="#0c3a22" stroke-width="1.7" stroke-linecap="round" opacity="0.9"/>
+  <path d="M33.2 15.2 C 27.6 19.5, 27.6 28.5, 33.2 32.8" fill="none" stroke="#0c3a22" stroke-width="1.7" stroke-linecap="round" opacity="0.9"/>
+  <ellipse cx="20" cy="18.5" rx="4.4" ry="2.6" fill="#ffffff" opacity="0.16"/>
+</svg>


### PR DESCRIPTION
## New extractor: tap-livetennisapi

Adds a plugin definition for [`tap-livetennisapi`](https://github.com/livetennisapi/tap-livetennisapi), a Meltano Singer SDK-based tap for the [Live Tennis API](https://livetennisapi.com) (tennis players, upcoming fixtures, live matches, and completed-match history across ATP/WTA/Challenger/ITF/juniors).

- **Variant**: `livetennisapi` (first variant; added to `default_variants.yml` and `maintainers.yml`)
- **pip_url**: `git+https://github.com/livetennisapi/tap-livetennisapi.git` (not on PyPI)
- **SDK-based**: yes (singer-sdk 0.54); capabilities and settings in the definition were taken from the tap's `--about --format json` output
- **Streams**: `players`, `fixtures`, `live_matches` (free tier), `match_history` (incremental; requires a paid key — documented in the tap's README)
- **Tests**: the tap ships a pytest suite on the SDK's built-in tap test framework with fully mocked responses (green in CI), release [v0.1.0](https://github.com/livetennisapi/tap-livetennisapi/releases/tag/v0.1.0)
- Definition follows the repo's yamllint config (key-ordering) and validates against `schemas/plugin_definitions/extractors.schema.json`
- Logo added at `static/assets/logos/extractors/livetennisapi.svg` (own brand asset)

**Disclosure**: I maintain the Live Tennis API, and this tap and PR were prepared with the help of an AI coding agent (Claude), reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)