### PR TITLE
Add tap-fxmacrodata

### DIFF
--- a/_data/default_variants.yml
+++ b/_data/default_variants.yml
@@ -214,6 +214,7 @@ extractors:
   tap-frontapp: singer-io
   tap-fulfil: fulfilio
   tap-fullstory: singer-io
+  tap-fxmacrodata: fxmacrodata
   tap-ga4: meltanolabs
   tap-gainsightpx: widen
   tap-geekbot: edgarrmondragon

--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -490,6 +490,10 @@ full360:
   label: full360
   name: full360
   url: https://github.com/full360
+fxmacrodata:
+  label: FXMacroData
+  name: fxmacrodata
+  url: https://github.com/fxmacrodata
 gabilew:
   label: gabilew
   name: gabilew

--- a/_data/meltano/extractors/tap-fxmacrodata/fxmacrodata.yml
+++ b/_data/meltano/extractors/tap-fxmacrodata/fxmacrodata.yml
@@ -1,0 +1,95 @@
+capabilities:
+- about
+- activate-version
+- batch
+- catalog
+- discover
+- schema-flattening
+- state
+- stream-maps
+- structured-logging
+description: Official macroeconomic, FX and release-calendar data for 18 currencies, aggregated from central
+  banks and national statistics agencies
+domain_url: https://fxmacrodata.com
+keywords:
+- api
+- meltano_sdk
+- macroeconomics
+- forex
+- economic-data
+label: FXMacroData
+maintenance_status: active
+name: tap-fxmacrodata
+namespace: tap_fxmacrodata
+next_steps: 'USD macro data is public, so the tap runs without an API key. Indicator slugs differ per
+  currency: sync the `data_catalogue` stream first to see what a currency publishes, then list the slugs
+  you want in `indicators`.'
+pip_url: git+https://github.com/fxmacrodata/tap-fxmacrodata.git
+quality: silver
+repo: https://github.com/fxmacrodata/tap-fxmacrodata
+settings:
+- description: FXMacroData API key. USD macro data is public, so the tap runs without one; a key widens
+    it to the other seventeen currencies, the full history, and FX.
+  kind: password
+  label: Api Key
+  name: api_key
+  sensitive: true
+- description: Override the API base URL. Rarely needed.
+  kind: string
+  label: Api Url
+  name: api_url
+- description: Configuration for BATCH message capabilities.
+  kind: object
+  label: Batch Config
+  name: batch_config
+- description: Currency codes to extract, for example ["USD", "EUR"].
+  kind: array
+  label: Currencies
+  name: currencies
+- description: Config for the [`Faker`](https://faker.readthedocs.io/en/master/) instance variable `fake`
+    used within map expressions. Only applicable if the plugin specifies `faker` as an additional dependency
+    (through the `singer-sdk` `faker` extra or directly).
+  kind: object
+  label: Faker Config
+  name: faker_config
+- description: '''True'' to enable schema flattening and automatically expand nested properties.'
+  kind: boolean
+  label: Flattening Enabled
+  name: flattening_enabled
+- description: The max depth to flatten schemas.
+  kind: integer
+  label: Flattening Max Depth
+  name: flattening_max_depth
+- description: The maximum length of a flattened key.
+  kind: integer
+  label: Flattening Max Key Length
+  name: flattening_max_key_length
+- description: The separator to use when flattening keys.
+  kind: string
+  label: Flattening Separator
+  name: flattening_separator
+- description: Currency pairs for the forex_rates stream, for example ["EUR/USD"]. Leave unset to skip
+    FX.
+  kind: array
+  label: Fx Pairs
+  name: fx_pairs
+- description: Indicator slugs for the announcements stream, for example ["inflation", "policy_rate"].
+    Sync the data_catalogue stream first to see what a currency publishes. Leave unset to skip announcements.
+  kind: array
+  label: Indicators
+  name: indicators
+- description: Earliest reference date to extract for dated streams.
+  kind: date_iso8601
+  label: Start Date
+  name: start_date
+- description: User-defined config values to be used within map expressions.
+  kind: object
+  label: Stream Map Config
+  name: stream_map_config
+- description: Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).
+  kind: object
+  label: Stream Maps
+  name: stream_maps
+settings_group_validation:
+- []
+variant: fxmacrodata


### PR DESCRIPTION
Adds an SDK-based extractor for [FXMacroData](https://fxmacrodata.com/?utm_source=meltano&utm_medium=referral&utm_campaign=open_source_integrations&utm_content=pr): official macroeconomic, FX and release-calendar data for 18 currencies, aggregated from central banks and national statistics agencies.

Repo: https://github.com/fxmacrodata/tap-fxmacrodata

### Streams

| Stream | Grain | Replication |
| --- | --- | --- |
| `announcements` | one record per release of one indicator | incremental on `date` |
| `release_calendar` | scheduled and recent releases | full table |
| `data_catalogue` | indicators a currency publishes | full table |
| `forex_rates` | daily reference rate for a pair | incremental on `date` |

Every `announcements` record carries `announcement_datetime`, the instant the figure was published. Most macro sources give a value and a reference date, which quietly invites lookahead — the figure for March was not knowable in March — so keeping the publication instant is the point of the stream.

`announcements` and `forex_rates` are partitioned per series, so state is held per currency/indicator and per pair rather than for the stream as a whole.

### Trying it without credentials

USD macro data is public, so the tap runs with no API key:

```json
{
  "currencies": ["USD"],
  "indicators": ["inflation", "policy_rate"],
  "start_date": "2020-01-01T00:00:00Z"
}
```

A key widens it to the other seventeen currencies, the full history and FX, and is sent as a header. A currency the key does not cover logs a warning and yields no rows rather than failing the run, so a mixed currency list stays usable.

### How this definition was produced

`hub-utils add --repo-url https://github.com/fxmacrodata/tap-fxmacrodata` installed the tap from the `pip_url` correctly, then failed at the settings scrape with `[WinError 2] The system cannot find the file specified` — it could not locate the installed executable on Windows. The definition is therefore written from the tap's own `--about --format=json` output, using the same transformation, and validated against `schemas/plugin_definitions/extractors.schema.json`.

Happy to regenerate it with the tool if a maintainer on Linux would rather have it produced that way.

Also updates `_data/default_variants.yml` and `_data/maintainers.yml`, both placed alphabetically.